### PR TITLE
Fixing issue in getRelativeOffset that regresses functionality in igGrid Filtering

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -8372,7 +8372,9 @@
 		},
 		setCellValue: function (rowId, colId, val, autoCommit) {
 			/*  sets a cell value for the cell denoted by rowId and colId. Creates a transaction for the update operation and returns it
-			dsMashup.setCellValue(1, "Name", "CD Player", true);
+			```
+				dsMashup.setCellValue(1, "Name", "CD Player", true);
+			``
 			paramType="object" the rowId - row key (string) or index (number)
 			paramType="object" the column id - column key (string) or index (number)
 			paramType="object" The new value
@@ -8426,11 +8428,13 @@
 		},
 		updateRow: function (rowId, rowObject, autoCommit) {
 			/* updates a record in the datasource. Creates a transaction that can be committed / rolled back
+			```
 			dsMashup.updateRow(1, {
 					Name: "DVD Player1",
 					Price: "10",
 					Rating: "5"
 				}, true);
+			```
 			paramType="object" the record key - primaryKey (string) or index (number)
 			paramType="object" the record object containing the key/value pairs we want to update. It doesn't have to include key/value pairs for all fields defined in the schema or in the data source (if no schema is defined)
 			paramType="bool" if autoCommit is true, the datasource will be updated automatically and the transaction is still stored in the accumulated transaction log

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -4960,6 +4960,7 @@
 		while (elem[ 0 ] !== null && elem[ 0 ] !== undefined && elem[ 0 ].nodeName !== "#document") {
 			position = elem.css("position");
 			
+			
 			// because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc
 			if (position !== "static" && position !== "") {
 				if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -4952,15 +4952,34 @@
 	// Get relative offset of the passed element according to the closest parent element with relative position if any
 	// e: jquery element
 	$.ig.util.getRelativeOffset = function (e) {
-		var elem = e.parent(), o = { left: 0, top: 0 }, position;
+		var elem = e.parent(), o = { left: 0, top: 0 }, position,
+			 windowBorderWidth = 8,
+			 zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth,
+			 documentScrollLeft, documentScrollTop, doc = e ? e[ 0 ].ownerDocument : document;
 
 		while (elem[ 0 ] !== null && elem[ 0 ] !== undefined && elem[ 0 ].nodeName !== "#document") {
 			position = elem.css("position");
-
+			
 			// because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc
 			if (position !== "static" && position !== "") {
-				o.left = elem.offset().left - elem.scrollLeft();
-				o.top = elem.offset().top - elem.scrollTop();
+				if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {
+					if ($.ig.util.isIE) {
+						documentScrollLeft = doc.documentElement.scrollLeft;
+						documentScrollTop = doc.documentElement.scrollTop;
+					} else if ($.ig.util.isEdge) {
+						documentScrollLeft = doc.body.scrollLeft;
+						documentScrollTop = doc.body.scrollTop;
+					}
+
+					o.left = elem.offset().left;
+					o.top = elem.offset().top;
+
+					o.left += documentScrollLeft - window.pageXOffset;
+					o.top += documentScrollTop - window.pageYOffset;
+				} else {
+					o.left = elem.offset().left - elem.scrollLeft();
+					o.top = elem.offset().top - elem.scrollTop();
+				}
 				break;
 			}
 			elem = elem.parent();

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -4959,9 +4959,7 @@
 
 		while (elem[ 0 ] !== null && elem[ 0 ] !== undefined && elem[ 0 ].nodeName !== "#document") {
 			position = elem.css("position");
-			
-			
-			// because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc
+			/* because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc */
 			if (position !== "static" && position !== "") {
 				if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {
 					if ($.ig.util.isIE) {

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -4955,7 +4955,7 @@
 		var elem = e.parent(), o = { left: 0, top: 0 }, position,
 			 windowBorderWidth = 8,
 			 zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth,
-			 documentScrollLeft, documentScrollTop, doc = e ? e[ 0 ].ownerDocument : document;
+			 documentScrollLeft, documentScrollTop, doc = e.length > 0 ? e[ 0 ].ownerDocument : document;
 
 		while (elem[ 0 ] !== null && elem[ 0 ] !== undefined && elem[ 0 ].nodeName !== "#document") {
 			position = elem.css("position");

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -15,7 +15,17 @@
 	<script type="text/javascript" src="../../../src/js/modules/i18n/regional/infragistics.ui.regional-en.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/i18n/regional/infragistics.ui.regional-es.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
-
+<style>
+.container {
+    position: relative;
+}
+.topright {
+    position: absolute;
+    top: 8px;
+    right: 16px;
+    font-size: 18px;
+}
+</style>
 	<script type="text/javascript">		
 		module("Basic Tests");
         // run tests
@@ -41,11 +51,23 @@
 		});
 
 		test("Test getRelativeOffset function", function () {
-			$("#container").append("<div style='position: relative; float:right;width:200px'><span id='span1'> Span elem</span><div>");
+			$("#container").append("<div class='container'><span id='span1' class='bottomleft'> Span elem</span><div>");
+			
+			$("#container").append("<div class='container'><div class='topright'><table id='table1'><tr><td>Table cell 1</td><td>Table cell 2</td></tr></table><div></div>");
+			
+			$("#container").append("<div  style='height: 500px;' class='container topright'><div class='bottomleft' style='position:static;'><span id='span2'  style='position:static;'>Span2</span></div></div>");
 
-			//check getRelativeOffset
+			//check getRelativeOffset with relative positioning of the parent
 			var relOffset = $.ig.util.getRelativeOffset($("#span1"));
-			ok($("#span1").offset().left === relOffset.left && $("#span1").offset().top === relOffset.top, "The element offset should be correct.");
+			ok($("#span1").parent().offset().left - $("#span1").parent().scrollLeft() === relOffset.left && $("#span1").parent().offset().top - $("#span1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+			
+			//check getRelativeOffset with absolute positioning of the parent
+			relOffset = $.ig.util.getRelativeOffset($("#table1"));
+			ok($("#table1").parent().offset().left - $("#table1").parent().scrollLeft() === relOffset.left && $("#table1").parent().offset().top - $("#table1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+			
+			//check getRelativeOffset with static positioning of the parent
+			relOffset = $.ig.util.getRelativeOffset($("#span2"));
+			ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
 		});
 
 	</script>

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+﻿<!DOCTYPE html PUBLIC "//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<meta charset="UTF-8">
@@ -40,6 +40,14 @@
 			equal(result, "string", "Check if result is correct for the object type.");			
 		});
 
+		test("Test getRelativeOffset function", function () {
+			$("#container").append("<div style='position: relative; float:right;width:200px'><span id='span1'> Span elem</span><div>");
+
+			//check getRelativeOffset
+			var relOffset = $.ig.util.getRelativeOffset($("#span1"));
+			ok($("#span1").offset().left === relOffset.left && $("#span1").offset().top === relOffset.top, "The element offset should be correct.");
+		});
+
 	</script>
 </head>
 <body>
@@ -49,5 +57,6 @@
 		<h2 id="qunit-userAgent"></h2>
 		<ol id="qunit-tests"></ol>
 	</div>
+	<div id="container" style="float:right;width:100%;overflow:auto;"></div>
 </body>
 </html>


### PR DESCRIPTION
Fixing issue in getRelativeOffset that regresses functionality in igGrid Filtering when filterDialogContainment: "window"