### PR TITLE
Fix mask validation with inner case flags and literals

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -4906,6 +4906,7 @@ if (typeof jQuery !== "function") {
 			this._promptCharsIndices = [];
 		},
 		_applyOptions: function () { //igMaskEditor
+			this._getMaskLiteralsAndRequiredPositions();
 
 			// In case value is not set we need to use the setInitialValue method to store mask, required field indeces, prompt indeces etc.
 			this._super();
@@ -5381,34 +5382,29 @@ if (typeof jQuery !== "function") {
 			return this._getValueByDataMode(text);
 		},
 		_validateValueAgainstMask: function (value) {
-			var i, j, length = value.length, result = true, ch, mask = this.options.inputMask;
+			var i, j, length = value.length, result = true, ch, mask = this._unescapedMask;
 			if (length && length > 0) {
 				for (j = 0, i = 0; i < mask.length && j < value.length; i++, j++) {
 					ch = value.charAt(j);
-					if (this._focused && ch === this.options.unfilledCharsPrompt) {
+
+					// In case passed value contains both literals and filled prompts we try to parse the value.
+					// In case of mask 00/00 we should accept both 1234 and 12/34 as input and parse it with the correct result.
+					if ($.inArray(i, this._literalIndeces) !== -1) {
+						if (mask.charAt(i) !== ch) {
+							j--;
+						}
 						continue;
 					}
-					if (this._validateCharOnPostion(ch, i) === null) {
 
-						// If we have left postions on the map and _validateCharOnPostion returns null this means we have literal and we need to move
+					// D.P. 24th Aug 2016 #264 Position tweaks should be done before unfilledCharsPrompt skip
+					if ("><".indexOf(mask.charAt(i)) > -1) {
 						// Move to next char on the mask
-						// We need to detect Escaped chars
-						if (mask.charAt(i) === "\\") {
-							i++;
-							j--;
-						} else if (mask.charAt(i) === "<" || mask.charAt(i) === ">") {
-							j--;
-						}
+						j--;
+						continue;
+					}
 
-						// In case passed value contains both literals and filled prompts we try to parse the value.
-						// In case of mask 00/00 we should accept both 1234 and 12/34 as input and parse it with the correct result.
-						else if ($.inArray(i, this._literalIndeces) !== -1) {
-							if (mask.charAt(i) !== ch) {
-								j--;
-							}
-						}
-
-					} else if (this._validateCharOnPostion(ch, i) === false) {
+					if (!(this._focused && ch === this.options.unfilledCharsPrompt) &&
+						this._validateCharOnPostion(ch, i) === false) {
 						return false;
 					}
 				}
@@ -6140,7 +6136,6 @@ if (typeof jQuery !== "function") {
 		},
 		_setInitialValue: function (value) { //igDateEditor
 			this._maskWithPrompts = this._parseValueByMask("");
-			this._getMaskLiteralsAndRequiredPositions();
 			if (value === null || value === "" || typeof value === "undefined") {
 				this._maskedValue = "";
 			} else {

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -37,7 +37,7 @@
 						"208809", "208887", "209012", "208350", "208356", "208448", "208036",
 						"208264", "210971", "211010", "211062", "210990", "210106", "211575",
 					"208274", "207546", "207321", "212596", "212374", "212642", "215549", "217214", "216789",
-					"218836", "218752", "220479", "220712", "221118", "221494", "221300", "98", "223245"];
+					"218836", "218752", "220479", "220712", "221118", "221494", "221300", "98", "223245", "264"];
 					for (var i = 0; i < testbedIDs.length; i++) {
 						var testBed = "Bug" + testbedIDs[i] + "Testbed";
 						if (window[testBed]) {
@@ -408,6 +408,15 @@
 						allowNullValue: true, //expected to set to minValue if input if less than 30
 						nullValue: "",
 						minValue: 0.3
+					});
+				}
+
+				window.Bug264Testbed = function () {
+					$("#264Editor1").igMaskEditor({
+						inputMask: "00-0L/>aa(test)"
+					});
+					$("#264Editor2").igMaskEditor({
+						inputMask: 'Aaa\\>L/>aa'
 					});
 				}
 
@@ -1004,7 +1013,7 @@
 				keyInteraction(13, input);
 				var text = $("#98Editor1").igNumericEditor("field").val();
 				equal(text, 5, "Text in editor is not set to the maxValue");
-				input.igNumericEditor("setFocus");
+				input.select();
 				typeInMaskedInput("1", input.igNumericEditor("field"));
 				keyInteraction(13, input);
 				var text = $("#98Editor1").igNumericEditor("field").val();
@@ -1029,7 +1038,7 @@
 
 				var input = $('#223245PercentEditor3');
 				input.igPercentEditor("setFocus");
-				typeInMaskedInput("20", input.igPercentEditor("field"));
+				typeInInput("20", input.igPercentEditor("field"));
 				keyInteraction(13, input);
 				var value = $("#223245PercentEditor3").igPercentEditor("value");
 				equal(value, 0.3, "igPercentEditor is not set to minValue");
@@ -1055,6 +1064,33 @@
 				var value = $("#223245NumericEditor3").igNumericEditor("value");
 				equal(value, 5, "igNumericEditor is not set to minValue");
 			});
+
+			testId = 'Bug 264';
+			test(testId, 2, function () {
+				var edit1 = $('#264Editor1'),
+					edit2 = $('#264Editor2');
+
+				edit1.trigger("focus");
+				stop();
+				setTimeout(function () {
+					start();
+					typeInMaskedInput("555a", edit1.igMaskEditor("field"));
+					edit1.blur();
+					var text = edit1.igMaskEditor("field").val();
+					equal(text, "55-5a/(test)", "MaskEditor did not accept value with required positions filled");
+					edit2.trigger("focus");
+					stop();
+					setTimeout(function () {
+						start();
+						typeInMaskedInput("123d", edit2.igMaskEditor("field"));
+						edit2.blur();
+						var text = edit2.igMaskEditor("field").val();
+						equal(text, "123>d/", "MaskEditor did not accept value with required positions filled");
+					
+					}, 100);
+				}, 100);
+			});
+
 		});
 
 		function emulateKeyBoard(key, ctrl, shift, alt, element) {
@@ -1103,8 +1139,11 @@
 				keyDown.charCode = keyUp.charCode = keyPress.charCode = ch.charCodeAt(0);
 				element.trigger(keyDown);
 				element.trigger(keyPress);
+				// refresh selection EACH time, mask editor moves over literals:
+				selectionStart = element[0].selectionStart;
 				value = value.replaceAt(selectionStart++, ch);
 				element.val(value);
+				element[0].selectionStart = selectionStart;
 				element.trigger(keyUp);
 			});
 		}
@@ -1287,6 +1326,9 @@
 		<input id="223245NumericEditor1" type="text" />
 		<input id="223245NumericEditor2" type="text" />
 		<input id="223245NumericEditor3" type="text" />
+
+		<input id="264Editor1" />
+		<input id="264Editor2" />
 
 	</div></body>
 </html>


### PR DESCRIPTION
Redoing value validation against mask, moving literals and required positions before options set so validation for initial value can be handled. Tests.
fixes #264

/ cc @bazal4o 
