### PR TITLE
Fix for bug 221919

### DIFF
--- a/src/css/themes/infragistics/infragistics.theme.css
+++ b/src/css/themes/infragistics/infragistics.theme.css
@@ -4171,6 +4171,7 @@ input.ui-igbutton {
 }
 .ui-icon-triangle-1-n:before {
   content: '\e644';
+  font-size: 10px;
 }
 .ui-icon-triangle-1-ne:before {
   content: '\e645';

--- a/src/css/themes/infragistics/infragistics.theme.less
+++ b/src/css/themes/infragistics/infragistics.theme.less
@@ -3877,7 +3877,7 @@ input.ui-igbutton {
 .ui-icon-carat-2-w:before{content:'\e641'}
 .ui-icon-carat-2-n-s:before{content:'\e642'}
 .ui-icon-carat-2-e-w:before{content:'\e643'}
-.ui-icon-triangle-1-n:before{content:'\e644'}
+.ui-icon-triangle-1-n:before{content:'\e644';font-size:10px}
 .ui-icon-triangle-1-ne:before{content:'\e645'}
 .ui-icon-triangle-1-e:before{content:'\e646'}
 .ui-icon-triangle-1-se:before{content:'\e647'}


### PR DESCRIPTION
Fix for issue in styling in igGrid ColumnFixing + Moving. The upper and
lower drop indicator icons should have the same size.