### PR TITLE
Do not set properties if the control didn't init igScroll

### DIFF
--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -3545,9 +3545,8 @@
 		if (container.length === 0 && args.owner.container) {
 			container = args.owner.container().find("[data-scroll]").eq(0);
 		}
-		container.igScroll({ modifyDOM: false });
-		if (container.data("igScroll") !== null && container.data("igScroll") !== undefined) {
-			/* Set _bKeyboardNavigation only if the control has igScroll initialized */
+		if (container.length !== 0) {
+			container.igScroll({ modifyDOM: false });
 			container.data("igScroll")._bKeyboardNavigation = false;
 		}
 	});

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -3546,7 +3546,10 @@
 			container = args.owner.container().find("[data-scroll]").eq(0);
 		}
 		container.igScroll({ modifyDOM: false });
-		container.data("igScroll")._bKeyboardNavigation = false;
+		if (container.data("igScroll") !== null && container.data("igScroll") !== undefined) {
+			/* Set _bKeyboardNavigation only if the control has igScroll initialized */
+			container.data("igScroll")._bKeyboardNavigation = false;
+		}
 	});
 	return $.ui.igScroll;// REMOVE_FROM_COMBINED_FILES
 }));// REMOVE_FROM_COMBINED_FILES


### PR DESCRIPTION
This is related to the internal issue 224531