### PR TITLE
Separate ms-touch-action class and apply it always to igScroll

### DIFF
--- a/src/css/structure/modules/infragistics.ui.scroll.css
+++ b/src/css/structure/modules/infragistics.ui.scroll.css
@@ -4,6 +4,9 @@
 	position: relative;
 	overflow: hidden;
 	outline:none;
+}
+
+.igscroll-touchscrollable {
 	-ms-touch-action: none;
 	-ms-content-zooming: none;
 }

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -597,6 +597,8 @@
 		css: {
 			/* Classes applied to the element the igScroll is instantiated on */
 			scrollableElem: "igscroll-scrollable",
+			/* Classes applied to the element the igScroll is instantiated on, related to touch scrolling */
+			touchScrollableElem: "igscroll-touchscrollable",
 			/* Classes applied to the scroll content wrapper */
 			scrollContent: "igscroll-content",
 			/* Classes applied to the scroll container */
@@ -709,6 +711,7 @@
 			//Counter for how many animation for smooth wheel scrolling are present. When 0 we are no longer scrolling with wheel
 			this._numSmoothAnimation = 0;
 
+			elem.addClass(this.css.touchScrollableElem);
 			if (this.options.modifyDOM) {
 				elem.addClass(this.css.scrollableElem);
 


### PR DESCRIPTION
This will apply 
```
 -ms-touch-action: none;
 -ms-content-zooming: none;
```
to igScroll always not only when modifyDOM is true, which will allow scrolling in IE and Edge for elements which are initializing igScroll with `modifyDOM: false` (e.g. igGrid)