### PR TITLE
Revert "added placeholders for AMD modules that are open sourced"

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -30,7 +30,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.datasource",*/ [
+		define( [
 			"jquery",
 			"./infragistics.util"
 		], factory );

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -25,7 +25,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.templating",*/ [
+		define( [
 			"jquery",
 			"./infragistics.util"
 		], factory );

--- a/src/js/modules/infragistics.ui.colorpicker.js
+++ b/src/js/modules/infragistics.ui.colorpicker.js
@@ -19,7 +19,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.colorpicker",*/ [
+		define( [
 			"jquery",
             "jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.colorpickersplitbutton.js
+++ b/src/js/modules/infragistics.ui.colorpickersplitbutton.js
@@ -23,7 +23,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.colorpickersplitbutton",*/ [
+		define( [
 			"jquery",
             "jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.combo.js
+++ b/src/js/modules/infragistics.ui.combo.js
@@ -27,7 +27,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.combo",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -27,7 +27,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.dialog",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util"

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.editors",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.htmleditor.js
+++ b/src/js/modules/infragistics.ui.htmleditor.js
@@ -27,7 +27,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.htmleditor",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.layoutmanager.js
+++ b/src/js/modules/infragistics.ui.layoutmanager.js
@@ -17,7 +17,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.layoutmanager",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util"

--- a/src/js/modules/infragistics.ui.notifier.js
+++ b/src/js/modules/infragistics.ui.notifier.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.notifier",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.popover.js
+++ b/src/js/modules/infragistics.ui.popover.js
@@ -17,7 +17,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.popover",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util"

--- a/src/js/modules/infragistics.ui.rating.js
+++ b/src/js/modules/infragistics.ui.rating.js
@@ -25,7 +25,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.rating",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util"

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -17,7 +17,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.scroll",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util"

--- a/src/js/modules/infragistics.ui.shared.js
+++ b/src/js/modules/infragistics.ui.shared.js
@@ -17,7 +17,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.shared",*/ [
+		define( [
 			"jquery",
             "jquery-ui",
 			"./infragistics.util"

--- a/src/js/modules/infragistics.ui.splitbutton.js
+++ b/src/js/modules/infragistics.ui.splitbutton.js
@@ -20,7 +20,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.splitbutton",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.splitter.js
+++ b/src/js/modules/infragistics.ui.splitter.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.splitter",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.tilemanager.js
+++ b/src/js/modules/infragistics.ui.tilemanager.js
@@ -22,7 +22,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.tilemanager",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.toolbar.js
+++ b/src/js/modules/infragistics.ui.toolbar.js
@@ -25,7 +25,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.toolbar",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.toolbarbutton.js
+++ b/src/js/modules/infragistics.ui.toolbarbutton.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.toolbarbutton",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -23,7 +23,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.tree",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.upload.js
+++ b/src/js/modules/infragistics.ui.upload.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.upload",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.validator.js
+++ b/src/js/modules/infragistics.ui.validator.js
@@ -26,7 +26,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.validator",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.videoplayer",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.ui.zoombar.js
+++ b/src/js/modules/infragistics.ui.zoombar.js
@@ -18,7 +18,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.ui.zoombar",*/ [
+		define( [
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -25,7 +25,7 @@
 	if (typeof define === "function" && define.amd) {
 
 		// AMD. Register as an anonymous module.
-		define( /*"igniteui/js/modules/infragistics.util",*/ [
+		define( [
 			"jquery",
 			"jquery-ui"
 		], factory );


### PR DESCRIPTION
This reverts commit c8938510476a2b470c9e84915390a8d58a8d3b33.
Closes #396 
@alexkartavov can re-introduce those module names if need in the future, but they are definitely not in use for now.