### PR TITLE
AMD support for combined files + misc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
 							// Set loader default locale:
 							content = content.replace(/_defaultLocale:\s*""/, "_defaultLocale: \"en\"");
 						}
-						return content.replace("<build_number>", buildVersion).replace("<year>", year);
+						return content.replace(/<build_number>/g, buildVersion).replace("<year>", year);
 					}
 				},
 			},
@@ -257,8 +257,8 @@ module.exports = function (grunt) {
 	grunt.task.registerTask("build", "Combine output files and prepare output", function() {
 		grunt.task.run("clean:build");
 		grunt.task.run("copy");
-	    grunt.task.run("uglify");
 		grunt.task.run("concat");
+	    grunt.task.run("uglify");
 		grunt.task.run("cssmin");
 	});
 };

--- a/build/packages/combined-files.js
+++ b/build/packages/combined-files.js
@@ -41,6 +41,13 @@ function buildLocaleMergePairs (locale) {
     return pairs;
 }
 
+function replaceAMDWraps(src) {
+    src = src.replace(/\(function\s*\(factory\)\s*\{[\s\S]*?\(function\s*\(\$\)\s*\{/g, '(function ($) {');
+    src = src.replace(/\}\)\)\;\s*\/\/\s*REMOVE_FROM_COMBINED_FILE.*/g, '})(jQuery);');
+    src = src.replace(/.*\/\/\s*REMOVE_FROM_COMBINED_FILE.*/g, '');
+    return src;
+}
+
 module.exports = {
     uglify: {
         source: {
@@ -74,7 +81,13 @@ module.exports = {
         controls: {
             files: buildLocaleMergePairs("en")
         },
-        core: {
+        core: { 
+            options: {
+                // Replace all AMD define statements with a single one at the top
+                banner: '(function(factory){if(typeof define==="function"&&define.amd){define(["jquery","jquery-ui"],factory)}else{factory(jQuery)}})(function($){',
+                process: replaceAMDWraps,
+                footer: '});'
+            },
             dest: "./dist/js/infragistics.core-lite.js",
             src: [
                     "./dist/js/i18n/infragistics-en.js",
@@ -85,7 +98,13 @@ module.exports = {
                     "./dist/js/modules/infragistics.ui.scroll.js"
                 ]
         }, 
-        lob: {
+        lob: { 
+            options: {
+                // Replace all AMD define statements with a single one at the top
+                banner: '(function(factory){if(typeof define==="function"&&define.amd){define(["jquery","jquery-ui","./infragistics.core-lite"],factory)}else{factory(jQuery)}})(function($){',
+                process: replaceAMDWraps,
+                footer: '});'
+            },
             dest: "./dist/js/infragistics.lob-lite.js",
             src: [
                     "./dist/js/modules/infragistics.ui.combo.js",

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1,5 +1,5 @@
 ﻿/*!@license
- * Infragistics.Web.ClientUI CountDown <build_number>
+ * Infragistics.Web.ClientUI Editors <build_number>
  *
  * Copyright (c) 2011-<year> Infragistics Inc.
  *


### PR DESCRIPTION
**AMD support for combined files** #396 
- Replace module definition with simple IIFE jQuery wrap and remove lines with remove comment
- Add header and footer to wrap the Core and LoB files in new modules, rather than registering separate modules

Configuration example I tested using one of the local demo files in the repo:
```html
<script src="require.js"></script>

    <script>
        require.config({
            paths: {
                jquery: "../../bower_components/jquery/dist/jquery",
                "jquery-ui": "../../bower_components/jquery-ui/jquery-ui"
            },
            packages: [
                { 
                    name: 'ignite-ui',
                    location: "../../dist/js"
                }
            ]
        });
    </script>
```
After which the main script can request the LoB file and initialize widgets like so:
```html
<script type="text/javascript">
    requirejs(['ignite-ui/infragistics.lob-lite'], function () {
            $(function () {
                $("#combo").igCombo(
                    //...
```
Package is defined to allow the relative dependency on the core file from LoB to work without defining separate paths for both, but the latter approach works just as well. Could also require jQuery explicitly first to pass it to the callback, but 

//cc @alexkartavov

Also updated the build number replace on files (was not global until now) for files with multiple widget definitions.