### PR TITLE
Dialog issues

### DIFF
--- a/src/css/themes/infragistics/infragistics.theme.css
+++ b/src/css/themes/infragistics/infragistics.theme.css
@@ -1939,6 +1939,9 @@ input.ui-igbutton {
   background-color: #e8e8e8;
   color: #444444;
 }
+.ui-igdialog-headerbutton .ui-icon:before {
+	font-size:12px;
+}
 /**********/
 /* igGrid */
 /**********/

--- a/src/css/themes/infragistics/infragistics.theme.less
+++ b/src/css/themes/infragistics/infragistics.theme.less
@@ -1479,6 +1479,9 @@ input.ui-igbutton {
 .ui-igdialog-footer {
     .stateNormal;
 }
+.ui-igdialog-headerbutton .ui-icon:before {
+	font-size:12px;
+}
 /**********/
 /* igGrid */
 /**********/

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -336,7 +336,7 @@
 			/* Classes applied to the icon of maximize button. */
 			maximizeIcon: "ui-igdialog-maximize-icon ui-icon ui-icon-extlink",
 			/* Classes applied to the icon of restore button. */
-			restoreIcon: "ui-igdialog-restore-icon ui-icon ui-icon-copy",
+			restoreIcon: "ui-igdialog-restore-icon ui-icon ui-icon-newwin",
 			/* Classes applied to the icon of pin button. */
 			pinIcon: "ui-igdialog-pin-icon ui-icon ui-icon-pin-s",
 			/* Classes applied to the icon of unpin button. */

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -1545,7 +1545,8 @@
 					self._toPx(o.height, true),
 					o.minHeight);
 				if (resize) {
-					elem.resizable("option", "minHeight", o.minHeight);
+					// D.P 12th Sep 2016 #312 minWidth, maxWidth and maxHeight options cannot be set at runtime
+					this._doResizable();
 				}
 			}
 			if (o.width === null) {

--- a/tests/unit/dialog/tests.html
+++ b/tests/unit/dialog/tests.html
@@ -343,6 +343,34 @@
             }, 250);
         });
 
+        test("Resizable options", 8, function () {
+           
+            var $dialog = $("#dialog4"), i,
+                settings = ["minWidth", "maxWidth", "minHeight","maxHeight"],
+                newValues = [400, 700, 250, 300];
+            
+            // #312 'minWidth', 'maxWidth' and 'maxHeight' options cannot be set at runtime
+            $dialog.igDialog("open");
+            
+            for (i = 0; i < settings.length; i++) {
+                  $dialog.igDialog("option", settings[i], newValues[i]);
+                  // verify option propagated to the resizable widget:
+                  equal($dialog.resizable("option", settings[i]), newValues[i], "Expected " + settings[i] + " to be " + newValues[i]);
+            }
+
+            // with closed dialog all settings are applied at once on open:
+            $dialog.igDialog("close");
+            newValues = [300, 600, 150, 200];
+            for (i = 0; i < settings.length; i++) {
+                  $dialog.igDialog("option", settings[i], newValues[i]);
+            }
+            $dialog.igDialog("open");
+            for (i = 0; i < settings.length; i++) {
+                  // verify option propagated to the resizable widget:
+                  equal($dialog.resizable("option", settings[i]), newValues[i], "Expected " + settings[i] + " to be " + newValues[i]);
+            }
+        });
+
         test("Inner controls/frames", function () {
             var $frameBody = $("#testFrame").contents().find('body'),
                 text = "test text";


### PR DESCRIPTION
- Allow setting all options on the resizable widget runtime. Fixes #312 
- Swap the restore icon to 'ui-icon-newwin' and reduce size slightly. Fixes #316 