### PR TITLE
Removing amd module signatures from i18n files

### DIFF
--- a/src/js/modules/i18n/infragistics.datasource-bg.js
+++ b/src/js/modules/i18n/infragistics.datasource-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -53,4 +46,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.datasource-de.js
+++ b/src/js/modules/i18n/infragistics.datasource-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 
     $.ig = $.ig || {};
@@ -54,4 +47,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.datasource-en.js
+++ b/src/js/modules/i18n/infragistics.datasource-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 
     $.ig = $.ig || {};
@@ -54,4 +47,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.datasource-es.js
+++ b/src/js/modules/i18n/infragistics.datasource-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 
     $.ig = $.ig || {};
@@ -54,4 +47,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.datasource-fr.js
+++ b/src/js/modules/i18n/infragistics.datasource-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -53,4 +46,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.datasource-ja.js
+++ b/src/js/modules/i18n/infragistics.datasource-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -52,4 +45,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.datasource-ru.js
+++ b/src/js/modules/i18n/infragistics.datasource-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -53,4 +46,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-bg.js
+++ b/src/js/modules/i18n/infragistics.shared-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-de.js
+++ b/src/js/modules/i18n/infragistics.shared-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-en.js
+++ b/src/js/modules/i18n/infragistics.shared-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-es.js
+++ b/src/js/modules/i18n/infragistics.shared-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-fr.js
+++ b/src/js/modules/i18n/infragistics.shared-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-ja.js
+++ b/src/js/modules/i18n/infragistics.shared-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.shared-ru.js
+++ b/src/js/modules/i18n/infragistics.shared-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.SharedLocale) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-bg.js
+++ b/src/js/modules/i18n/infragistics.templating-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-de.js
+++ b/src/js/modules/i18n/infragistics.templating-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-en.js
+++ b/src/js/modules/i18n/infragistics.templating-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-es.js
+++ b/src/js/modules/i18n/infragistics.templating-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-fr.js
+++ b/src/js/modules/i18n/infragistics.templating-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@ if (!$.ig.Templating) {
 		}
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-ja.js
+++ b/src/js/modules/i18n/infragistics.templating-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@ if (!$.ig.Templating) {
 		}
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.templating-ru.js
+++ b/src/js/modules/i18n/infragistics.templating-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-de.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-en.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-es.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.combo-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.combo-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-de.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-en.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-es.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.dialog-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.dialog-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -31,4 +24,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -86,4 +79,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-de.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -86,4 +79,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-en.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 	$.ig = $.ig || {};
 
@@ -85,4 +78,4 @@
 			}
 		};
 	}
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-es.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -86,4 +79,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -86,4 +79,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -86,4 +79,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.editors-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -86,4 +79,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -138,4 +131,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-de.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -138,4 +131,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-en.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -138,4 +131,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-es.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -138,4 +131,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -138,4 +131,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -141,4 +134,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.htmleditor-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.htmleditor-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -138,4 +131,4 @@ if (!$.ig.HtmlEditor) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-de.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-en.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-es.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.notifier-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.notifier-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Notifier) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-de.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-en.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-es.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.popover-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.popover-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Popover) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-de.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-en.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-en.js
@@ -7,13 +7,7 @@
 *
 */
 
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -26,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-es.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.rating-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.rating-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -27,4 +20,4 @@
 		    }
 	    });
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-de.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-en.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-es.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.scroll-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.scroll-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-de.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Splitter) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-en.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-es.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Splitter) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Splitter) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.Splitter) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.splitter-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.splitter-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.TileManager) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-de.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.TileManager) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-en.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -28,4 +21,4 @@ if (!$.ig.TileManager) {
 		}
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-es.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.TileManager) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.TileManager) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.TileManager) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tilemanager-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.tilemanager-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -29,4 +22,4 @@ if (!$.ig.TileManager) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-de.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-en.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-es.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.toolbar-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.toolbar-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -30,4 +23,4 @@ if (!$.ig.Toolbar) {
 
 	});
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -42,4 +35,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-de.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -42,4 +35,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-en.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -42,4 +35,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-es.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -42,4 +35,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -42,4 +35,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -43,4 +36,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.tree-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.tree-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -42,4 +35,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -71,4 +64,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-de.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -71,4 +64,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-en.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -71,4 +64,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-es.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -71,4 +64,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -71,4 +64,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -66,4 +59,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.upload-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.upload-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -71,4 +64,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-de.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-en.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-es.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.validator-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.validator-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -46,4 +39,4 @@
 		    }
 	    };
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-de.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-en.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-es.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.videoplayer-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.videoplayer-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -62,4 +55,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 	$.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		});
 
 	}
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-de.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@ if (!$.ig.Zoombar) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-en.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 	$.ig = $.ig || {};
 
@@ -32,4 +25,4 @@
 		});
 
 	}
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-es.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@ if (!$.ig.Zoombar) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@ if (!$.ig.Zoombar) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@ if (!$.ig.Zoombar) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.ui.zoombar-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.zoombar-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 
@@ -32,4 +25,4 @@ if (!$.ig.Zoombar) {
 	});
 
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-bg.js
+++ b/src/js/modules/i18n/infragistics.util-bg.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-de.js
+++ b/src/js/modules/i18n/infragistics.util-de.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-en.js
+++ b/src/js/modules/i18n/infragistics.util-en.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-es.js
+++ b/src/js/modules/i18n/infragistics.util-es.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-fr.js
+++ b/src/js/modules/i18n/infragistics.util-fr.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-ja.js
+++ b/src/js/modules/i18n/infragistics.util-ja.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/infragistics.util-ru.js
+++ b/src/js/modules/i18n/infragistics.util-ru.js
@@ -7,14 +7,7 @@
 *
 */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
 
@@ -40,4 +33,4 @@
 	    });
 
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-af.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-af.js
@@ -1,13 +1,6 @@
 ﻿/* South Africa +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -52,4 +45,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('af');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ar.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ar.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Arabic Egypt +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 $.ig.regional = $.ig.regional || {};
@@ -37,4 +30,4 @@ $.ig.regional.ar = {
 if ($.ig.setRegionalDefault) {
 	$.ig.setRegionalDefault('ar');
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-az.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-az.js
@@ -1,13 +1,6 @@
 ﻿/* Azerbaijan, Latin +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('az');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-bg.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-bg.js
@@ -1,13 +1,6 @@
 ﻿/* Bulgaria +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -62,4 +55,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('bg');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-bs.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-bs.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Bosnia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('bs');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ca.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ca.js
@@ -1,13 +1,6 @@
 ﻿/* Catalan +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('ca');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-cs.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-cs.js
@@ -1,13 +1,6 @@
 ﻿/* Czech +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('cs');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-da.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-da.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Denmark +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -59,4 +52,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('da');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-de.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-de.js
@@ -1,13 +1,6 @@
 ﻿/* Germany +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('de');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-el.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-el.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Greece +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('el');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-en-GB.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-en-GB.js
@@ -1,13 +1,6 @@
 ﻿/* English/UK +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('en-GB');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-en.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-en.js
@@ -1,13 +1,6 @@
 ﻿/* English, US */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -51,4 +44,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('en-US');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es-419.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es-419.js
@@ -1,13 +1,6 @@
 ﻿/* Latin America, Spain +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 	$.ig = $.ig || {};
 	$.ig.regional = $.ig.regional || {};
@@ -59,4 +52,4 @@
 	if ($.ig.setRegionalDefault) {
 		$.ig.setRegionalDefault('es-419');
 	}
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es-MX.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es-MX.js
@@ -1,13 +1,6 @@
 ﻿/* Mexico, Spain +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 	$.ig = $.ig || {};
 	$.ig.regional = $.ig.regional || {};
@@ -59,4 +52,4 @@
 	if ($.ig.setRegionalDefault) {
 		$.ig.setRegionalDefault('es-MX');
 	}
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es.js
@@ -1,13 +1,6 @@
 ﻿/* Spain +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('es');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-et.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-et.js
@@ -1,13 +1,6 @@
 ﻿/* Estonia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('et');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fa.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fa.js
@@ -1,13 +1,6 @@
 ﻿/* Iran (Farsi) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -92,4 +85,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('fa');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fi.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fi.js
@@ -1,13 +1,6 @@
 ﻿/* Finland +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('fi');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fo.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fo.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Faroe +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('fo');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fr-CH.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fr-CH.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Switzerland, French +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -59,4 +52,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('fr-CH');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fr.js
@@ -1,13 +1,6 @@
 ﻿/* France +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('fr');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-he.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-he.js
@@ -1,13 +1,6 @@
 ﻿/* Israel (Hebrew) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -51,4 +44,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('he');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hr.js
@@ -1,6 +1,6 @@
 ﻿﻿/* Croatia +*/
 
-/*global define, jQuery */
+/*global jQuery */
 (function (factory) {
 	if (typeof define === "function" && define.amd) {
 		define( ["jquery"], factory );
@@ -58,4 +58,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('hr');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hu.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hu.js
@@ -1,13 +1,6 @@
 ﻿/* Hungary +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('hu');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hy.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hy.js
@@ -1,13 +1,6 @@
 ﻿/* Armenia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -52,4 +45,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('hy');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-i18n.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-i18n.js
@@ -1,13 +1,6 @@
 ﻿/* English, US */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 $.ig.regional = $.ig.regional || {};
@@ -1210,4 +1203,4 @@ $.ig.regional['zh-TW'] = {
 	currencyNegativePattern: '-$n',
 	currencySymbol: 'NT$'
 };
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-id.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-id.js
@@ -1,13 +1,6 @@
 ﻿/* Indonesia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('id');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-is.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-is.js
@@ -1,13 +1,6 @@
 ﻿/* Iceland +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('is');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-it.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-it.js
@@ -1,13 +1,6 @@
 ﻿/* Italy +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('it');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ja.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ja.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Japan +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
 $.ig = $.ig || {};
 $.ig.regional = $.ig.regional || {};
@@ -54,4 +47,4 @@ $.ig.regional.ja = {
 if ($.ig.setRegionalDefault) {
 	$.ig.setRegionalDefault('ja');
 }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ko.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ko.js
@@ -1,13 +1,6 @@
 ﻿/* Korea +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -56,4 +49,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('ko');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-lt.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-lt.js
@@ -1,13 +1,6 @@
 ﻿/* Lithuania +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('lt');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-lv.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-lv.js
@@ -1,13 +1,6 @@
 ﻿/* Latvia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('lv');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ms.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ms.js
@@ -1,13 +1,6 @@
 ﻿/* Malaysia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -59,4 +52,4 @@
     if ($.ig.setRegionalDefault) {
     	$.ig.setRegionalDefault('ms');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-nl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-nl.js
@@ -1,13 +1,6 @@
 ﻿/* Netherlands (Dutch) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -59,4 +52,4 @@
     if ($.ig.setRegionalDefault) {
     	$.ig.setRegionalDefault('nl');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-no.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-no.js
@@ -1,13 +1,6 @@
 ﻿/* Norway +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
     	$.ig.setRegionalDefault('no');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-pl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-pl.js
@@ -1,13 +1,6 @@
 ﻿/* Poland +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
     	$.ig.setRegionalDefault('pl');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-pt-BR.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-pt-BR.js
@@ -1,13 +1,6 @@
 ﻿/* Brazil +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -57,4 +50,4 @@
     if ($.ig.setRegionalDefault) {
     	$.ig.setRegionalDefault('pt-BR');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ro.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ro.js
@@ -1,13 +1,6 @@
 ﻿/* Romania +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
     	$.ig.setRegionalDefault('ro');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ru.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ru.js
@@ -1,13 +1,6 @@
 ﻿/* Russia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('ru');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sk.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sk.js
@@ -1,13 +1,6 @@
 ﻿/* Slovakia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('sk');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sl.js
@@ -1,13 +1,6 @@
 ﻿/* Slovenia +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('sl');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sq.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sq.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Albania +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -62,4 +55,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('sq');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sr-SR.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sr-SR.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Serbia (Latin) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('sr-SR');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sr.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Serbia (Cyrillic) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('sr');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sv.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sv.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Sweden +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('sv');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ta.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ta.js
@@ -1,13 +1,6 @@
 ﻿﻿/* India (Tamil) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -55,4 +48,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('ta');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-th.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-th.js
@@ -1,13 +1,6 @@
 ﻿﻿/* Thailand +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -52,4 +45,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('th');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-tr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-tr.js
@@ -1,13 +1,6 @@
 ﻿/* Turkey +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('tr');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-uk.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-uk.js
@@ -1,13 +1,6 @@
 ﻿/* Ukraine +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global Query */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -58,4 +51,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('uk');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-vi.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-vi.js
@@ -1,13 +1,6 @@
 ﻿/* Vietnam +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -60,4 +53,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('vi');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-CN.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-CN.js
@@ -1,13 +1,6 @@
 ﻿/* China (PRC) */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -52,4 +45,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('zh-CN');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-HK.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-HK.js
@@ -1,13 +1,6 @@
 ﻿/* China (Hong Kong SAR, PRC) +*/
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -45,4 +38,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('zh-HK');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-TW.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-TW.js
@@ -1,13 +1,6 @@
 ﻿﻿/* China (Taiwan) */
 
-/*global define, jQuery */
-(function (factory) {
-	if (typeof define === "function" && define.amd) {
-		define( ["jquery"], factory );
-	} else {
-		factory(jQuery);
-	}
-}
+/*global jQuery */
 (function ($) {
     $.ig = $.ig || {};
     $.ig.regional = $.ig.regional || {};
@@ -52,4 +45,4 @@
     if ($.ig.setRegionalDefault) {
 	    $.ig.setRegionalDefault('zh-TW');
     }
-}));// REMOVE_FROM_COMBINED_FILES
+})(jQuery);


### PR DESCRIPTION
The modules are defined anonymously and when combined with main files they cause an error for requirejs - multiple anonymous modules. Thus removing the AMD signatures from the i18n files so they can be safely combined with the main modules.