### PR TITLE
split util.js into jquery specific and non jquery specific

### DIFF
--- a/build/config/all/instrument.json
+++ b/build/config/all/instrument.json
@@ -26,6 +26,8 @@
 		"<%= config.modulesDir%>/infragistics.ui.validator.js",
 		"<%= config.modulesDir%>/infragistics.ui.videoplayer.js",
 		"<%= config.modulesDir%>/infragistics.ui.zoombar.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/combo/jshint.json
+++ b/build/config/combo/jshint.json
@@ -6,6 +6,8 @@
 		"<%= config.modulesDir%>/infragistics.ui.validator.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
 		"<%= config.modulesDir%>/infragistics.util.js",	
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js",
 		"<%= config.extensionsDir%>/infragistics.ui.combo.knockout-extensions.js"
 	]
 }

--- a/build/config/datasource/jshint.json
+++ b/build/config/datasource/jshint.json
@@ -1,6 +1,8 @@
 {
 	"config": [
 		"<%= config.modulesDir%>/infragistics.dataSource.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/dialog/jshint.json
+++ b/build/config/dialog/jshint.json
@@ -2,6 +2,8 @@
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.dialog*.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/editors/instrument.json
+++ b/build/config/editors/instrument.json
@@ -7,6 +7,8 @@
 		"<%= config.modulesDir%>/infragistics.util.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
 		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js",
 		"<%= config.extensionsDir%>/infragistics.ui.editors.knockout-extensions.js"
 	]
 }

--- a/build/config/editors/jshint.json
+++ b/build/config/editors/jshint.json
@@ -6,6 +6,8 @@
 		"<%= config.modulesDir%>/infragistics.ui.validator.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
 		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js",
 		"<%= config.extensionsDir%>/infragistics.ui.editors.knockout-extensions.js"
 	]
 }

--- a/build/config/htmleditor/jshint.json
+++ b/build/config/htmleditor/jshint.json
@@ -9,6 +9,8 @@
 		"<%= config.modulesDir%>/infragistics.dataSource.js",
 		"<%= config.modulesDir%>/infragistics.ui.dialog.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/managers/jshint.json
+++ b/build/config/managers/jshint.json
@@ -6,6 +6,8 @@
 		"<%= config.modulesDir%>/infragistics.dataSource.js",
 		"<%= config.modulesDir%>/infragistics.templating.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/rating/jshint.json
+++ b/build/config/rating/jshint.json
@@ -1,6 +1,8 @@
 {
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.rating.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/scroll/jshint.json
+++ b/build/config/scroll/jshint.json
@@ -1,6 +1,8 @@
 {
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.scroll.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/splitter/jshint.json
+++ b/build/config/splitter/jshint.json
@@ -2,6 +2,8 @@
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.splitter.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/tree/jshint.json
+++ b/build/config/tree/jshint.json
@@ -5,6 +5,8 @@
 		"<%= config.modulesDir%>/infragistics.templating.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
 		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js",
 		"<%= config.extensionsDir%>/infragistics.ui.tree.knockout-extensions.js"
 	]
 }

--- a/build/config/treegrid/instrument.json
+++ b/build/config/treegrid/instrument.json
@@ -8,6 +8,8 @@
 		"<%= config.modulesDir%>/infragistics.ui.editors.js",
 		"<%= config.modulesDir%>/infragistics.dataSource.js",
 		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js",
 		"<%= config.modulesDir%>/infragistics.templating.js"
 	]
 }

--- a/build/config/treegrid/jshint.json
+++ b/build/config/treegrid/jshint.json
@@ -5,6 +5,8 @@
 		"<%= config.modulesDir%>/infragistics.templating.js",
 		"<%= config.modulesDir%>/infragistics.ui.grid.framework.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/upload/jshint.json
+++ b/build/config/upload/jshint.json
@@ -2,6 +2,8 @@
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.upload.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/validator/jshint.json
+++ b/build/config/validator/jshint.json
@@ -3,6 +3,8 @@
         "<%= config.modulesDir%>/infragistics.ui.validator.js",
         "<%= config.modulesDir%>/infragistics.ui.notifier.js",
         "<%= config.modulesDir%>/infragistics.ui.popover.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+        "<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/videoplayer/jshint.json
+++ b/build/config/videoplayer/jshint.json
@@ -2,6 +2,8 @@
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.videoplayer.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/config/zoombar/instrument.json
+++ b/build/config/zoombar/instrument.json
@@ -2,6 +2,8 @@
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.zoombar.js",
 		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js"
 	]
 }

--- a/build/config/zoombar/jshint.json
+++ b/build/config/zoombar/jshint.json
@@ -2,6 +2,8 @@
 	"config": [
 		"<%= config.modulesDir%>/infragistics.ui.zoombar.js",
 		"<%= config.modulesDir%>/infragistics.ui.shared.js",
-		"<%= config.modulesDir%>/infragistics.util.js"
+		"<%= config.modulesDir%>/infragistics.util.js",
+		"<%= config.modulesDir%>/infragistics.util.jquery.js",
+		"<%= config.modulesDir%>/infragistics.util.jquerydeferred.js"
 	]
 }

--- a/build/packages/combined-files.js
+++ b/build/packages/combined-files.js
@@ -92,6 +92,8 @@ module.exports = {
             src: [
                     "./dist/js/i18n/infragistics-en.js",
                     "./dist/js/modules/infragistics.util.js",
+                    "./dist/js/modules/infragistics.util.jquery.js",
+                    "./dist/js/modules/infragistics.util.jquerydeferred.js",
                     "./dist/js/modules/infragistics.dataSource.js",
                     "./dist/js/modules/infragistics.templating.js",
                     "./dist/js/modules/infragistics.ui.shared.js",

--- a/demos/scroll/igScroll-CustomBars-Hsync.html
+++ b/demos/scroll/igScroll-CustomBars-Hsync.html
@@ -11,6 +11,8 @@
 	<script type="text/javascript" src="../../src/js/modules/i18n/infragistics.ui.scroll-en.js"></script>
 		
 	<script type="text/javascript" src="../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../src/js/modules/infragistics.ui.scroll.js"></script>
 	
 	<style type="text/css">	

--- a/demos/scroll/igScroll-NativeBars.html
+++ b/demos/scroll/igScroll-NativeBars.html
@@ -11,6 +11,8 @@
 	<script type="text/javascript" src="../../src/js/modules/i18n/infragistics.ui.scroll-en.js"></script>
 	
 	<script type="text/javascript" src="../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../src/js/modules/infragistics.ui.scroll.js"></script>
 	
 	<style type="text/css">

--- a/src/js/extensions/infragistics.ui.combo.knockout-extensions.js
+++ b/src/js/extensions/infragistics.ui.combo.knockout-extensions.js
@@ -19,6 +19,8 @@
             "jquery-ui",
             "knockout",
             "../modules/infragistics.util",
+            "../modules/infragistics.util.jquery",
+            "../modules/infragistics.util.jquerydeferred",
             "../modules/infragistics.datasource",
             "../modules/infragistics.ui.combo"
             ], factory );

--- a/src/js/extensions/infragistics.ui.editors.knockout-extensions.js
+++ b/src/js/extensions/infragistics.ui.editors.knockout-extensions.js
@@ -8,6 +8,8 @@
 * Depends on:
 *	jquery-1.9.1.js
 *	infragistics.util.js
+*   infragistics.util.jquery.js
+*   infragistics.util.jquerydeferred.js
 *	infragistics.ui.editors.js
 */
 
@@ -19,6 +21,8 @@
             "jquery-ui",
             "knockout",
             "../modules/infragistics.util",
+			"../modules/infragistics.util.jquery",
+			"../modules/infragistics.util.jquerydeferred",
             "../modules/infragistics.ui.editors"
             ], factory );
 	} else {

--- a/src/js/extensions/infragistics.ui.tree.knockout-extensions.js
+++ b/src/js/extensions/infragistics.ui.tree.knockout-extensions.js
@@ -27,6 +27,8 @@
             "jquery-ui",
             "knockout",
             "../modules/infragistics.util",
+			"../modules/infragistics.util.jquery",
+			"../modules/infragistics.util.jquerydeferred",
             "../modules/infragistics.datasource",
             "../modules/infragistics.templating",
             "../modules/infragistics.ui.shared",

--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -43,7 +43,9 @@ $.ig.dependencies = [
 	{
 		widget: "igUtil",
 		priority: true,
-		scripts: [ "$path$/modules/infragistics.util.js" ],
+		scripts: [ "$path$/modules/infragistics.util.js", 
+		"$path$/modules/infragistics.util.jquery.js",
+		"$path$/modules/infragistics.util.jquerydeferred.js" ],
 		locale: [ "$localePath$/infragistics.util-$locale$.js" ],
 		group: $.ig.loaderClass.locale.miscGroup,
 		css: [  ]

--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -43,7 +43,7 @@ $.ig.dependencies = [
 	{
 		widget: "igUtil",
 		priority: true,
-		scripts: [ "$path$/modules/infragistics.util.js", 
+		scripts: [ "$path$/modules/infragistics.util.js",
 		"$path$/modules/infragistics.util.jquery.js",
 		"$path$/modules/infragistics.util.jquerydeferred.js" ],
 		locale: [ "$localePath$/infragistics.util-$locale$.js" ],

--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -22,6 +22,7 @@
  * Depends on:
  *	jquery-1.9.1.js
  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *
  */
 
@@ -32,7 +33,8 @@
 		// AMD. Register as an anonymous module.
 		define( [
 			"jquery",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -26,7 +26,8 @@
 		// AMD. Register as an anonymous module.
 		define( [
 			"jquery",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.ui.colorpicker.js
+++ b/src/js/modules/infragistics.ui.colorpicker.js
@@ -10,7 +10,8 @@
  *   jquery-1.9.1.js
  *   jquery.ui.core.js
  *   jquery.ui.widget.js
- *   infragistics.util.js
+ *	 infragistics.util.js
+ *   infragistics.util.jquery.js
  *   infragistics.ui.shared.js
  */
 
@@ -22,6 +23,7 @@
 			"jquery",
             "jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.shared"
 		], factory );
 	} else {

--- a/src/js/modules/infragistics.ui.colorpickersplitbutton.js
+++ b/src/js/modules/infragistics.ui.colorpickersplitbutton.js
@@ -11,6 +11,7 @@
  *   jquery.ui.core.js
  *   jquery.ui.widget.js
  *   infragistics.util.js
+ *   infragistics.util.jquery.js
  *   infragistics.ui.shared.js
  *   infragistics.ui.popover.js
  *   infragistics.ui.toolbarbutton.js
@@ -26,6 +27,7 @@
 			"jquery",
             "jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.popover",
 			"./infragistics.ui.splitbutton",
 			"./infragistics.ui.colorpicker"

--- a/src/js/modules/infragistics.ui.combo.js
+++ b/src/js/modules/infragistics.ui.combo.js
@@ -11,6 +11,7 @@
 * jquery.ui.widget.js
 * infragistics.templating.js
 * infragistics.util.js
+* infragistics.util.jquery.js
 * infragistics.dataSource.js
 *
 * Example to use:
@@ -30,6 +31,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.templating",
 			"./infragistics.datasource",
 			"./infragistics.scroll",

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -13,6 +13,8 @@
 * jquery.ui.mouse.js
 * jquery.ui.draggable.js
 * jquery.ui.resizable.js
+* infragistics.util.js
+* infragistics.util.jquery.js
 * Example to use:
 *	<script type="text/javascript">
 *	$(function () {
@@ -29,7 +31,8 @@
 		define( [
 			"jquery",
 			"jquery-ui",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -9,6 +9,7 @@
  * jquery-1.9.1.js
  *	jquery.ui-1.9.0.js
  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *	infragistics.ui.scroll.js
  *	infragistics.ui.validator.js
  */
@@ -21,6 +22,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.scroll",
 			"./infragistics.validator"
 		], factory );

--- a/src/js/modules/infragistics.ui.htmleditor.js
+++ b/src/js/modules/infragistics.ui.htmleditor.js
@@ -10,7 +10,8 @@
  *   jquery-1.9.1.js
  *   jquery.ui.core.js
  *   jquery.ui.widget.js
- *   infragistics.util.js
+ *	 infragistics.util.js
+ *   infragistics.util.jquery.js
  *   infragistics.ui.toolbarbutton.js
  *   infragistics.ui.toolbar.js
  *   infragistics.ui.popover.js
@@ -31,6 +32,7 @@
             "jquery",
             "jquery-ui",
             "./infragistics.util",
+			"./infragistics.util.jquery",
             "./infragistics.ui.popover",
             "./infragistics.ui.splitbutton",
             "./infragistics.ui.colorpicker",

--- a/src/js/modules/infragistics.ui.layoutmanager.js
+++ b/src/js/modules/infragistics.ui.layoutmanager.js
@@ -9,7 +9,8 @@
 *	jquery-1.9.1.js
 *	jquery.ui.core.js
 *	jquery.ui.widget.js
-*   infragistics.util.js
+*	infragistics.util.js
+*   infragistics.util.jquery.js
 */
 
 (function (factory) {
@@ -19,7 +20,8 @@
         define([
             "jquery",
             "jquery-ui",
-            "./infragistics.util"
+            "./infragistics.util",
+			"./infragistics.util.jquery"
         ], factory);
     } else {
 

--- a/src/js/modules/infragistics.ui.notifier.js
+++ b/src/js/modules/infragistics.ui.notifier.js
@@ -9,7 +9,8 @@
 *  jquery-1.9.1.js
 *  jquery.ui.core.js
 *  jquery.ui.widget.js
-*  infragistics.util.js
+*	infragistics.util.js
+*  infragistics.util.jquery.js
 *  infragistics.ui.popover.js
 */
 
@@ -21,6 +22,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.popover"
 		], factory );
 	} else {

--- a/src/js/modules/infragistics.ui.popover.js
+++ b/src/js/modules/infragistics.ui.popover.js
@@ -9,7 +9,8 @@
  *  jquery-1.9.1.js
  *  jquery.ui.core.js
  *  jquery.ui.widget.js
- *  infragistics.util.js
+ *	infragistics.util.js
+ *  infragistics.util.jquery.js
  */
 
 /*global HTMLElement */
@@ -20,7 +21,8 @@
 		define( [
 			"jquery",
 			"jquery-ui",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.ui.rating.js
+++ b/src/js/modules/infragistics.ui.rating.js
@@ -9,6 +9,8 @@
 * jquery-1.9.1.js
 * jquery.ui.core.js
 * jquery.ui.widget.js
+* infragistics.util.js
+* infragistics.util.jquery.js
 * infragistics.ui.rating-en.js
 *
 * Example to use:
@@ -27,7 +29,8 @@
 		define( [
 			"jquery",
 			"jquery-ui",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -9,6 +9,7 @@
 * jquery-1.9.1.js
 * jquery.ui-1.9.0.js
 * infragistics.util.js
+* infragistics.util.jquery.js
 * modernizr.js
 */
 
@@ -20,7 +21,8 @@
 		define( [
 			"jquery",
 			"jquery-ui",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.ui.shared.js
+++ b/src/js/modules/infragistics.ui.shared.js
@@ -10,6 +10,7 @@
  *	jquery.ui.core.js
  *	jquery.ui.widget.js
  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  */
 
 (function (factory) {
@@ -19,7 +20,8 @@
 		define( [
 			"jquery",
             "jquery-ui",
-			"./infragistics.util"
+			"./infragistics.util",
+			"./infragistics.util.jquery"
 		], factory );
 	} else {
 

--- a/src/js/modules/infragistics.ui.splitbutton.js
+++ b/src/js/modules/infragistics.ui.splitbutton.js
@@ -10,7 +10,8 @@
  *   jquery-1.9.1.js
  *   jquery.ui.core.js
  *   jquery.ui.widget.js
- *   infragistics.util.js
+ * 	 infragistics.util.js
+ *   infragistics.util.jquery.js
  *   infragistics.ui.shared.js
  *   infragistics.ui.toolbarbutton.js
  */
@@ -23,6 +24,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.toolbarbutton"
 		], factory );
 	} else {

--- a/src/js/modules/infragistics.ui.splitter.js
+++ b/src/js/modules/infragistics.ui.splitter.js
@@ -10,6 +10,7 @@
  *	jquery.ui.core.js
  *	jquery.ui.widget.js
  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *	infragistics.ui.splitter-en.js
  */
 
@@ -21,6 +22,7 @@
             "jquery",
             "jquery-ui",
             "./infragistics.util",
+			"./infragistics.util.jquery",
             "./infragistics.ui.splitter-en"
         ], factory);
     } else {

--- a/src/js/modules/infragistics.ui.tilemanager.js
+++ b/src/js/modules/infragistics.ui.tilemanager.js
@@ -12,6 +12,7 @@
  *	infragistics.templating.js
  *	infragistics.dataSource.js
  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *  infragistics.ui.splitter.js
  *	infragistics.ui.layoutmanager.js
  *	infragistics.ui.tilemanager-en.js
@@ -25,6 +26,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.datasource",
 			"./infragistics.templating",
 			"./infragistics.ui.layoutmanager",

--- a/src/js/modules/infragistics.ui.toolbar.js
+++ b/src/js/modules/infragistics.ui.toolbar.js
@@ -11,6 +11,7 @@
  *   jquery.ui.core.js
  *   jquery.ui.widget.js
  *   infragistics.util.js
+ *   infragistics.util.jquery.js
  *   infragistics.ui.shared.js
  *   infragistics.ui.popover.js
  *   infragistics.ui.toolbarbutton.js
@@ -29,6 +30,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.toolbarbutton"
 		], factory );
 	} else {

--- a/src/js/modules/infragistics.ui.toolbarbutton.js
+++ b/src/js/modules/infragistics.ui.toolbarbutton.js
@@ -10,6 +10,7 @@
  *	jquery.ui.core.js
  *	jquery.ui.widget.js
  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *	infragistics.ui.shared.js
  */
 
@@ -21,6 +22,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.shared"
 		], factory );
 	} else {

--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -13,7 +13,8 @@
  *	jquery.ui.draggable.js
  *	jquery.ui.droppable.js
  *	infragistics.templating.js
- *	infragistics.util.js
+  *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *	infragistics.dataSource.js
  *	infragistics.ui.tree-en.js
  */
@@ -26,6 +27,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.datasource",
 			"./infragistics.templating",
 			"./infragistics.ui.shared",

--- a/src/js/modules/infragistics.ui.upload.js
+++ b/src/js/modules/infragistics.ui.upload.js
@@ -9,7 +9,8 @@
  *  jquery-1.9.1.js
  *	jquery.ui.core.js
  *	jquery.ui.widget.js
- *  infragistics.util.js
+ *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *  infragistics.ui.shared.js
  */
 
@@ -21,6 +22,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.shared",
 			"./infragistics.ui.upload-en"
 		], factory );

--- a/src/js/modules/infragistics.ui.validator.js
+++ b/src/js/modules/infragistics.ui.validator.js
@@ -9,6 +9,7 @@
 * jquery.ui.core.js
 * jquery.ui.widget.js
 * infragistics.util.js
+* infragistics.util.jquery.js
 * infragistics.ui.popover.js
 * infragistics.ui.notifier.js
 
@@ -30,6 +31,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.notifier",
 			"./infragistics.ui.validator-en"
 		], factory );

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -9,7 +9,8 @@
  *  jquery-1.9.1.js
  *	jquery.ui.core.js
  *	jquery.ui.widget.js
- *  infragistics.util.js
+ *	infragistics.util.js
+ *  infragistics.util.jquery.js
  *  infragistics.ui.shared.js
  */
 
@@ -21,6 +22,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.shared",
 			"./infragistics.ui.videoplayer-en"
 		], factory );

--- a/src/js/modules/infragistics.ui.zoombar.js
+++ b/src/js/modules/infragistics.ui.zoombar.js
@@ -10,6 +10,7 @@
  * jquery.ui.core.js
  * jquery.ui.widget.js
  * infragistics.util.js
+ * infragistics.util.jquery.js
  * infragistics.ui.shared.js
 */
 
@@ -22,6 +23,7 @@
 			"jquery",
 			"jquery-ui",
 			"./infragistics.util",
+			"./infragistics.util.jquery",
 			"./infragistics.ui.shared",
 			"./infragistics.ui.zoombar-en"
 		], factory );

--- a/src/js/modules/infragistics.util.jquery.js
+++ b/src/js/modules/infragistics.util.jquery.js
@@ -1,0 +1,866 @@
+/*!@license
+ * Infragistics.Web.ClientUI Util functions <build_number>
+ *
+ * Copyright (c) 2011-<year> Infragistics Inc.
+ *
+ * util functions that extend the jQuery  namespace
+ * if something is not already available in jQuery, please add it here.
+ *
+ * http://www.infragistics.com/
+ *
+ * Depends on:
+ * jquery-1.9.1.js
+ * modernizr.js (Optional)
+ * infragistics.util.js
+ *
+ */
+
+(function (factory) {
+	if (typeof define === "function" && define.amd) {
+
+		// AMD. Register as an anonymous module.
+		define( [
+			"jquery",
+			"jquery-ui",
+			"./infragistics.util"
+		], factory );
+	} else {
+
+		// Browser globals
+		factory(jQuery);
+	}
+}
+(function ($) {
+	$.ig = window.$ig || $.ig || { _isNamespace: true };
+	window.$ig = window.$ig || $.ig;
+
+	$.fn.startsWith = function (str) {
+		return this[ 0 ].innerHTML.indexOf(str) === 0;
+	};
+
+	$ig.extendNativePrototype(Array.prototype, "clone", function () {
+		return $.extend(true, [], this);
+	});
+
+	$.ajaxQueue = function (queueName, options) {
+		var callback;
+
+		//        var s = $("#status");
+		//        s.html(options.url + "<br />" + s.html());
+
+		if (typeof document.ajaxQueue === "undefined") {
+			document.ajaxQueue = { queue: {} };
+		}
+		if (typeof document.ajaxQueue.queue[queueName] === "undefined") {
+			document.ajaxQueue.queue[queueName] = [];
+		}
+
+		if (typeof options === "undefined") {
+			return;
+		}
+
+		callback = options.complete; //original callback
+
+		//overwrite complete
+		options.complete = function (request, status) {
+			document.ajaxQueue.queue[queueName].shift(); //remove the first element from the array
+			//we should check if original callbak is defined in options
+			if (typeof callback !== "undefined") {
+				callback(request, status);
+			}
+
+			if (document.ajaxQueue.queue[queueName].length > 0) {
+				$.ajax(document.ajaxQueue.queue[queueName][0]);
+			}
+		};
+
+		document.ajaxQueue.queue[queueName].push(options);
+		if (document.ajaxQueue.queue[queueName].length === 1) {
+			$.ajax(document.ajaxQueue.queue[queueName][0]);
+		}
+	};
+
+	// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+	if (!Object.keys) {
+		Object.keys = (function () {
+			"use strict";
+			var hasOwnProperty = Object.prototype.hasOwnProperty,
+				hasDontEnumBug = !({ toString: null }).propertyIsEnumerable("toString"),
+				dontEnums = [
+					"toString",
+					"toLocaleString",
+					"valueOf",
+					"hasOwnProperty",
+					"isPrototypeOf",
+					"propertyIsEnumerable",
+					"constructor"
+				],
+				dontEnumsLength = dontEnums.length;
+			return function (obj) {
+				if (typeof obj !== "object" && (typeof obj !== "function" || obj === null)) {
+					throw new TypeError("Object.keys called on non-object");
+				}
+				var result = [], prop, i;
+				for (prop in obj) {
+					if (hasOwnProperty.call(obj, prop)) {
+						result.push(prop);
+					}
+				}
+				if (hasDontEnumBug) {
+					for (i = 0; i < dontEnumsLength; i++) {
+						if (hasOwnProperty.call(obj, dontEnums[i])) {
+							result.push(dontEnums[i]);
+						}
+					}
+				}
+				return result;
+			};
+		}());
+	}
+
+	//checkbox markup classes can be changed
+	//and setting them in a a box can be done by the predefined classes "ui-state-default ui-corner-all ui-igcheckbox-small"
+	$ig.checkboxMarkupClasses = "";
+
+	$ig.formatter = function (val, type, format, notTemplate, enableUTCDates,
+		displayStyle, labelText, tabIndex) {
+		var min, y, h, m, s, ms, am, e, day, pattern, len, n, dot, gr,
+			gr0, grps, curS, percS, cur, perc, prefix, i, d = val && val.getTime,
+			reg = $ig.regional.defaults, pow,
+
+			// L.A. 17 October 2012 - Fixing bug #123215 The group rows of a grouped checkbox column are too large
+			display = displayStyle || "inline-block";
+		if (format === "checkbox" && notTemplate) {
+			s = "<span class='ui-igcheckbox-container' style='display:" +
+				display + ";' role='checkbox' aria-disabled='true' aria-checked='" +
+				val + "' aria-label='" + labelText + "' tabindex='" + tabIndex + "'>";
+			s += "<span class='" + $ig.checkboxMarkupClasses + "' style='display:inline-block'>";
+			s += "<span style='display:block' class='" + (val ? "" : "ui-igcheckbox-small-off ");
+			return s + "ui-icon ui-icon-check ui-igcheckbox-small-on'></span></span></span>";
+		}
+		if (!val && val !== 0 && val !== false) {
+			return "&nbsp;";
+		}
+		if (type === "date" || d) {
+			if (!val) {
+				return "&nbsp;";
+			}
+			if (!d) {
+				return val;
+			}
+			pattern = reg[(format && format !== "null" && format !== "undefined") ?
+				format + "Pattern" : "datePattern"] || format;
+			if (enableUTCDates) {
+				y = val.getUTCFullYear();
+				m = val.getUTCMonth() + 1;
+				d = val.getUTCDate();
+				h = val.getUTCHours();
+				min = val.getUTCMinutes();
+				s = val.getUTCSeconds();
+				ms = val.getUTCMilliseconds();
+				day = val.getUTCDay();
+			} else {
+				y = val.getFullYear();
+				m = val.getMonth() + 1;
+				d = val.getDate();
+				h = val.getHours();
+				min = val.getMinutes();
+				s = val.getSeconds();
+				ms = val.getMilliseconds();
+				day = val.getDay();
+			}
+
+			// M.P. 25 July 2014: 176543 - $ig.formatter doesn't work with escaped characters for date formatting
+			pattern = pattern.replace(/\\d/g, "\x06").replace(/\\y/g, "\x07").replace(/\\M/g, "\x08")
+				.replace(/\\m/g, "\x09").replace(/\\t/g, "\x0A").replace(/\\s/g, "\x0B")
+				.replace(/\\f/g, "\x0C").replace(/\\h/g, "\x0D").replace(/\\H/g, "\x0E");
+
+			// remove MMMM, MMM, dddd, ddd, tt, t
+			pattern = pattern.replace("MMMM", "\x01").replace("MMM", "\x02").replace("dddd", "\x03")
+				.replace("ddd", "\x04");
+			if (pattern.indexOf("t") >= 0) {
+				am = (h >= 12) ? reg.pm : reg.am;
+				am = am || " ";
+				if (pattern.indexOf("tt") >= 0) {
+					pattern = pattern.replace("tt", "t");
+				} else if (am.length > 1) {
+					am = am.substring(0, 1);
+				}
+				pattern = pattern.replace("t", "\x05");
+			}
+			if (pattern.indexOf("h") >= 0) {
+				if (h > 12) {
+					h -= 12;
+				}
+
+				// M.P. 2 August 2013 - Fix for bug #147778 Incorrect date formatting when 12 hour format is used
+				if (h === 0) {
+					h = 12;
+				}
+			}
+			pattern = pattern.replace(/H/g, "h");
+
+			// L.A. 23 October 2012 - Fixing bug #125273 Missing leading zeros when using format MM/dd/yyyy for dates before 1000
+			pattern = pattern
+				.replace("yyyy", y < 10 ? "000" + y : y < 100 ? "00" + y : y < 1000 ? "0" + y : y)
+				.replace("yy", ((y = y % 100) < 10) ? "0" + y : y).replace("y", y % 100)
+				.replace("MM", (m < 10) ? "0" + m : m).replace("M", m);
+			pattern = pattern.replace("dd", (d < 10) ? "0" + d : d).replace("d", d);
+			pattern = pattern.replace("hh", (h < 10) ? "0" + h : h).replace("h", h)
+				.replace("mm", (min < 10) ? "0" + min : min).replace("m", min)
+				.replace("ss", (s < 10) ? "0" + s : s).replace("s", s);
+			pattern = pattern.replace("fff", (ms < 10) ? "00" + ms : ((ms < 100) ? "0" + ms : ms))
+				.replace("ff", ((ms = Math.round(ms / 10)) < 10) ? "0" + ms : ms)
+				.replace("f", Math.round(ms / 100));
+			pattern = pattern.replace("\x01", reg.monthNames[m - 1])
+				.replace("\x02", reg.monthNamesShort[m - 1]).replace("\x05", am);
+			pattern = pattern.replace("\x03", reg.dayNames[day]).replace("\x04", reg.dayNamesShort[day]);
+			pattern = pattern.replace(/\x06/g, "d").replace(/\x07/g, "y").replace(/\x08/g, "M")
+				.replace(/\x09/g, "m").replace(/\x0A/g, "t").replace(/\x0B/g, "s")
+				.replace(/\x0C/g, "f").replace("\x0D", "h").replace("\x0E", "H");
+			return pattern;
+		}
+		d = format === "double";
+		if (!d) {
+			cur = format === (curS = "currency");
+			if (!cur) {
+				perc = format === (percS = "percent");
+				if (!perc) {
+					i = format === "int";
+				}
+			}
+		}
+		n = typeof val === "number";
+		if (d || n || i || cur || perc || type === "number") {
+			if (!n) {
+
+				// N.A. 26 April 2013 - Fixing bug #139790 When regional settings, different from english, are used and the decimal separator is different than "." the value is calculated wrong
+				// keep only e, E, -, +, decimal separator and digits
+				val = parseFloat(val.replace("(", "-")
+					.replace(new RegExp("[^0-9\\-eE\\" +
+						reg.numericDecimalSeparator + "\\+]", "gm"), "")
+					.replace(reg.numericDecimalSeparator, "."));
+			}
+			if (isNaN(val)) {
+				return "&nbsp;";
+			}
+
+			// M.H. 27 Oct 2014 Fix for bug #183668: when setting column format to percent the formatted value doesn"t reflect proper math to address decimal placement
+			if (perc) {
+				val *= 100;
+			}
+			prefix = cur ? curS : (perc ? percS : "numeric");
+			pattern = reg[prefix + ((val < 0) ? "Negative" : "Positive") + "Pattern"] || "n";
+			len = format ? format.length : 0;
+
+			// calculate maximum number of decimals
+			if (len > 0 && ((s = format.charAt(0)) === "0" || s === "#")) {
+				min = m = 0;
+				dot = format.indexOf(".");
+				if (dot > 0) {
+					m = len - 1 - dot;
+					while (++dot < len) {
+						if (format.charAt(dot) !== "0") {
+							break;
+						}
+						min++;
+					}
+				}
+			} else {
+				min = reg[prefix + "MinDecimals"] || 0;
+				if (d) {
+					m = 999;
+				} else {
+					m = reg[prefix + "MaxDecimals"];
+					m = (m && !i) ? m : 0;
+				}
+			}
+			if (val < 0) {
+				val = -val;
+			}
+
+			// S.S. March 26, 2013 Bug #137025. IE8 and below do not round numbers in toFixed() so we need to round
+			// them first before passing them to toFixed()
+			// val = (m === 999) ? val.toString(10) : val.toFixed(m);
+			if (m === 999) {
+				val = val.toString(10);
+			} else {
+				if ($ig.util.isIE && $ig.util.browserVersion <= 8) {
+					pow = Math.pow(10, m);
+					val = (Math.round(pow * val) / pow).toFixed(m);
+				} else {
+					val = val.toFixed(m);
+				}
+			}
+			if ((i = val.indexOf("E")) < 0) {
+				i = val.indexOf("e");
+			}
+
+			// cut-off E-power (e)
+			e = "";
+			if (i > 0) {
+				e = val.substring(i);
+				val = val.substring(0, i);
+			}
+			dot = val.indexOf(".");
+			len = val.length;
+			i = 0;
+
+			// remove trailing 0s
+			while (dot > 0 && m > min + i && val.charAt(len - 1 - i) === "0") {
+				i++;
+			}
+			if (i > 0) {
+				val = val.substring(0, len -= i);
+			}
+
+			// remove trailing .
+			if (dot === len - 1) {
+				val = val.substring(0, dot);
+			}
+			if (dot > 0) {
+				len = dot;
+			}
+
+			// replace decimal separator
+			s = reg[prefix + "DecimalSeparator"];
+			if (s) {
+				val = val.replace(".", s);
+			}
+
+			// insert group separators
+			s = reg[prefix + "GroupSeparator"];
+			grps = s ? reg[prefix + "Groups"] : "";
+			gr = gr0 = (grps.length > 0) ? grps[i = 0] : 0;
+			while (gr > 0 && --len > 0) {
+				if (--gr === 0) {
+					val = val.substring(0, len) + s + val.substring(len);
+					gr = grps[++i];
+					if (!gr || gr < 1) {
+						gr = gr0;
+					} else {
+						gr0 = gr;
+					}
+				}
+			}
+
+			// replace "n" by number, "$" by symbol and "-" by negative sign
+			s = reg[prefix + "Symbol"] || "";
+			return pattern.replace("-", reg.negativeSign).replace("n", val + e).replace("$", s);
+		}
+		if (format) {
+			if (format.indexOf(s = "{0}") >= 0) {
+				return format.replace(s, val);
+			}
+			if (format.indexOf(s = "[0]") >= 0) {
+				return format.replace(s, val);
+			}
+		}
+		return (val || val === 0) ? val : "&nbsp;";
+	};
+	$ig._regional = {
+		monthNames: ["January", "February", "March", "April", "May", "June",
+			"July", "August", "September", "October", "November", "December"],
+		monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+		dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday",
+			"Thursday", "Friday", "Saturday"],
+		dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		am: "AM",
+		pm: "PM",
+		datePattern: "M/d/yyyy",
+		dateLongPattern: "dddd, MMMM dd, yyyy",
+		dateTimePattern: "M/d/yyyy h:mm tt",
+		timePattern: "h:mm tt",
+		timeLongPattern: "h:mm:ss tt",
+		negativeSign: "-",
+		numericNegativePattern: "-$n",
+		numericDecimalSeparator: ".",
+		numericGroupSeparator: ",",
+		numericGroups: [3],
+		numericMaxDecimals: 2,
+		numericMinDecimals: 0,
+		currencyPositivePattern: "$n",
+		currencyNegativePattern: "-$n",
+		currencySymbol: "$",
+		currencyDecimalSeparator: ".",
+		currencyGroupSeparator: ",",
+		currencyGroups: [3],
+		currencyMaxDecimals: 2,
+		currencyMinDecimals: 2,
+		percentPositivePattern: "n$",
+		percentNegativePattern: "-n$",
+		percentSymbol: "%",
+		percentDecimalSeparator: ".",
+		percentGroupSeparator: ",",
+		percentGroups: [3],
+		percentDisplayFactor: 100,
+		percentMaxDecimals: 2,
+		percentMinDecimals: 2
+	};
+	$ig.regional = $ig.regional || {};
+	$ig.regional.defaults = $ig._regional;
+	$ig.setRegionalDefault = function (regional) {
+		if ($.ui && $.ui.igEditor) {
+			$.ui.igEditor.setDefaultCulture(regional);
+		} else {
+			$ig.regional.defaults = $.extend($ig._regional,
+				(typeof regional === "string") ? $ig.regional[regional] : regional);
+		}
+	};
+	$ig.calcSummaries = function (summaryFunction, data, caller, dataType) {
+		var sum = function (data) {
+			var sum = 0,
+				i;
+			for (i = 0; i < data.length; i++) {
+				sum += data[i];
+			}
+			return sum;
+		};
+
+		// M.H. 16 Nov. 2011 Fix for bug 97886
+		summaryFunction = summaryFunction.toLowerCase();
+		if (summaryFunction.startsWith("custom")) {
+			summaryFunction = "custom";
+		}
+
+		switch (summaryFunction) {
+			case "min":
+				if (data.length === 0) {
+					if (dataType === "date") {
+						return null;
+					}
+					return 0;
+				}
+				return Math.min.apply(Math, data);
+			case "max":
+				if (data.length === 0) {
+					if (dataType === "date") {
+						return null;
+					}
+					return 0;
+				}
+				return Math.max.apply(Math, data);
+			case "sum":
+				return sum(data);
+			case "avg":
+				if (data.length === 0) {
+					return 0;
+				}
+				return sum(data) / data.length;
+			case "count":
+				return data.length;
+			case "custom":
+
+				// M.H. 30 Sept. 2011 Fix for bug #88717 - fix when caller is string
+				if (caller !== undefined && caller !== null) {
+					if ($.type(caller) === "function") {
+						return caller(data);
+					}
+					if ($.type(caller) === "string") {
+						/*jshint evil:true */
+						caller = eval(caller);
+						return caller(data);
+					}
+				} else {
+					return null;
+				}
+				break;
+		}
+	};
+
+	// get max zIndex of ui-dialogs - method is usually called by feautures for configuring zIndex of modal dialogs(like filtering, feature chooser, hiding, etc.)
+	$ig.getMaxZIndex = function (id) {
+		var maxZ = 10000, thisZ;
+		$(".ui-dialog").each(function () {
+			if (!id || $(this)[0].id !== id) {
+				thisZ = $(this).css("z-index");
+				if (!isNaN(thisZ)) {
+					maxZ = Math.max(maxZ, thisZ);
+				}
+			}
+		});
+		return maxZ;
+	};
+
+	// generate unique identifiers
+	$ig.uid = function () {
+		return ((1 + Math.random()) * parseInt("10000", 16)).toString(16).substring(1, 5);
+	};
+
+	$ig.getColType = function (o) {
+		var t = typeof o;
+		if (t === "undefined") {
+			return "string";
+		} else if (o && o.getTime && !isNaN(o.getTime()) &&
+			Object.prototype.toString.call(o) === "[object Date]") {
+			return "date";
+		} else if (t === "boolean") {
+			return "bool";
+		} else if (t === "number") {
+			return t;
+		} else if (t === "object") {
+			return "object";
+		} else {
+			return "string";
+		}
+
+	};
+
+	(function ($) {
+
+		$ig.util.profiler = {};
+
+		var methods = {};
+
+		$ig.util.profiler.recordTime = function (methodName, time) {
+			var key = "meth: " + methodName;
+			if (!methods[key]) {
+				methods[key] = [];
+			}
+			methods[key][methods[key].length] = time;
+		};
+
+		$ig.util.profiler.reset = function () {
+			methods = {};
+		};
+
+		$ig.util.profiler.logReport = function () {
+			var meths = [];
+			var j = 0;
+			var sum = 0;
+			var avg = 0;
+			for (var prop in methods) {
+				if (prop.indexOf("meth:") === 0) {
+					var meth = {};
+					meth.name = prop.substr(5);
+
+					sum = 0;
+					for (var i = 0; i < methods[prop].length; i++) {
+						sum = sum + methods[prop][i];
+					}
+					avg = sum / methods[prop].length;
+					meth.avg = avg;
+					meth.callCount = methods[prop].length;
+					meths[j] = meth;
+					j++;
+				}
+			}
+
+			meths.sort(function (m1, m2) {
+				if (m1.avg < m2.avg) {
+					return 1;
+				}
+				if (m1.avg > m2.avg) {
+					return -1;
+				}
+				if (m1.avg == m2.avg) {
+					return 0;
+				}
+			});
+
+			for (var k = 0; k < Math.min(200, meths.length) ; k++) {
+				console.log(meths[k].name + " avg: " + meths[k].avg +
+					" callCount: " + meths[k].callCount);
+			}
+		};
+	}(jQuery));
+
+	// N.A. 10/17/2013 - Bug #155039: The property "offset" is deprecated in 1.9.
+	$ig.util.jQueryUIMainVersion = $.ui && $.ui.version &&
+		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 1)[0], 10) : null;
+	$ig.util.jQueryUISubVersion = $.ui && $.ui.version &&
+		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 2)[1], 10) : null;
+
+	$ig.util.jQueryMainVersion = $.fn.jquery &&
+		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 1)[0], 10) : null;
+	$ig.util.jQuerySubVersion = $.fn.jquery &&
+		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 2)[1], 10) : null;
+
+	// Ajdusts jQuery.offset in IE10/IE11/Edge.
+	// jQuery.offset function calculates the coordinates by using element.getBoundingClientRect()
+	// function and adding the page scrolls offests (window.pageXOffset and window.pageYOffset).
+	// When zooming in/out the offset is incorrect because window.pageXOffset and
+	// window.pageYOffset values increase when the user zooms in/out. They should not.
+	// Below we calculate the element coordinates by adding the real page scroll offsets.
+	// The page zoom is detected by using the the inner window's width which reacts to
+	// zooming in/out the page.
+	// e: jquery object/element
+	// xy: optional precalculated e.offset or existing position/point with members left/top
+	$ig.util.offset = function (e, xy) {
+		var doc = e ? e[0].ownerDocument : document,
+            windowBorderWidth = 8,
+            zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth;
+
+		xy = xy || e.offset();
+
+		if (zoom && zoom > 1 && ($ig.util.isIE10 || $ig.util.isIE11 || $ig.util.isEdge)) {
+			if ($ig.util.isIE) {
+				xy.documentScrollLeft = doc.documentElement.scrollLeft;
+				xy.documentScrollTop = doc.documentElement.scrollTop;
+			} else if ($ig.util.isEdge) {
+				xy.documentScrollLeft = doc.body.scrollLeft;
+				xy.documentScrollTop = doc.body.scrollTop;
+			}
+
+			xy.left += xy.documentScrollLeft - window.pageXOffset;
+			xy.top += xy.documentScrollTop - window.pageYOffset;
+		}
+
+		return xy;
+	};
+
+	// Get relative offset of the passed element according to the closest parent element with relative position if any
+	// e: jquery element
+	$ig.util.getRelativeOffset = function (e) {
+		var elem = e.parent(), o = { left: 0, top: 0 }, position,
+			 windowBorderWidth = 8,
+			 zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth,
+			 documentScrollLeft, documentScrollTop, doc = e.length > 0 ? e[0].ownerDocument : document;
+
+		while (elem[0] !== null && elem[0] !== undefined && elem[0].nodeName !== "#document") {
+			position = elem.css("position");
+			/* because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc */
+			if (position !== "static" && position !== "") {
+				if (zoom && zoom > 1 && ($ig.util.isIE10 || $ig.util.isIE11 || $ig.util.isEdge)) {
+					if ($ig.util.isIE) {
+						documentScrollLeft = doc.documentElement.scrollLeft;
+						documentScrollTop = doc.documentElement.scrollTop;
+					} else if ($ig.util.isEdge) {
+						documentScrollLeft = doc.body.scrollLeft;
+						documentScrollTop = doc.body.scrollTop;
+					}
+
+					o.left = elem.offset().left;
+					o.top = elem.offset().top;
+
+					o.left += documentScrollLeft - window.pageXOffset;
+					o.top += documentScrollTop - window.pageYOffset;
+				} else {
+					o.left = elem.offset().left - elem.scrollLeft();
+					o.top = elem.offset().top - elem.scrollTop();
+				}
+				break;
+			}
+			elem = elem.parent();
+		}
+		return o;
+	};
+
+	// animates rotation
+	$.fn.animateRotate = function (startAngle, endAngle, duration, easing, complete) {
+		return this.each(function () {
+			var elem = $(this);
+			$({ deg: startAngle }).animate({ deg: endAngle }, {
+				duration: duration,
+				easing: easing,
+				step: function (now) {
+					elem.css({
+						"-moz-transform": "rotate(" + now + "deg)",
+						"-webkit-transform": "rotate(" + now + "deg)",
+						"-o-transform": "rotate(" + now + "deg)",
+						"-ms-transform": "rotate(" + now + "deg)",
+						"transform": "rotate(" + now + "deg)"
+					});
+				},
+				complete: complete || $.noop
+			});
+		});
+	};
+
+	// creates crc32 table
+	$ig.util.makeCRCTable = function () {
+		var c, n, k, crcTable = [];
+		for (n = 0; n < 256; n++) {
+			c = n;
+			for (k = 0; k < 8; k++) {
+				/*jslint bitwise: true */
+				c = ((c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1));
+			}
+			crcTable[n] = c;
+		}
+		return crcTable;
+	};
+
+	// returns crc32 checksum for the input string
+	$ig.util.crc32 = function (str) {
+		/*jslint bitwise: true */
+		var crcTable = $ig.util.crcTable || ($ig.util.crcTable = $ig.util.makeCRCTable()),
+			crc = 0 ^ (-1), i;
+		str = unescape(encodeURIComponent(str));
+		for (i = 0; i < str.length; i++) {
+			crc = (crc >>> 8) ^ crcTable[(crc ^ str.charCodeAt(i)) & 0xFF];
+		}
+		return (crc ^ (-1)) >>> 0;
+	};
+
+	// returns checksum based on the string representations of an object's property values
+	$ig.util.getCheckSumForObject = function (obj) {
+		var str = "", key;
+		for (key in obj) {
+			if (obj.hasOwnProperty(key) && typeof obj[key] !== "object"/* only stringify simple properties */) {
+				str += obj[key];
+			}
+		}
+		return $ig.util.crc32(str);
+	};
+
+	/* jshint +W016*/
+
+	$ig.util.invokeCallback = function (callback, args) {
+		if (callback) {
+			if ($.type(callback) === "string" &&
+				window[callback] && $.type(window[callback]) === "function") {
+				callback = window[callback];
+			}
+			if ($.type(callback) === "function") {
+				callback.apply(window, args);
+			}
+		}
+	};
+
+	$ig.util.IMEtoENNumbersMapping = function () {
+		return {
+			"１": "1", "２": "2", "３": "3", "４": "4", "５": "5",
+			"６": "6", "７": "7", "８": "8", "９": "9", "０": "0"
+		};
+	};
+	$ig.util.IMEtoNumberString = function (stringValue, mapping) {
+		if (mapping === undefined) {
+			return stringValue;
+		}
+		if (stringValue) {
+			stringValue = stringValue.toString();
+			$.each(mapping, function (jpVal, engVal) {
+				stringValue = stringValue.replace(new RegExp(jpVal, "g"), engVal);
+			});
+		}
+		return stringValue;
+	};
+
+	// M.H. 5 Mar 2013 Fix for bug #134982: When you instantiate dataSource object and there isn't reference to jQueryUI js error is thrown.
+	if ($.Widget) {
+
+		// M.H. 1 Mar 2013 Fix for bug #134534: Updating the jQuery`s version breaks most of the samples in the new samples browser
+		// In jquery-ui 1.9.2+ it is used only full name - we fix this breaking change as adding also widgetName(it is used in older versions)
+		(function (createWidget) {
+			$.Widget.prototype._createWidget = function (options, element) {
+				var el = $(element || this.defaultElement || this)[0];
+				if (el !== this) {
+					$.data(el, this.widgetName, this);
+				}
+				return createWidget.apply(this, arguments);
+			};
+		})($.Widget.prototype._createWidget);
+
+		// M.H. 21 Oct 2014 Fix for bug #183464: With jQuery UI 1.11.x destroy leaves the { widgetName: widgetInstance } pairs intact on the elements
+		// it should be removed data for this.widgetName as well
+		(function (destroy) {
+			$.Widget.prototype.destroy = function () {
+				// we should call first prototype destroy because _destroy is called before remove data for the element
+				var ret = destroy.apply(this, arguments);
+				if (this.widgetName && this.element) {
+					this.element.removeData(this.widgetName);
+				}
+				return ret;
+			};
+		})($.Widget.prototype.destroy);
+	}
+
+	// Check if given element has vertical scrollbar
+	// elem - jQuery object
+	$ig.util.hasVerticalScroll = function (elem) {
+		var overflow = $(elem).css("overflow-y");
+		return overflow === "scroll" ||
+			overflow === "auto" && elem[0].scrollHeight > elem[0].clientHeight;
+	};
+
+	// Check if given element has horizontal scrollbar
+	// elem - jQuery object
+	$ig.util.hasHorizontalScroll = function (elem) {
+		var overflow = $(elem).css("overflow-x");
+		return overflow === "scroll" ||
+			overflow === "auto" && elem[0].scrollWidth > elem[0].clientWidth;
+	};
+
+	// Returns the width of the vertical scrollbar
+	$ig.util.getScrollWidth = function () {
+		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
+			'top: -10000px; left: -10000px; overflow: scroll"></div>')
+			.appendTo($(document.body)), scrollWidth;
+		scrollWidth = el[0].offsetWidth - el[0].clientWidth;
+		el.remove();
+		return scrollWidth;
+	};
+
+	// Returns the height of the horizontal scrollbar
+	$ig.util.getScrollHeight = function () {
+		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
+			'top: -10000px; left: -10000px; overflow: scroll"></div>')
+			.appendTo($(document.body)), scrollHeight;
+		scrollHeight = el[0].offsetHeight - el[0].clientHeight;
+		el.remove();
+		return scrollHeight;
+	};
+
+	$ig.util._renderUnsupportedBrowser = function (widget, locale) {
+		if (!widget.events || !widget.events.browserNotSupported ||
+			widget._trigger(widget.events.browserNotSupported)) {
+			var elem = widget.element, o = widget.options,
+				container = $("<div></div>").css("overflow", "auto")
+					.addClass(widget.css.unsupportedBrowserClass).appendTo(elem),
+				ul, browserUnsupported;
+			locale = locale || $ig.util.locale;
+			if ($ig.util.isIE) {
+				browserUnsupported = "Internet Explorer " + $ig.util.browserVersion;
+			} else if ($ig.util.isOpera) {
+				browserUnsupported = "Opera " + $ig.util.browserVersion;
+			} else if ($ig.util.isWebKit) {
+				browserUnsupported = "Webkit " + $ig.util.browserVersion;
+			} else if ($ig.util.isFF) {
+				browserUnsupported = "Mozilla Firefox " + $ig.util.browserVersion;
+			} else {
+				browserUnsupported = $ig.util.browserVersion;
+			}
+
+			$("<div></div>").addClass("ui-html5-current-browser-label")
+				.html(locale.currentBrowser.replace("{0}", browserUnsupported))
+				.appendTo(container);
+			$("<div></div>").addClass("ui-html5-non-html5-text")
+				.html(locale.unsupportedBrowser).appendTo(container);
+			ul = $("<ul></ul>").addClass("ui-html5-browsers-list").appendTo(container);
+			$("<a></a>").attr("href", locale.chromeDownload).attr("target", "_blank")
+				.addClass("ui-html5-chrome-icon").html(locale.chrome8).appendTo($("<li></li>")
+				.addClass("ui-corner-all").appendTo(ul));
+			$("<a></a>").attr("href", locale.firefoxDownload).attr("target", "_blank")
+				.addClass("ui-html5-firefox-icon").html(locale.firefox36).appendTo($("<li></li>")
+				.addClass("ui-corner-all").appendTo(ul));
+			$("<a></a>").attr("href", locale.operaDownload).attr("target", "_blank")
+				.addClass("ui-html5-Opera-icon").html(locale.opera11).appendTo($("<li></li>")
+				.addClass("ui-corner-all").appendTo(ul));
+			$("<a></a>").attr("href", locale.safariDownload).attr("target", "_blank")
+				.addClass("ui-html5-safari-icon").html(locale.safari5).appendTo($("<li></li>")
+				.addClass("ui-corner-all").appendTo(ul));
+			$("<a></a>").attr("href", locale.ieDownload).attr("target", "_blank")
+				.addClass("ui-html5-ie-icon").html(locale.ie9).appendTo($("<li></li>")
+				.addClass("ui-corner-all").appendTo(ul));
+			if (widget.css.unsupportedBrowserClass.indexOf(" ui-html5-non-html5") === -1) {
+				elem.addClass("ui-html5-non-html5");
+			}
+			if (o.width) {
+				elem.css("width", o.width);
+			}
+			if (o.height) {
+				elem.css("height", o.height);
+			}
+		}
+	};
+
+	$ig.util.defType("jQueryDomRenderer", "Object", {
+		init: function () {
+		},
+		
+		$type: new $ig.Type("jQueryDomRenderer", $ig.Object.prototype.$type)
+	}, true);
+
+}));

--- a/src/js/modules/infragistics.util.jquery.js
+++ b/src/js/modules/infragistics.util.jquery.js
@@ -14,6 +14,7 @@
  * infragistics.util.js
  *
  */
+/*global xyz, Class, ActiveXObject, Modernizr, VBArray, Intl, XDomainRequest, unescape*/ /*jshint -W106*/ /*jshint -W116*/ /*jshint unused:false*/
 
 (function (factory) {
 	if (typeof define === "function" && define.amd) {

--- a/src/js/modules/infragistics.util.jquery.js
+++ b/src/js/modules/infragistics.util.jquery.js
@@ -52,8 +52,8 @@
 		if (typeof document.ajaxQueue === "undefined") {
 			document.ajaxQueue = { queue: {} };
 		}
-		if (typeof document.ajaxQueue.queue[queueName] === "undefined") {
-			document.ajaxQueue.queue[queueName] = [];
+		if (typeof document.ajaxQueue.queue[ queueName ] === "undefined") {
+			document.ajaxQueue.queue[ queueName ] = [];
 		}
 
 		if (typeof options === "undefined") {
@@ -64,20 +64,20 @@
 
 		//overwrite complete
 		options.complete = function (request, status) {
-			document.ajaxQueue.queue[queueName].shift(); //remove the first element from the array
+			document.ajaxQueue.queue[ queueName ].shift(); //remove the first element from the array
 			//we should check if original callbak is defined in options
 			if (typeof callback !== "undefined") {
 				callback(request, status);
 			}
 
-			if (document.ajaxQueue.queue[queueName].length > 0) {
-				$.ajax(document.ajaxQueue.queue[queueName][0]);
+			if (document.ajaxQueue.queue[ queueName ].length > 0) {
+				$.ajax(document.ajaxQueue.queue[ queueName ][ 0 ]);
 			}
 		};
 
-		document.ajaxQueue.queue[queueName].push(options);
-		if (document.ajaxQueue.queue[queueName].length === 1) {
-			$.ajax(document.ajaxQueue.queue[queueName][0]);
+		document.ajaxQueue.queue[ queueName ].push(options);
+		if (document.ajaxQueue.queue[ queueName ].length === 1) {
+			$.ajax(document.ajaxQueue.queue[ queueName ][ 0 ]);
 		}
 	};
 
@@ -109,8 +109,8 @@
 				}
 				if (hasDontEnumBug) {
 					for (i = 0; i < dontEnumsLength; i++) {
-						if (hasOwnProperty.call(obj, dontEnums[i])) {
-							result.push(dontEnums[i]);
+						if (hasOwnProperty.call(obj, dontEnums[ i ])) {
+							result.push(dontEnums[ i ]);
 						}
 					}
 				}
@@ -149,8 +149,8 @@
 			if (!d) {
 				return val;
 			}
-			pattern = reg[(format && format !== "null" && format !== "undefined") ?
-				format + "Pattern" : "datePattern"] || format;
+			pattern = reg[ (format && format !== "null" && format !== "undefined") ?
+				format + "Pattern" : "datePattern" ] || format;
 			if (enableUTCDates) {
 				y = val.getUTCFullYear();
 				m = val.getUTCMonth() + 1;
@@ -213,9 +213,9 @@
 			pattern = pattern.replace("fff", (ms < 10) ? "00" + ms : ((ms < 100) ? "0" + ms : ms))
 				.replace("ff", ((ms = Math.round(ms / 10)) < 10) ? "0" + ms : ms)
 				.replace("f", Math.round(ms / 100));
-			pattern = pattern.replace("\x01", reg.monthNames[m - 1])
-				.replace("\x02", reg.monthNamesShort[m - 1]).replace("\x05", am);
-			pattern = pattern.replace("\x03", reg.dayNames[day]).replace("\x04", reg.dayNamesShort[day]);
+			pattern = pattern.replace("\x01", reg.monthNames[ m - 1 ])
+				.replace("\x02", reg.monthNamesShort[ m - 1 ]).replace("\x05", am);
+			pattern = pattern.replace("\x03", reg.dayNames[ day ]).replace("\x04", reg.dayNamesShort[ day ]);
 			pattern = pattern.replace(/\x06/g, "d").replace(/\x07/g, "y").replace(/\x08/g, "M")
 				.replace(/\x09/g, "m").replace(/\x0A/g, "t").replace(/\x0B/g, "s")
 				.replace(/\x0C/g, "f").replace("\x0D", "h").replace("\x0E", "H");
@@ -251,7 +251,7 @@
 				val *= 100;
 			}
 			prefix = cur ? curS : (perc ? percS : "numeric");
-			pattern = reg[prefix + ((val < 0) ? "Negative" : "Positive") + "Pattern"] || "n";
+			pattern = reg[ prefix + ((val < 0) ? "Negative" : "Positive") + "Pattern" ] || "n";
 			len = format ? format.length : 0;
 
 			// calculate maximum number of decimals
@@ -268,11 +268,11 @@
 					}
 				}
 			} else {
-				min = reg[prefix + "MinDecimals"] || 0;
+				min = reg[ prefix + "MinDecimals" ] || 0;
 				if (d) {
 					m = 999;
 				} else {
-					m = reg[prefix + "MaxDecimals"];
+					m = reg[ prefix + "MaxDecimals" ];
 					m = (m && !i) ? m : 0;
 				}
 			}
@@ -324,19 +324,19 @@
 			}
 
 			// replace decimal separator
-			s = reg[prefix + "DecimalSeparator"];
+			s = reg[ prefix + "DecimalSeparator" ];
 			if (s) {
 				val = val.replace(".", s);
 			}
 
 			// insert group separators
-			s = reg[prefix + "GroupSeparator"];
-			grps = s ? reg[prefix + "Groups"] : "";
-			gr = gr0 = (grps.length > 0) ? grps[i = 0] : 0;
+			s = reg[ prefix + "GroupSeparator" ];
+			grps = s ? reg[ prefix + "Groups" ] : "";
+			gr = gr0 = (grps.length > 0) ? grps[ i = 0 ] : 0;
 			while (gr > 0 && --len > 0) {
 				if (--gr === 0) {
 					val = val.substring(0, len) + s + val.substring(len);
-					gr = grps[++i];
+					gr = grps[ ++i ];
 					if (!gr || gr < 1) {
 						gr = gr0;
 					} else {
@@ -346,7 +346,7 @@
 			}
 
 			// replace "n" by number, "$" by symbol and "-" by negative sign
-			s = reg[prefix + "Symbol"] || "";
+			s = reg[ prefix + "Symbol" ] || "";
 			return pattern.replace("-", reg.negativeSign).replace("n", val + e).replace("$", s);
 		}
 		if (format) {
@@ -360,13 +360,13 @@
 		return (val || val === 0) ? val : "&nbsp;";
 	};
 	$.ig._regional = {
-		monthNames: ["January", "February", "March", "April", "May", "June",
-			"July", "August", "September", "October", "November", "December"],
-		monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-		dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday",
-			"Thursday", "Friday", "Saturday"],
-		dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		monthNames: [ "January", "February", "March", "April", "May", "June",
+			"July", "August", "September", "October", "November", "December" ],
+		monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+		dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday",
+			"Thursday", "Friday", "Saturday" ],
+		dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
 		am: "AM",
 		pm: "PM",
 		datePattern: "M/d/yyyy",
@@ -378,7 +378,7 @@
 		numericNegativePattern: "-$n",
 		numericDecimalSeparator: ".",
 		numericGroupSeparator: ",",
-		numericGroups: [3],
+		numericGroups: [ 3 ],
 		numericMaxDecimals: 2,
 		numericMinDecimals: 0,
 		currencyPositivePattern: "$n",
@@ -386,7 +386,7 @@
 		currencySymbol: "$",
 		currencyDecimalSeparator: ".",
 		currencyGroupSeparator: ",",
-		currencyGroups: [3],
+		currencyGroups: [ 3 ],
 		currencyMaxDecimals: 2,
 		currencyMinDecimals: 2,
 		percentPositivePattern: "n$",
@@ -394,7 +394,7 @@
 		percentSymbol: "%",
 		percentDecimalSeparator: ".",
 		percentGroupSeparator: ",",
-		percentGroups: [3],
+		percentGroups: [ 3 ],
 		percentDisplayFactor: 100,
 		percentMaxDecimals: 2,
 		percentMinDecimals: 2
@@ -406,7 +406,7 @@
 			$.ui.igEditor.setDefaultCulture(regional);
 		} else {
 			$.ig.regional.defaults = $.extend($.ig._regional,
-				(typeof regional === "string") ? $.ig.regional[regional] : regional);
+				(typeof regional === "string") ? $.ig.regional[ regional ] : regional);
 		}
 	};
 	$.ig.calcSummaries = function (summaryFunction, data, caller, dataType) {
@@ -414,7 +414,7 @@
 			var sum = 0,
 				i;
 			for (i = 0; i < data.length; i++) {
-				sum += data[i];
+				sum += data[ i ];
 			}
 			return sum;
 		};
@@ -474,7 +474,7 @@
 	$.ig.getMaxZIndex = function (id) {
 		var maxZ = 10000, thisZ;
 		$(".ui-dialog").each(function () {
-			if (!id || $(this)[0].id !== id) {
+			if (!id || $(this)[ 0 ].id !== id) {
 				thisZ = $(this).css("z-index");
 				if (!isNaN(thisZ)) {
 					maxZ = Math.max(maxZ, thisZ);
@@ -516,10 +516,10 @@
 
 		$.ig.util.profiler.recordTime = function (methodName, time) {
 			var key = "meth: " + methodName;
-			if (!methods[key]) {
-				methods[key] = [];
+			if (!methods[ key ]) {
+				methods[ key ] = [];
 			}
-			methods[key][methods[key].length] = time;
+			methods[ key ][ methods[ key ].length ] = time;
 		};
 
 		$.ig.util.profiler.reset = function () {
@@ -537,13 +537,13 @@
 					meth.name = prop.substr(5);
 
 					sum = 0;
-					for (var i = 0; i < methods[prop].length; i++) {
-						sum = sum + methods[prop][i];
+					for (var i = 0; i < methods[ prop ].length; i++) {
+						sum = sum + methods[ prop ][ i ];
 					}
-					avg = sum / methods[prop].length;
+					avg = sum / methods[ prop ].length;
 					meth.avg = avg;
-					meth.callCount = methods[prop].length;
-					meths[j] = meth;
+					meth.callCount = methods[ prop ].length;
+					meths[ j ] = meth;
 					j++;
 				}
 			}
@@ -561,22 +561,22 @@
 			});
 
 			for (var k = 0; k < Math.min(200, meths.length) ; k++) {
-				console.log(meths[k].name + " avg: " + meths[k].avg +
-					" callCount: " + meths[k].callCount);
+				console.log(meths[ k ].name + " avg: " + meths[ k ].avg +
+					" callCount: " + meths[ k ].callCount);
 			}
 		};
 	}(jQuery));
 
 	// N.A. 10/17/2013 - Bug #155039: The property "offset" is deprecated in 1.9.
 	$.ig.util.jQueryUIMainVersion = $.ui && $.ui.version &&
-		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 1)[0], 10) : null;
+		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 1)[ 0 ], 10) : null;
 	$.ig.util.jQueryUISubVersion = $.ui && $.ui.version &&
-		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 2)[1], 10) : null;
+		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 2)[ 1 ], 10) : null;
 
 	$.ig.util.jQueryMainVersion = $.fn.jquery &&
-		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 1)[0], 10) : null;
+		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 1)[ 0 ], 10) : null;
 	$.ig.util.jQuerySubVersion = $.fn.jquery &&
-		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 2)[1], 10) : null;
+		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 2)[ 1 ], 10) : null;
 
 	// Ajdusts jQuery.offset in IE10/IE11/Edge.
 	// jQuery.offset function calculates the coordinates by using element.getBoundingClientRect()
@@ -589,7 +589,7 @@
 	// e: jquery object/element
 	// xy: optional precalculated e.offset or existing position/point with members left/top
 	$.ig.util.offset = function (e, xy) {
-		var doc = e ? e[0].ownerDocument : document,
+		var doc = e ? e[ 0 ].ownerDocument : document,
             windowBorderWidth = 8,
             zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth;
 
@@ -617,9 +617,9 @@
 		var elem = e.parent(), o = { left: 0, top: 0 }, position,
 			 windowBorderWidth = 8,
 			 zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth,
-			 documentScrollLeft, documentScrollTop, doc = e.length > 0 ? e[0].ownerDocument : document;
+			 documentScrollLeft, documentScrollTop, doc = e.length > 0 ? e[ 0 ].ownerDocument : document;
 
-		while (elem[0] !== null && elem[0] !== undefined && elem[0].nodeName !== "#document") {
+		while (elem[ 0 ] !== null && elem[ 0 ] !== undefined && elem[ 0 ].nodeName !== "#document") {
 			position = elem.css("position");
 			/* because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc */
 			if (position !== "static" && position !== "") {
@@ -678,7 +678,7 @@
 				/*jslint bitwise: true */
 				c = ((c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1));
 			}
-			crcTable[n] = c;
+			crcTable[ n ] = c;
 		}
 		return crcTable;
 	};
@@ -690,7 +690,7 @@
 			crc = 0 ^ (-1), i;
 		str = unescape(encodeURIComponent(str));
 		for (i = 0; i < str.length; i++) {
-			crc = (crc >>> 8) ^ crcTable[(crc ^ str.charCodeAt(i)) & 0xFF];
+			crc = (crc >>> 8) ^ crcTable[ (crc ^ str.charCodeAt(i)) & 0xFF ];
 		}
 		return (crc ^ (-1)) >>> 0;
 	};
@@ -699,8 +699,8 @@
 	$.ig.util.getCheckSumForObject = function (obj) {
 		var str = "", key;
 		for (key in obj) {
-			if (obj.hasOwnProperty(key) && typeof obj[key] !== "object"/* only stringify simple properties */) {
-				str += obj[key];
+			if (obj.hasOwnProperty(key) && typeof obj[ key ] !== "object"/* only stringify simple properties */) {
+				str += obj[ key ];
 			}
 		}
 		return $.ig.util.crc32(str);
@@ -711,8 +711,8 @@
 	$.ig.util.invokeCallback = function (callback, args) {
 		if (callback) {
 			if ($.type(callback) === "string" &&
-				window[callback] && $.type(window[callback]) === "function") {
-				callback = window[callback];
+				window[ callback ] && $.type(window[ callback ]) === "function") {
+				callback = window[ callback ];
 			}
 			if ($.type(callback) === "function") {
 				callback.apply(window, args);
@@ -746,7 +746,7 @@
 		// In jquery-ui 1.9.2+ it is used only full name - we fix this breaking change as adding also widgetName(it is used in older versions)
 		(function (createWidget) {
 			$.Widget.prototype._createWidget = function (options, element) {
-				var el = $(element || this.defaultElement || this)[0];
+				var el = $(element || this.defaultElement || this)[ 0 ];
 				if (el !== this) {
 					$.data(el, this.widgetName, this);
 				}
@@ -773,7 +773,7 @@
 	$.ig.util.hasVerticalScroll = function (elem) {
 		var overflow = $(elem).css("overflow-y");
 		return overflow === "scroll" ||
-			overflow === "auto" && elem[0].scrollHeight > elem[0].clientHeight;
+			overflow === "auto" && elem[ 0 ].scrollHeight > elem[ 0 ].clientHeight;
 	};
 
 	// Check if given element has horizontal scrollbar
@@ -781,7 +781,7 @@
 	$.ig.util.hasHorizontalScroll = function (elem) {
 		var overflow = $(elem).css("overflow-x");
 		return overflow === "scroll" ||
-			overflow === "auto" && elem[0].scrollWidth > elem[0].clientWidth;
+			overflow === "auto" && elem[ 0 ].scrollWidth > elem[ 0 ].clientWidth;
 	};
 
 	// Returns the width of the vertical scrollbar
@@ -789,7 +789,7 @@
 		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
 			'top: -10000px; left: -10000px; overflow: scroll"></div>')
 			.appendTo($(document.body)), scrollWidth;
-		scrollWidth = el[0].offsetWidth - el[0].clientWidth;
+		scrollWidth = el[ 0 ].offsetWidth - el[ 0 ].clientWidth;
 		el.remove();
 		return scrollWidth;
 	};
@@ -799,7 +799,7 @@
 		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
 			'top: -10000px; left: -10000px; overflow: scroll"></div>')
 			.appendTo($(document.body)), scrollHeight;
-		scrollHeight = el[0].offsetHeight - el[0].clientHeight;
+		scrollHeight = el[ 0 ].offsetHeight - el[ 0 ].clientHeight;
 		el.remove();
 		return scrollHeight;
 	};
@@ -860,7 +860,6 @@
 	$.ig.util.defType("jQueryDomRenderer", "Object", {
 		init: function () {
 		},
-		
 		$type: new $.ig.Type("jQueryDomRenderer", $.ig.Object.prototype.$type)
 	}, true);
 

--- a/src/js/modules/infragistics.util.jquery.js
+++ b/src/js/modules/infragistics.util.jquery.js
@@ -31,14 +31,14 @@
 	}
 }
 (function ($) {
-	$.ig = window.$ig || $.ig || { _isNamespace: true };
+	$.ig = window.$.ig || $.ig || { _isNamespace: true };
 	window.$ig = window.$ig || $.ig;
 
 	$.fn.startsWith = function (str) {
 		return this[ 0 ].innerHTML.indexOf(str) === 0;
 	};
 
-	$ig.extendNativePrototype(Array.prototype, "clone", function () {
+	$.ig.extendNativePrototype(Array.prototype, "clone", function () {
 		return $.extend(true, [], this);
 	});
 
@@ -120,13 +120,13 @@
 
 	//checkbox markup classes can be changed
 	//and setting them in a a box can be done by the predefined classes "ui-state-default ui-corner-all ui-igcheckbox-small"
-	$ig.checkboxMarkupClasses = "";
+	$.ig.checkboxMarkupClasses = "";
 
-	$ig.formatter = function (val, type, format, notTemplate, enableUTCDates,
+	$.ig.formatter = function (val, type, format, notTemplate, enableUTCDates,
 		displayStyle, labelText, tabIndex) {
 		var min, y, h, m, s, ms, am, e, day, pattern, len, n, dot, gr,
 			gr0, grps, curS, percS, cur, perc, prefix, i, d = val && val.getTime,
-			reg = $ig.regional.defaults, pow,
+			reg = $.ig.regional.defaults, pow,
 
 			// L.A. 17 October 2012 - Fixing bug #123215 The group rows of a grouped checkbox column are too large
 			display = displayStyle || "inline-block";
@@ -134,7 +134,7 @@
 			s = "<span class='ui-igcheckbox-container' style='display:" +
 				display + ";' role='checkbox' aria-disabled='true' aria-checked='" +
 				val + "' aria-label='" + labelText + "' tabindex='" + tabIndex + "'>";
-			s += "<span class='" + $ig.checkboxMarkupClasses + "' style='display:inline-block'>";
+			s += "<span class='" + $.ig.checkboxMarkupClasses + "' style='display:inline-block'>";
 			s += "<span style='display:block' class='" + (val ? "" : "ui-igcheckbox-small-off ");
 			return s + "ui-icon ui-icon-check ui-igcheckbox-small-on'></span></span></span>";
 		}
@@ -170,7 +170,7 @@
 				day = val.getDay();
 			}
 
-			// M.P. 25 July 2014: 176543 - $ig.formatter doesn't work with escaped characters for date formatting
+			// M.P. 25 July 2014: 176543 - $.ig.formatter doesn't work with escaped characters for date formatting
 			pattern = pattern.replace(/\\d/g, "\x06").replace(/\\y/g, "\x07").replace(/\\M/g, "\x08")
 				.replace(/\\m/g, "\x09").replace(/\\t/g, "\x0A").replace(/\\s/g, "\x0B")
 				.replace(/\\f/g, "\x0C").replace(/\\h/g, "\x0D").replace(/\\H/g, "\x0E");
@@ -285,7 +285,7 @@
 			if (m === 999) {
 				val = val.toString(10);
 			} else {
-				if ($ig.util.isIE && $ig.util.browserVersion <= 8) {
+				if ($.ig.util.isIE && $.ig.util.browserVersion <= 8) {
 					pow = Math.pow(10, m);
 					val = (Math.round(pow * val) / pow).toFixed(m);
 				} else {
@@ -358,7 +358,7 @@
 		}
 		return (val || val === 0) ? val : "&nbsp;";
 	};
-	$ig._regional = {
+	$.ig._regional = {
 		monthNames: ["January", "February", "March", "April", "May", "June",
 			"July", "August", "September", "October", "November", "December"],
 		monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -398,17 +398,17 @@
 		percentMaxDecimals: 2,
 		percentMinDecimals: 2
 	};
-	$ig.regional = $ig.regional || {};
-	$ig.regional.defaults = $ig._regional;
-	$ig.setRegionalDefault = function (regional) {
+	$.ig.regional = $.ig.regional || {};
+	$.ig.regional.defaults = $.ig._regional;
+	$.ig.setRegionalDefault = function (regional) {
 		if ($.ui && $.ui.igEditor) {
 			$.ui.igEditor.setDefaultCulture(regional);
 		} else {
-			$ig.regional.defaults = $.extend($ig._regional,
-				(typeof regional === "string") ? $ig.regional[regional] : regional);
+			$.ig.regional.defaults = $.extend($.ig._regional,
+				(typeof regional === "string") ? $.ig.regional[regional] : regional);
 		}
 	};
-	$ig.calcSummaries = function (summaryFunction, data, caller, dataType) {
+	$.ig.calcSummaries = function (summaryFunction, data, caller, dataType) {
 		var sum = function (data) {
 			var sum = 0,
 				i;
@@ -470,7 +470,7 @@
 	};
 
 	// get max zIndex of ui-dialogs - method is usually called by feautures for configuring zIndex of modal dialogs(like filtering, feature chooser, hiding, etc.)
-	$ig.getMaxZIndex = function (id) {
+	$.ig.getMaxZIndex = function (id) {
 		var maxZ = 10000, thisZ;
 		$(".ui-dialog").each(function () {
 			if (!id || $(this)[0].id !== id) {
@@ -484,11 +484,11 @@
 	};
 
 	// generate unique identifiers
-	$ig.uid = function () {
+	$.ig.uid = function () {
 		return ((1 + Math.random()) * parseInt("10000", 16)).toString(16).substring(1, 5);
 	};
 
-	$ig.getColType = function (o) {
+	$.ig.getColType = function (o) {
 		var t = typeof o;
 		if (t === "undefined") {
 			return "string";
@@ -509,11 +509,11 @@
 
 	(function ($) {
 
-		$ig.util.profiler = {};
+		$.ig.util.profiler = {};
 
 		var methods = {};
 
-		$ig.util.profiler.recordTime = function (methodName, time) {
+		$.ig.util.profiler.recordTime = function (methodName, time) {
 			var key = "meth: " + methodName;
 			if (!methods[key]) {
 				methods[key] = [];
@@ -521,11 +521,11 @@
 			methods[key][methods[key].length] = time;
 		};
 
-		$ig.util.profiler.reset = function () {
+		$.ig.util.profiler.reset = function () {
 			methods = {};
 		};
 
-		$ig.util.profiler.logReport = function () {
+		$.ig.util.profiler.logReport = function () {
 			var meths = [];
 			var j = 0;
 			var sum = 0;
@@ -567,14 +567,14 @@
 	}(jQuery));
 
 	// N.A. 10/17/2013 - Bug #155039: The property "offset" is deprecated in 1.9.
-	$ig.util.jQueryUIMainVersion = $.ui && $.ui.version &&
+	$.ig.util.jQueryUIMainVersion = $.ui && $.ui.version &&
 		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 1)[0], 10) : null;
-	$ig.util.jQueryUISubVersion = $.ui && $.ui.version &&
+	$.ig.util.jQueryUISubVersion = $.ui && $.ui.version &&
 		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 2)[1], 10) : null;
 
-	$ig.util.jQueryMainVersion = $.fn.jquery &&
+	$.ig.util.jQueryMainVersion = $.fn.jquery &&
 		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 1)[0], 10) : null;
-	$ig.util.jQuerySubVersion = $.fn.jquery &&
+	$.ig.util.jQuerySubVersion = $.fn.jquery &&
 		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 2)[1], 10) : null;
 
 	// Ajdusts jQuery.offset in IE10/IE11/Edge.
@@ -587,18 +587,18 @@
 	// zooming in/out the page.
 	// e: jquery object/element
 	// xy: optional precalculated e.offset or existing position/point with members left/top
-	$ig.util.offset = function (e, xy) {
+	$.ig.util.offset = function (e, xy) {
 		var doc = e ? e[0].ownerDocument : document,
             windowBorderWidth = 8,
             zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth;
 
 		xy = xy || e.offset();
 
-		if (zoom && zoom > 1 && ($ig.util.isIE10 || $ig.util.isIE11 || $ig.util.isEdge)) {
-			if ($ig.util.isIE) {
+		if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {
+			if ($.ig.util.isIE) {
 				xy.documentScrollLeft = doc.documentElement.scrollLeft;
 				xy.documentScrollTop = doc.documentElement.scrollTop;
-			} else if ($ig.util.isEdge) {
+			} else if ($.ig.util.isEdge) {
 				xy.documentScrollLeft = doc.body.scrollLeft;
 				xy.documentScrollTop = doc.body.scrollTop;
 			}
@@ -612,7 +612,7 @@
 
 	// Get relative offset of the passed element according to the closest parent element with relative position if any
 	// e: jquery element
-	$ig.util.getRelativeOffset = function (e) {
+	$.ig.util.getRelativeOffset = function (e) {
 		var elem = e.parent(), o = { left: 0, top: 0 }, position,
 			 windowBorderWidth = 8,
 			 zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth,
@@ -622,11 +622,11 @@
 			position = elem.css("position");
 			/* because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc */
 			if (position !== "static" && position !== "") {
-				if (zoom && zoom > 1 && ($ig.util.isIE10 || $ig.util.isIE11 || $ig.util.isEdge)) {
-					if ($ig.util.isIE) {
+				if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {
+					if ($.ig.util.isIE) {
 						documentScrollLeft = doc.documentElement.scrollLeft;
 						documentScrollTop = doc.documentElement.scrollTop;
-					} else if ($ig.util.isEdge) {
+					} else if ($.ig.util.isEdge) {
 						documentScrollLeft = doc.body.scrollLeft;
 						documentScrollTop = doc.body.scrollTop;
 					}
@@ -669,7 +669,7 @@
 	};
 
 	// creates crc32 table
-	$ig.util.makeCRCTable = function () {
+	$.ig.util.makeCRCTable = function () {
 		var c, n, k, crcTable = [];
 		for (n = 0; n < 256; n++) {
 			c = n;
@@ -683,9 +683,9 @@
 	};
 
 	// returns crc32 checksum for the input string
-	$ig.util.crc32 = function (str) {
+	$.ig.util.crc32 = function (str) {
 		/*jslint bitwise: true */
-		var crcTable = $ig.util.crcTable || ($ig.util.crcTable = $ig.util.makeCRCTable()),
+		var crcTable = $.ig.util.crcTable || ($.ig.util.crcTable = $.ig.util.makeCRCTable()),
 			crc = 0 ^ (-1), i;
 		str = unescape(encodeURIComponent(str));
 		for (i = 0; i < str.length; i++) {
@@ -695,19 +695,19 @@
 	};
 
 	// returns checksum based on the string representations of an object's property values
-	$ig.util.getCheckSumForObject = function (obj) {
+	$.ig.util.getCheckSumForObject = function (obj) {
 		var str = "", key;
 		for (key in obj) {
 			if (obj.hasOwnProperty(key) && typeof obj[key] !== "object"/* only stringify simple properties */) {
 				str += obj[key];
 			}
 		}
-		return $ig.util.crc32(str);
+		return $.ig.util.crc32(str);
 	};
 
 	/* jshint +W016*/
 
-	$ig.util.invokeCallback = function (callback, args) {
+	$.ig.util.invokeCallback = function (callback, args) {
 		if (callback) {
 			if ($.type(callback) === "string" &&
 				window[callback] && $.type(window[callback]) === "function") {
@@ -719,13 +719,13 @@
 		}
 	};
 
-	$ig.util.IMEtoENNumbersMapping = function () {
+	$.ig.util.IMEtoENNumbersMapping = function () {
 		return {
 			"１": "1", "２": "2", "３": "3", "４": "4", "５": "5",
 			"６": "6", "７": "7", "８": "8", "９": "9", "０": "0"
 		};
 	};
-	$ig.util.IMEtoNumberString = function (stringValue, mapping) {
+	$.ig.util.IMEtoNumberString = function (stringValue, mapping) {
 		if (mapping === undefined) {
 			return stringValue;
 		}
@@ -769,7 +769,7 @@
 
 	// Check if given element has vertical scrollbar
 	// elem - jQuery object
-	$ig.util.hasVerticalScroll = function (elem) {
+	$.ig.util.hasVerticalScroll = function (elem) {
 		var overflow = $(elem).css("overflow-y");
 		return overflow === "scroll" ||
 			overflow === "auto" && elem[0].scrollHeight > elem[0].clientHeight;
@@ -777,14 +777,14 @@
 
 	// Check if given element has horizontal scrollbar
 	// elem - jQuery object
-	$ig.util.hasHorizontalScroll = function (elem) {
+	$.ig.util.hasHorizontalScroll = function (elem) {
 		var overflow = $(elem).css("overflow-x");
 		return overflow === "scroll" ||
 			overflow === "auto" && elem[0].scrollWidth > elem[0].clientWidth;
 	};
 
 	// Returns the width of the vertical scrollbar
-	$ig.util.getScrollWidth = function () {
+	$.ig.util.getScrollWidth = function () {
 		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
 			'top: -10000px; left: -10000px; overflow: scroll"></div>')
 			.appendTo($(document.body)), scrollWidth;
@@ -794,7 +794,7 @@
 	};
 
 	// Returns the height of the horizontal scrollbar
-	$ig.util.getScrollHeight = function () {
+	$.ig.util.getScrollHeight = function () {
 		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
 			'top: -10000px; left: -10000px; overflow: scroll"></div>')
 			.appendTo($(document.body)), scrollHeight;
@@ -803,24 +803,24 @@
 		return scrollHeight;
 	};
 
-	$ig.util._renderUnsupportedBrowser = function (widget, locale) {
+	$.ig.util._renderUnsupportedBrowser = function (widget, locale) {
 		if (!widget.events || !widget.events.browserNotSupported ||
 			widget._trigger(widget.events.browserNotSupported)) {
 			var elem = widget.element, o = widget.options,
 				container = $("<div></div>").css("overflow", "auto")
 					.addClass(widget.css.unsupportedBrowserClass).appendTo(elem),
 				ul, browserUnsupported;
-			locale = locale || $ig.util.locale;
-			if ($ig.util.isIE) {
-				browserUnsupported = "Internet Explorer " + $ig.util.browserVersion;
-			} else if ($ig.util.isOpera) {
-				browserUnsupported = "Opera " + $ig.util.browserVersion;
-			} else if ($ig.util.isWebKit) {
-				browserUnsupported = "Webkit " + $ig.util.browserVersion;
-			} else if ($ig.util.isFF) {
-				browserUnsupported = "Mozilla Firefox " + $ig.util.browserVersion;
+			locale = locale || $.ig.util.locale;
+			if ($.ig.util.isIE) {
+				browserUnsupported = "Internet Explorer " + $.ig.util.browserVersion;
+			} else if ($.ig.util.isOpera) {
+				browserUnsupported = "Opera " + $.ig.util.browserVersion;
+			} else if ($.ig.util.isWebKit) {
+				browserUnsupported = "Webkit " + $.ig.util.browserVersion;
+			} else if ($.ig.util.isFF) {
+				browserUnsupported = "Mozilla Firefox " + $.ig.util.browserVersion;
 			} else {
-				browserUnsupported = $ig.util.browserVersion;
+				browserUnsupported = $.ig.util.browserVersion;
 			}
 
 			$("<div></div>").addClass("ui-html5-current-browser-label")
@@ -856,11 +856,11 @@
 		}
 	};
 
-	$ig.util.defType("jQueryDomRenderer", "Object", {
+	$.ig.util.defType("jQueryDomRenderer", "Object", {
 		init: function () {
 		},
 		
-		$type: new $ig.Type("jQueryDomRenderer", $ig.Object.prototype.$type)
+		$type: new $.ig.Type("jQueryDomRenderer", $.ig.Object.prototype.$type)
 	}, true);
 
 }));

--- a/src/js/modules/infragistics.util.jquerydeferred.js
+++ b/src/js/modules/infragistics.util.jquerydeferred.js
@@ -13,7 +13,7 @@
  * modernizr.js (Optional)
  * infragistics.util.js
  * infragistics.util.jquery.js
- * 
+ *
  */
 /*global xyz, Class, ActiveXObject, Modernizr, VBArray, Intl, XDomainRequest, unescape*/ /*jshint -W106*/ /*jshint -W116*/ /*jshint unused:false*/
 (function (factory) {
@@ -44,11 +44,11 @@
 
 	// Convert String-formatted flags into Object-formatted ones and store in cache
 	$.ig.util.jqueryCreateFlags = function (flags) {
-		var object = $.ig.util.jqueryFlagsCache[flags] = {},
+		var object = $.ig.util.jqueryFlagsCache[ flags ] = {},
 				i, length;
 		flags = flags.split(/\s+/);
 		for (i = 0, length = flags.length; i < length; i++) {
-			object[flags[i]] = true;
+			object[ flags[ i ] ] = true;
 		}
 		return object;
 	};
@@ -79,7 +79,7 @@
 
 		// Convert flags from String-formatted to Object-formatted
 		// (we check in cache first)
-		flags = flags ? ($.ig.util.jqueryFlagsCache[flags] ||
+		flags = flags ? ($.ig.util.jqueryFlagsCache[ flags ] ||
 			$.ig.util.jqueryCreateFlags(flags)) : {};
 
 		var // Actual Callbacks object
@@ -116,7 +116,7 @@
 					elem,
 					type;
 				for (i = 0, length = args.length; i < length; i++) {
-					elem = args[i];
+					elem = args[ i ];
 					type = jQuery.type(elem);
 					if (type === "array") {
 
@@ -135,14 +135,14 @@
 			// Fire callbacks
 			fire = function (context, args) {
 				args = args || [];
-				memory = !flags.memory || [context, args];
+				memory = !flags.memory || [ context, args ];
 				fired = true;
 				firing = true;
 				firingIndex = firingStart || 0;
 				firingStart = 0;
 				firingLength = list.length;
 				for (; list && firingIndex < firingLength; firingIndex++) {
-					if (list[firingIndex].apply(context, args) === false && flags.stopOnFalse) {
+					if (list[ firingIndex ].apply(context, args) === false && flags.stopOnFalse) {
 						memory = true; // Mark as halted
 						break;
 					}
@@ -152,7 +152,7 @@
 					if (!flags.once) {
 						if (stack && stack.length) {
 							memory = stack.shift();
-							self.fireWith(memory[0], memory[1]);
+							self.fireWith(memory[ 0 ], memory[ 1 ]);
 						}
 					} else if (memory === true) {
 						self.disable();
@@ -180,7 +180,7 @@
 						// firing was halted (stopOnFalse)
 					} else if (memory && memory !== true) {
 						firingStart = length;
-						fire(memory[0], memory[1]);
+						fire(memory[ 0 ], memory[ 1 ]);
 					}
 				}
 				return this;
@@ -194,7 +194,7 @@
 						argLength = args.length;
 					for (; argIndex < argLength ; argIndex++) {
 						for (var i = 0; i < list.length; i++) {
-							if (args[argIndex] === list[i]) {
+							if (args[ argIndex ] === list[ i ]) {
 
 								// Handle firingIndex and firingLength
 								if (firing) {
@@ -227,7 +227,7 @@
 					var i = 0,
 						length = list.length;
 					for (; i < length; i++) {
-						if (fn === list[i]) {
+						if (fn === list[ i ]) {
 							return true;
 						}
 					}
@@ -271,7 +271,7 @@
 				if (stack) {
 					if (firing) {
 						if (!flags.once) {
-							stack.push([context, args]);
+							stack.push([ context, args ]);
 						}
 					} else if (!(flags.once && memory)) {
 						fire(context, args);
@@ -330,24 +330,24 @@
 				pipe: function (fnDone, fnFail, fnProgress) {
 					return $.ig.util.jqueryDeferred(function (newDefer) {
 						jQuery.each({
-							done: [fnDone, "resolve"],
-							fail: [fnFail, "reject"],
-							progress: [fnProgress, "notify"]
+							done: [ fnDone, "resolve" ],
+							fail: [ fnFail, "reject" ],
+							progress: [ fnProgress, "notify" ]
 						}, function (handler, data) {
-							var fn = data[0],
-								action = data[1],
+							var fn = data[ 0 ],
+								action = data[ 1 ],
 								returned;
 							if (jQuery.isFunction(fn)) {
-								deferred[handler](function () {
+								deferred[ handler ](function () {
 									returned = fn.apply(this, arguments);
 									if (returned && jQuery.isFunction(returned.promise)) {
 										returned.promise().then(newDefer.resolve, newDefer.reject, newDefer.notify);
 									} else {
-										newDefer[action + "With"](this === deferred ? newDefer : this, [returned]);
+										newDefer[ action + "With" ](this === deferred ? newDefer : this, [ returned ]);
 									}
 								});
 							} else {
-								deferred[handler](newDefer[action]);
+								deferred[ handler ](newDefer[ action ]);
 							}
 						});
 					}).promise();
@@ -360,7 +360,7 @@
 						obj = promise;
 					} else {
 						for (var key in promise) {
-							obj[key] = promise[key];
+							obj[ key ] = promise[ key ];
 						}
 					}
 					return obj;
@@ -371,8 +371,8 @@
 		deferred = promise.promise({});
 
 		for (key in lists) {
-			deferred[key] = lists[key].fire;
-			deferred[key + "With"] = lists[key].fireWith;
+			deferred[ key ] = lists[ key ].fire;
+			deferred[ key + "With" ] = lists[ key ].fireWith;
 		}
 
 		// Handle state

--- a/src/js/modules/infragistics.util.jquerydeferred.js
+++ b/src/js/modules/infragistics.util.jquerydeferred.js
@@ -15,7 +15,7 @@
  * infragistics.util.jquery.js
  * 
  */
-
+/*global xyz, Class, ActiveXObject, Modernizr, VBArray, Intl, XDomainRequest, unescape*/ /*jshint -W106*/ /*jshint -W116*/ /*jshint unused:false*/
 (function (factory) {
 	if (typeof define === "function" && define.amd) {
 

--- a/src/js/modules/infragistics.util.jquerydeferred.js
+++ b/src/js/modules/infragistics.util.jquerydeferred.js
@@ -1,0 +1,534 @@
+/*!@license
+ * Infragistics.Web.ClientUI Util functions <build_number>
+ *
+ * Copyright (c) 2011-<year> Infragistics Inc.
+ *
+ * util functions that extend the jQuery  namespace
+ * if something is not already available in jQuery, please add it here.
+ *
+ * http://www.infragistics.com/
+ *
+ * Depends on:
+ * jquery-1.9.1.js
+ * modernizr.js (Optional)
+ * infragistics.util.js
+ * infragistics.util.jquery.js
+ * 
+ */
+
+(function (factory) {
+	if (typeof define === "function" && define.amd) {
+
+		// AMD. Register as an anonymous module.
+		define( [
+			"jquery",
+			"jquery-ui",
+            "./infragistics.util",
+            "./infragistics.util.jquery"
+		], factory );
+	} else {
+
+		// Browser globals
+		factory(jQuery);
+	}
+}
+(function ($) {
+	$.ig = $.ig || { _isNamespace: true };
+	window.$ig = window.$ig || $.ig;
+
+	//A CommonJS Promises/A implementation that will be used with jquery versions prior to 1.5
+	//that do not have a $.Deferred implementation
+
+	// String to Object flags format cache
+	$.ig.util.jqueryFlagsCache = {};
+
+	// Convert String-formatted flags into Object-formatted ones and store in cache
+	$.ig.util.jqueryCreateFlags = function (flags) {
+		var object = $.ig.util.jqueryFlagsCache[flags] = {},
+				i, length;
+		flags = flags.split(/\s+/);
+		for (i = 0, length = flags.length; i < length; i++) {
+			object[flags[i]] = true;
+		}
+		return object;
+	};
+
+	/*
+	 * Create a callback list using the following parameters:
+	 *
+	 *	flags:	an optional list of space-separated flags that will change how
+	 *			the callback list behaves
+	 *
+	 * By default a callback list will act like an event callback list and can be
+	 * "fired" multiple times.
+	 *
+	 * Possible flags:
+	 *
+	 *	once:			will ensure the callback list can only be fired once (like a Deferred)
+	 *
+	 *	memory:			will keep track of previous values and will call any callback added
+	 *					after the list has been fired right away with the latest "memorized"
+	 *					values (like a Deferred)
+	 *
+	 *	unique:			will ensure a callback can only be added once (no duplicate in the list)
+	 *
+	 *	stopOnFalse:	interrupt callings when a callback returns false
+	 *
+	 */
+	$.ig.util.jqueryCallbacks = function (flags) {
+
+		// Convert flags from String-formatted to Object-formatted
+		// (we check in cache first)
+		flags = flags ? ($.ig.util.jqueryFlagsCache[flags] ||
+			$.ig.util.jqueryCreateFlags(flags)) : {};
+
+		var // Actual Callbacks object
+			self,
+
+			// Actual callback list
+			list = [],
+
+			// Stack of fire calls for repeatable lists
+			stack = [],
+
+			// Last fire value (for non-forgettable lists)
+			memory,
+
+			// Flag to know if list was already fired
+			fired,
+
+			// Flag to know if list is currently firing
+			firing,
+
+			// First callback to fire (used internally by add and fireWith)
+			firingStart,
+
+			// End of the loop when firing
+			firingLength,
+
+			// Index of currently firing callback (modified by remove if needed)
+			firingIndex,
+
+			// Add one or several callbacks to the list
+			add = function (args) {
+				var i,
+					length,
+					elem,
+					type,
+					actual;
+				for (i = 0, length = args.length; i < length; i++) {
+					elem = args[i];
+					type = jQuery.type(elem);
+					if (type === "array") {
+
+						// Inspect recursively
+						add(elem);
+					} else if (type === "function") {
+
+						// Add if not in unique mode and callback is not in
+						if (!flags.unique || !self.has(elem)) {
+							list.push(elem);
+						}
+					}
+				}
+			},
+
+			// Fire callbacks
+			fire = function (context, args) {
+				args = args || [];
+				memory = !flags.memory || [context, args];
+				fired = true;
+				firing = true;
+				firingIndex = firingStart || 0;
+				firingStart = 0;
+				firingLength = list.length;
+				for (; list && firingIndex < firingLength; firingIndex++) {
+					if (list[firingIndex].apply(context, args) === false && flags.stopOnFalse) {
+						memory = true; // Mark as halted
+						break;
+					}
+				}
+				firing = false;
+				if (list) {
+					if (!flags.once) {
+						if (stack && stack.length) {
+							memory = stack.shift();
+							self.fireWith(memory[0], memory[1]);
+						}
+					} else if (memory === true) {
+						self.disable();
+					} else {
+						list = [];
+					}
+				}
+			};
+
+		// Actual Callbacks object
+		self = {
+			// Add a callback or a collection of callbacks to the list
+			add: function () {
+				if (list) {
+					var length = list.length;
+					add(arguments);
+
+					// Do we need to add the callbacks to the
+					// current firing batch?
+					if (firing) {
+						firingLength = list.length;
+
+						// With memory, if we're not firing then
+						// we should call right away, unless previous
+						// firing was halted (stopOnFalse)
+					} else if (memory && memory !== true) {
+						firingStart = length;
+						fire(memory[0], memory[1]);
+					}
+				}
+				return this;
+			},
+
+			// Remove a callback from the list
+			remove: function () {
+				if (list) {
+					var args = arguments,
+						argIndex = 0,
+						argLength = args.length;
+					for (; argIndex < argLength ; argIndex++) {
+						for (var i = 0; i < list.length; i++) {
+							if (args[argIndex] === list[i]) {
+
+								// Handle firingIndex and firingLength
+								if (firing) {
+									if (i <= firingLength) {
+										firingLength--;
+										if (i <= firingIndex) {
+											firingIndex--;
+										}
+									}
+								}
+
+								// Remove the element
+								list.splice(i--, 1);
+
+								// If we have some unicity property then
+								// we only need to do this once
+								if (flags.unique) {
+									break;
+								}
+							}
+						}
+					}
+				}
+				return this;
+			},
+
+			// Control if a given callback is in the list
+			has: function (fn) {
+				if (list) {
+					var i = 0,
+						length = list.length;
+					for (; i < length; i++) {
+						if (fn === list[i]) {
+							return true;
+						}
+					}
+				}
+				return false;
+			},
+
+			// Remove all callbacks from the list
+			empty: function () {
+				list = [];
+				return this;
+			},
+
+			// Have the list do nothing anymore
+			disable: function () {
+				list = stack = memory = undefined;
+				return this;
+			},
+
+			// Is it disabled?
+			disabled: function () {
+				return !list;
+			},
+
+			// Lock the list in its current state
+			lock: function () {
+				stack = undefined;
+				if (!memory || memory === true) {
+					self.disable();
+				}
+				return this;
+			},
+
+			// Is it locked?
+			locked: function () {
+				return !stack;
+			},
+
+			// Call all callbacks with the given context and arguments
+			fireWith: function (context, args) {
+				if (stack) {
+					if (firing) {
+						if (!flags.once) {
+							stack.push([context, args]);
+						}
+					} else if (!(flags.once && memory)) {
+						fire(context, args);
+					}
+				}
+				return this;
+			},
+
+			// Call all the callbacks with the given arguments
+			fire: function () {
+				self.fireWith(this, arguments);
+				return this;
+			},
+
+			// To know if the callbacks have already been called at least once
+			fired: function () {
+				return !!fired;
+			}
+		};
+
+		return self;
+	};
+
+	$.ig.util.jqueryDeferred = function (func) {
+		var deferred,
+			doneList = $.ig.util.jqueryCallbacks("once memory"),
+			failList = $.ig.util.jqueryCallbacks("once memory"),
+			progressList = $.ig.util.jqueryCallbacks("memory"),
+			state = "pending",
+			lists = {
+				resolve: doneList,
+				reject: failList,
+				notify: progressList
+			},
+			promise = {
+				done: doneList.add,
+				fail: failList.add,
+				progress: progressList.add,
+
+				state: function () {
+					return state;
+				},
+
+				// Deprecated
+				isResolved: doneList.fired,
+				isRejected: failList.fired,
+
+				then: function (doneCallbacks, failCallbacks, progressCallbacks) {
+					deferred.done(doneCallbacks).fail(failCallbacks).progress(progressCallbacks);
+					return this;
+				},
+				always: function () {
+					deferred.done.apply(deferred, arguments).fail.apply(deferred, arguments);
+					return this;
+				},
+				pipe: function (fnDone, fnFail, fnProgress) {
+					return $.ig.util.jqueryDeferred(function (newDefer) {
+						jQuery.each({
+							done: [fnDone, "resolve"],
+							fail: [fnFail, "reject"],
+							progress: [fnProgress, "notify"]
+						}, function (handler, data) {
+							var fn = data[0],
+								action = data[1],
+								returned;
+							if (jQuery.isFunction(fn)) {
+								deferred[handler](function () {
+									returned = fn.apply(this, arguments);
+									if (returned && jQuery.isFunction(returned.promise)) {
+										returned.promise().then(newDefer.resolve, newDefer.reject, newDefer.notify);
+									} else {
+										newDefer[action + "With"](this === deferred ? newDefer : this, [returned]);
+									}
+								});
+							} else {
+								deferred[handler](newDefer[action]);
+							}
+						});
+					}).promise();
+				},
+
+				// Get a promise for this deferred
+				// If obj is provided, the promise aspect is added to the object
+				promise: function (obj) {
+					if (obj === undefined || obj === null) {
+						obj = promise;
+					} else {
+						for (var key in promise) {
+							obj[key] = promise[key];
+						}
+					}
+					return obj;
+				}
+			},
+			key;
+
+		deferred = promise.promise({});
+
+		for (key in lists) {
+			deferred[key] = lists[key].fire;
+			deferred[key + "With"] = lists[key].fireWith;
+		}
+
+		// Handle state
+		deferred.done(function () {
+			state = "resolved";
+		}, failList.disable, progressList.lock).fail(function () {
+			state = "rejected";
+		}, doneList.disable, progressList.lock);
+
+		// Call given func if any
+		if (func) {
+			func.call(deferred, deferred);
+		}
+
+		// All done!
+		return deferred;
+	};
+
+	// PA 7/8/2013 - fix for jQuery versions in the interval (1.4.4, 1.7.0) where $.Deferred is defined, but has some missing members that we need
+	$.ig.util.checkDeferred = function () {
+		$.ig.util.deferredDefined = !!($.Deferred !== undefined && $.Deferred().state);
+	};
+
+	$.ig.util.deferred = function () {
+		if ($.ig.util.deferredDefined === undefined) {
+			$.ig.util.checkDeferred();
+		}
+
+		if ($.ig.util.deferredDefined) {
+			return $.Deferred();
+		} else {
+			return $.ig.util.jqueryDeferred();
+		}
+	};
+
+	$.ig.util.ajax = function (url, contentType, data, method, requestOptions) {
+		//return $.ig.util.corsRequest(url, contentType, data, method, requestOptions);
+
+		var deferred = $.ig.util.deferred();
+		var isCrossDomain;
+		if (requestOptions && "isCrossDomain" in requestOptions) {
+			isCrossDomain = requestOptions.isCrossDomain;
+		} else {
+			isCrossDomain = $.support.cors;
+		}
+
+		var xhrObj = (function (rOptions) {
+			var xhr = new XMLHttpRequest();
+
+			// do not use XDomainRequest for IE8/IE9 if the user has specifed withCredentials in request options
+			// which is interpreted as XmlHttpRequest to be used against trusted domain
+			// since XDomainRequest does not support withCredentials
+			if (isCrossDomain &&
+				!(("withCredentials" in xhr) ||
+				(rOptions && "withCredentials" in rOptions && rOptions.withCredentials)) &&
+					typeof XDomainRequest != "undefined") {
+
+				// handle IE8/IE9 with anonymous authentication
+				xhr = new XDomainRequest();
+
+				// fix for jQuery.ajax() callback is expecting some methods and props are defined
+				// PP 12/05/2012 jQuery 1.4.4 fix
+				xhr.getResponseHeader = function () {
+					return null;
+				};
+
+				// M.S. July 24st, 2013 Bug #145199 Fixed the data loading from XMLA, when using jQuery 2.0.0 in IE9
+				xhr.setRequestHeader = function () {
+					xhr.status = 200;
+				};
+
+				xhr.getAllResponseHeaders = function () {
+					return null;
+				};
+
+				xhr.onload = function () {
+					xhr.readyState = 4;
+					xhr.status = 200;
+					xhr.statusText = "success";
+					xhr.getAllResponseHeaders = function () {
+					};
+					xhr.onreadystatechange();
+				};
+
+				xhr.onerror = function () {
+					xhr.readyState = 4;
+					xhr.status = 0;
+					xhr.statusText = "error";
+					xhr.getAllResponseHeaders = function () {
+					};
+					xhr.onreadystatechange();
+				};
+
+				xhr.ontimeout = function () {
+					xhr.readyState = 4;
+					xhr.status = 0;
+					xhr.statusText = "timeout";
+					xhr.getAllResponseHeaders = function () {
+					};
+					xhr.onreadystatechange();
+				};
+
+				// keep this callback because otherwise XDomainRequest is aborted
+				// it's a bug in XDomainRequest
+				xhr.onprogress = function () {
+				};
+			}
+
+			return xhr;
+		})(requestOptions);
+
+		var xhrFields;
+
+		// when credentials are specified that will work with Chrome/FireFox/IE10
+		if ("withCredentials" in xhrObj &&
+			requestOptions && "withCredentials" in requestOptions &&
+		requestOptions.withCredentials) {
+
+			xhrFields = {
+				withCredentials: true
+			};
+		}
+
+		var beforeSend = function (jqXHR, options) {
+			if (requestOptions) {
+
+				if ($.isFunction(requestOptions.beforeSend)) {
+					jqXHR.setRequestHeader("Content-Type", contentType);
+					requestOptions.beforeSend.call(this, jqXHR, options, requestOptions);
+				}
+			}
+		};
+
+		$.ajax({
+			crossDomain: (isCrossDomain ? true : false),
+			isLocal: false,
+			url: url,
+			contentType: contentType,
+			data: data,
+			type: method,
+			dataType: "text",
+			xhrFields: xhrFields,
+			beforeSend: beforeSend,
+			xhr: function () {
+				return xhrObj;
+			},
+			success: function (responce, textStatus, jqXHR) {
+				deferred.resolve(responce);
+			},
+			error: function (jqXHR, textStatus, errorThrown) {
+				deferred.reject(errorThrown);
+			}
+		});
+
+		return deferred.promise();
+	};
+
+}));

--- a/src/js/modules/infragistics.util.jquerydeferred.js
+++ b/src/js/modules/infragistics.util.jquerydeferred.js
@@ -114,8 +114,7 @@
 				var i,
 					length,
 					elem,
-					type,
-					actual;
+					type;
 				for (i = 0, length = args.length; i < length; i++) {
 					elem = args[i];
 					type = jQuery.type(elem);
@@ -429,7 +428,7 @@
 			if (isCrossDomain &&
 				!(("withCredentials" in xhr) ||
 				(rOptions && "withCredentials" in rOptions && rOptions.withCredentials)) &&
-					typeof XDomainRequest != "undefined") {
+					typeof XDomainRequest !== undefined) {
 
 				// handle IE8/IE9 with anonymous authentication
 				xhr = new XDomainRequest();
@@ -520,7 +519,7 @@
 			xhr: function () {
 				return xhrObj;
 			},
-			success: function (responce, textStatus, jqXHR) {
+			success: function (responce) {
 				deferred.resolve(responce);
 			},
 			error: function (jqXHR, textStatus, errorThrown) {

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -18,7 +18,7 @@
 */
 
 // Inspired by base2 and Prototype
-/*global xyz, Class, ActiveXObject, Modernizr, VBArray, Intl, XDomainRequest, unescape*/ /*jshint -W106*/ /*jshint -W116*/ /*jshint unused:false*/
+/*global xyz, Class, ActiveXObject, Modernizr, VBArray, Intl, XDomainRequest, unescape, igRoot*/ /*jshint -W106*/ /*jshint -W116*/ /*jshint unused:false*/
 (function (factory) {
 	if (typeof define === "function" && define.amd) {
 

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -18,6 +18,7 @@
 */
 
 // Inspired by base2 and Prototype
+
 /*global xyz, Class, ActiveXObject, Modernizr, VBArray, Intl, XDomainRequest, unescape, igRoot*/ /*jshint -W106*/ /*jshint -W116*/ /*jshint unused:false*/
 (function (factory) {
 	if (typeof define === "function" && define.amd) {
@@ -36,6 +37,7 @@
 	if (window.jQuery !== undefined) {
 		window.igRoot = jQuery;
 	}
+
 	//window.$ = window.$ || window.igRoot;
 
 	window.igRoot.ig = window.igRoot.ig || { _isNamespace: true };
@@ -47,7 +49,7 @@
 
 	if (!Array.isArray) {
 		Array.isArray = function (arg) {
-			return Object.prototype.toString.call(arg) === '[object Array]';
+			return Object.prototype.toString.call(arg) === "[object Array]";
 		};
 	}
 
@@ -327,7 +329,6 @@
 		return ds;
 	};
 
-	
 	$.ig.nextHashCode = 0;
 	$.ig.util.ensureUniqueId = function (obj) {
 		if (!obj.getHashCode) {
@@ -3450,8 +3451,6 @@
 		$type: new $.ig.Type("Stream", $.ig.Object.prototype.$type)
 	}, true);
 
-	
-
 	/*
 	Function.prototype.invoke = function () {
 		return this.apply(null, arguments);
@@ -3723,7 +3722,7 @@
 	$.ig.util.shallowClone = function (arr) {
 		var newArr = [];
 		for (var i = 0; i < arr.length; i++) {
-			newArr[i] = arr[i];
+			newArr[ i ] = arr[ i ];
 		}
 		return newArr;
 	};
@@ -3825,11 +3824,6 @@
 	window.MSApp = window.MSApp || {};
 	window.MSApp.execUnsafeLocalFunction = window.MSApp.execUnsafeLocalFunction ||
 		function (fn) { fn.apply(); };
-
-	
-	
-
-    
 
 	// Synchronize width/height of widget with its chart/dv controller
 	// elem - jquery object which represents widget.element
@@ -4283,7 +4277,7 @@
 			return string.split("");
 		}
 	};
-	
+
 	$.ig.util.stringCompare1 = function (strA, strB, comparisonType) {
 
 		if (!strA) {

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -5080,164 +5080,6 @@
 		return 0;
 	};
 
-	
-
-	//jscs:enable
-	$.ig.util.netRegexToJS = function (netPattern) {
-		var jsPattern = "";
-		var nextNETGroupIndex = 1;
-		var nextJSGroupIndex = 1;
-		var namedGroups = [ ];
-		var nameToJSGroupIndexMap = {};
-		var netToJSGroupIndexMap = [ [ 0 ] ];
-		var matchMustStartAtCurrentPosition = false;
-		var name;
-
-		var i = 0;
-		if (netPattern.startsWith("\\G")) {
-			i += 2;
-			matchMustStartAtCurrentPosition = true;
-		}
-
-		var isInClass = false;
-		for (; i < netPattern.length; i++) {
-			var current = netPattern.charAt(i);
-			switch (current) {
-				case "\\":
-					switch (netPattern.charAt(i + 1)) {
-						case "A":
-							jsPattern = jsPattern.concat("^");
-							i++;
-							break;
-
-						case "z":
-						case "Z":
-							jsPattern = jsPattern.concat("$");
-							i++;
-							break;
-
-						case "G":
-							throw new Error("\\G .NET Regex escape is only supported at the start of the pattern.");
-
-						case "p":
-							if (netPattern.charAt(i + 2) !== "{") {
-								throw new Error("\\p should be followed by braces.");
-							}
-
-							var endBraceIndex = netPattern.indexOf("}", i + 3);
-							if (endBraceIndex < 0) {
-								throw new Error("Could not find the close brace of the \\p pattern.");
-							}
-
-							var pattern = netPattern.substring(i + 3, endBraceIndex);
-							i = endBraceIndex;
-
-							var content = unicodeCategories[ pattern ];
-							if (content === void 0) {
-								throw new Error("Unknown \\p pattern: " + pattern);
-							}
-
-							if (isInClass) {
-								jsPattern = jsPattern.concat(content.substr(1, content.length - 2));
-							} else {
-								jsPattern = jsPattern.concat(content);
-							}
-							break;
-
-						default:
-							jsPattern = jsPattern.concat(netPattern.substr(i, 2));
-							i++;
-							break;
-					}
-					break;
-
-				case "/":
-					jsPattern = jsPattern.concat("\\/");
-					break;
-
-				case "[":
-					isInClass = true;
-					jsPattern = jsPattern.concat("[");
-					break;
-
-				case "]":
-					isInClass = false;
-					jsPattern = jsPattern.concat("]");
-					break;
-
-				case "(":
-
-					jsPattern = jsPattern.concat("(");
-
-					var next = netPattern[ i + 1 ];
-					name = "";
-
-					if (next === "?") {
-						i++;
-						next = netPattern[ i + 1 ];
-						if (next === "<" || next === "\"") {
-
-							if (netPattern[ i + 2 ] === "=" || netPattern[ i + 2 ] === "!") {
-								throw new Error("Lookbehind assertions are not supported in JavaScript: " + pattern);
-							}
-
-							i++;
-							var end = next === "<" ? ">" : "\"";
-							var start = ++i;
-							for (; i < netPattern.length && netPattern[ i ] != end; i++) {
-							}
-
-							name = netPattern.slice(start, i);
-						} else {
-							jsPattern = jsPattern.concat("?");
-
-							// Non-capturing group
-							if (next === ":") {
-								continue;
-							}
-						}
-					}
-
-					var currentJSGroupIndex = nextJSGroupIndex++;
-
-					if (name.length !== 0) {
-						if (!namedGroups.contains(name)) {
-							namedGroups.push(name);
-						}
-
-						var jsGroups = nameToJSGroupIndexMap[ name ];
-						if (!jsGroups) {
-							nameToJSGroupIndexMap[ name ] = jsGroups = [ ];
-						}
-						jsGroups.push(currentJSGroupIndex);
-					} else {
-						netToJSGroupIndexMap[ nextNETGroupIndex++ ] = [ currentJSGroupIndex ];
-					}
-
-					break;
-
-				default:
-					jsPattern = jsPattern.concat(netPattern.substr(i, 1));
-					break;
-			}
-		}
-
-		var nameToNetGroupIndexMap = {};
-		for (i = 0; i < namedGroups.length; i++) {
-			var currentNETGroupIndex = nextNETGroupIndex++;
-			name = namedGroups[ i ];
-			netToJSGroupIndexMap[ currentNETGroupIndex ] = nameToJSGroupIndexMap[ name ];
-			nameToNetGroupIndexMap[ name ] = currentNETGroupIndex;
-		}
-
-		return {
-			pattern: jsPattern,
-			nameToNetGroupIndexMap: nameToNetGroupIndexMap,
-			netToJSGroupIndexMap: netToJSGroupIndexMap,
-			matchMustStartAtCurrentPosition: matchMustStartAtCurrentPosition
-		};
-	};
-
 	$.ig.util.timeSpanInit1 = function (h, m, s) {
 		return (h * 3600000) + (m * 60000) + (s * 1000);
 	};
@@ -5810,6 +5652,7 @@
 		Pf: "[\u00bb\u2019\u201d\u203a\u2e03\u2e05\u2e0a\u2e0d\u2e1d\u2e21]"
 	};
 
+
 	$.ig.util.defType('DomRenderer', 'Object', {
 
 		$type: new $.ig.Type('DomRenderer', null)
@@ -5856,6 +5699,162 @@
 			return new RegExp(regexpString, modifiers);
 		};
 	})();
+
+	//jscs:enable
+	$.ig.util.netRegexToJS = function (netPattern) {
+		var jsPattern = "";
+		var nextNETGroupIndex = 1;
+		var nextJSGroupIndex = 1;
+		var namedGroups = [ ];
+		var nameToJSGroupIndexMap = {};
+		var netToJSGroupIndexMap = [ [ 0 ] ];
+		var matchMustStartAtCurrentPosition = false;
+		var name;
+
+		var i = 0;
+		if (netPattern.startsWith("\\G")) {
+			i += 2;
+			matchMustStartAtCurrentPosition = true;
+		}
+
+		var isInClass = false;
+		for (; i < netPattern.length; i++) {
+			var current = netPattern.charAt(i);
+			switch (current) {
+				case "\\":
+					switch (netPattern.charAt(i + 1)) {
+						case "A":
+							jsPattern = jsPattern.concat("^");
+							i++;
+							break;
+
+						case "z":
+						case "Z":
+							jsPattern = jsPattern.concat("$");
+							i++;
+							break;
+
+						case "G":
+							throw new Error("\\G .NET Regex escape is only supported at the start of the pattern.");
+
+						case "p":
+							if (netPattern.charAt(i + 2) !== "{") {
+								throw new Error("\\p should be followed by braces.");
+							}
+
+							var endBraceIndex = netPattern.indexOf("}", i + 3);
+							if (endBraceIndex < 0) {
+								throw new Error("Could not find the close brace of the \\p pattern.");
+							}
+
+							var pattern = netPattern.substring(i + 3, endBraceIndex);
+							i = endBraceIndex;
+
+							var content = unicodeCategories[ pattern ];
+							if (content === void 0) {
+								throw new Error("Unknown \\p pattern: " + pattern);
+							}
+
+							if (isInClass) {
+								jsPattern = jsPattern.concat(content.substr(1, content.length - 2));
+							} else {
+								jsPattern = jsPattern.concat(content);
+							}
+							break;
+
+						default:
+							jsPattern = jsPattern.concat(netPattern.substr(i, 2));
+							i++;
+							break;
+					}
+					break;
+
+				case "/":
+					jsPattern = jsPattern.concat("\\/");
+					break;
+
+				case "[":
+					isInClass = true;
+					jsPattern = jsPattern.concat("[");
+					break;
+
+				case "]":
+					isInClass = false;
+					jsPattern = jsPattern.concat("]");
+					break;
+
+				case "(":
+
+					jsPattern = jsPattern.concat("(");
+
+					var next = netPattern[ i + 1 ];
+					name = "";
+
+					if (next === "?") {
+						i++;
+						next = netPattern[ i + 1 ];
+						if (next === "<" || next === "\"") {
+
+							if (netPattern[ i + 2 ] === "=" || netPattern[ i + 2 ] === "!") {
+								throw new Error("Lookbehind assertions are not supported in JavaScript: " + pattern);
+							}
+
+							i++;
+							var end = next === "<" ? ">" : "\"";
+							var start = ++i;
+							for (; i < netPattern.length && netPattern[ i ] != end; i++) {
+							}
+
+							name = netPattern.slice(start, i);
+						} else {
+							jsPattern = jsPattern.concat("?");
+
+							// Non-capturing group
+							if (next === ":") {
+								continue;
+							}
+						}
+					}
+
+					var currentJSGroupIndex = nextJSGroupIndex++;
+
+					if (name.length !== 0) {
+						if (!namedGroups.contains(name)) {
+							namedGroups.push(name);
+						}
+
+						var jsGroups = nameToJSGroupIndexMap[ name ];
+						if (!jsGroups) {
+							nameToJSGroupIndexMap[ name ] = jsGroups = [ ];
+						}
+						jsGroups.push(currentJSGroupIndex);
+					} else {
+						netToJSGroupIndexMap[ nextNETGroupIndex++ ] = [ currentJSGroupIndex ];
+					}
+
+					break;
+
+				default:
+					jsPattern = jsPattern.concat(netPattern.substr(i, 1));
+					break;
+			}
+		}
+
+		var nameToNetGroupIndexMap = {};
+		for (i = 0; i < namedGroups.length; i++) {
+			var currentNETGroupIndex = nextNETGroupIndex++;
+			name = namedGroups[ i ];
+			netToJSGroupIndexMap[ currentNETGroupIndex ] = nameToJSGroupIndexMap[ name ];
+			nameToNetGroupIndexMap[ name ] = currentNETGroupIndex;
+		}
+
+		return {
+			pattern: jsPattern,
+			nameToNetGroupIndexMap: nameToNetGroupIndexMap,
+			netToJSGroupIndexMap: netToJSGroupIndexMap,
+			matchMustStartAtCurrentPosition: matchMustStartAtCurrentPosition
+		};
+	};
 
 	return igRoot;
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -9,8 +9,6 @@
  * http://www.infragistics.com/
  *
  * Depends on:
- *  jquery-1.9.1.js
- *  modernizr.js (Optional)
  *
  */
 
@@ -26,18 +24,32 @@
 
 		// AMD. Register as an anonymous module.
 		define( [
-			"jquery",
-			"jquery-ui"
 		], factory );
 	} else {
 
 		// Browser globals
-		factory(jQuery);
+		factory();
 	}
 }
-(function ($) {
+(function () {
+	window.igRoot = window.igRoot || {};
+	if (window.jQuery !== undefined) {
+		window.igRoot = jQuery;
+	}
+	//window.$ = window.$ || window.igRoot;
+
+	window.igRoot.ig = window.igRoot.ig || { _isNamespace: true };
+	window.$ig = window.$ig || window.igRoot.ig;
+
+	var $ = igRoot;
 
 	var initializing = false, fnTest = /xyz/.test(function () { xyz(); }) ? /\b_super\b/ : /.*/;
+
+	if (!Array.isArray) {
+		Array.isArray = function (arg) {
+			return Object.prototype.toString.call(arg) === '[object Array]';
+		};
+	}
 
 	// The base Class implementation (does nothing) or expects Class to already be defined as a function
 	// K.D. August 18, 2016 Bug #242 global scope Class object is overridden by Ignite UI Class object
@@ -182,11 +194,7 @@
 		};
 	}
 
-	$.fn.startsWith = function (str) {
-		return this[ 0 ].innerHTML.indexOf(str) === 0;
-	};
-
-	$.ig = $.ig || { _isNamespace: true };
+	//$.ig = $.ig || { _isNamespace: true };
 	$.ig.util = $.ig.util || {};
 
 	$.ig.util.browserVersion = "";
@@ -215,44 +223,6 @@
 			false;
 	$.ig.util.isWebKit = !!window.webkitURL;
 	$.ig.util.isEdge = window.navigator.userAgent.indexOf("Edge") > -1;
-
-	$.ajaxQueue = function (queueName, options) {
-		var callback;
-
-		//        var s = $("#status");
-		//        s.html(options.url + "<br />" + s.html());
-
-		if (typeof document.ajaxQueue === "undefined") {
-			document.ajaxQueue = { queue: {} };
-		}
-		if (typeof document.ajaxQueue.queue[ queueName ] === "undefined") {
-			document.ajaxQueue.queue[ queueName ] = [ ];
-		}
-
-		if (typeof options === "undefined") {
-			return;
-		}
-
-		callback = options.complete; //original callback
-
-		//overwrite complete
-		options.complete = function (request, status) {
-			document.ajaxQueue.queue[ queueName ].shift(); //remove the first element from the array
-			//we should check if original callbak is defined in options
-			if (typeof callback !== "undefined") {
-				callback(request, status);
-			}
-
-			if (document.ajaxQueue.queue[ queueName ].length > 0) {
-				$.ajax(document.ajaxQueue.queue[ queueName ][ 0 ]);
-			}
-		};
-
-		document.ajaxQueue.queue[ queueName ].push(options);
-		if (document.ajaxQueue.queue[ queueName ].length === 1) {
-			$.ajax(document.ajaxQueue.queue[ queueName ][ 0 ]);
-		}
-	};
 
 	//A.T. 29 Nov 2012 - Fix for bug #119896
 	if (typeof $.ig.useDefineProperty === "undefined") { $.ig.useDefineProperty = true; }
@@ -342,44 +312,6 @@
 		return this.getTimezoneOffset() < this.stdTimezoneOffset();
 	};
 
-	// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
-	if (!Object.keys) {
-		Object.keys = (function () {
-			"use strict";
-			var hasOwnProperty = Object.prototype.hasOwnProperty,
-				hasDontEnumBug = !({ toString: null }).propertyIsEnumerable("toString"),
-				dontEnums = [
-					"toString",
-					"toLocaleString",
-					"valueOf",
-					"hasOwnProperty",
-					"isPrototypeOf",
-					"propertyIsEnumerable",
-					"constructor"
-				 ],
-				dontEnumsLength = dontEnums.length;
-			return function (obj) {
-				if (typeof obj !== "object" && (typeof obj !== "function" || obj === null)) {
-					throw new TypeError("Object.keys called on non-object");
-				}
-				var result = [ ], prop, i;
-				for (prop in obj) {
-					if (hasOwnProperty.call(obj, prop)) {
-						result.push(prop);
-					}
-				}
-				if (hasDontEnumBug) {
-					for (i = 0; i < dontEnumsLength; i++) {
-						if (hasOwnProperty.call(obj, dontEnums[ i ])) {
-							result.push(dontEnums[ i ]);
-						}
-					}
-				}
-				return result;
-			};
-		}());
-	}
-
 	$.ig.findPath = function (dsObj, resKey) {
 		var resPath, ds = dsObj;
 		resPath = resKey.split(".");
@@ -395,376 +327,7 @@
 		return ds;
 	};
 
-	//checkbox markup classes can be changed
-	//and setting them in a a box can be done by the predefined classes "ui-state-default ui-corner-all ui-igcheckbox-small"
-	$.ig.checkboxMarkupClasses = "";
-
-	$.ig.formatter = function (val, type, format, notTemplate, enableUTCDates,
-		displayStyle, labelText, tabIndex) {
-		var min, y, h, m, s, ms, am, e, day, pattern, len, n, dot, gr,
-			gr0, grps, curS, percS, cur, perc, prefix, i, d = val && val.getTime,
-			reg = $.ig.regional.defaults, pow,
-
-			// L.A. 17 October 2012 - Fixing bug #123215 The group rows of a grouped checkbox column are too large
-			display = displayStyle || "inline-block";
-		if (format === "checkbox" && notTemplate) {
-			s = "<span class='ui-igcheckbox-container' style='display:" +
-				display + ";' role='checkbox' aria-disabled='true' aria-checked='" +
-				val + "' aria-label='" + labelText + "' tabindex='" + tabIndex + "'>";
-			s += "<span class='" + $.ig.checkboxMarkupClasses + "' style='display:inline-block'>";
-			s += "<span style='display:block' class='" + (val ? "" : "ui-igcheckbox-small-off ");
-			return s + "ui-icon ui-icon-check ui-igcheckbox-small-on'></span></span></span>";
-		}
-		if (!val && val !== 0 && val !== false) {
-			return "&nbsp;";
-		}
-		if (type === "date" || d) {
-			if (!val) {
-				return "&nbsp;";
-			}
-			if (!d) {
-				return val;
-			}
-			pattern = reg[ (format && format !== "null" && format !== "undefined") ?
-				format + "Pattern" : "datePattern" ] || format;
-			if (enableUTCDates) {
-				y = val.getUTCFullYear();
-				m = val.getUTCMonth() + 1;
-				d = val.getUTCDate();
-				h = val.getUTCHours();
-				min = val.getUTCMinutes();
-				s = val.getUTCSeconds();
-				ms = val.getUTCMilliseconds();
-				day = val.getUTCDay();
-			} else {
-				y = val.getFullYear();
-				m = val.getMonth() + 1;
-				d = val.getDate();
-				h = val.getHours();
-				min = val.getMinutes();
-				s = val.getSeconds();
-				ms = val.getMilliseconds();
-				day = val.getDay();
-			}
-
-			// M.P. 25 July 2014: 176543 - $.ig.formatter doesn't work with escaped characters for date formatting
-			pattern = pattern.replace(/\\d/g, "\x06").replace(/\\y/g, "\x07").replace(/\\M/g, "\x08")
-				.replace(/\\m/g, "\x09").replace(/\\t/g, "\x0A").replace(/\\s/g, "\x0B")
-				.replace(/\\f/g, "\x0C").replace(/\\h/g, "\x0D").replace(/\\H/g, "\x0E");
-
-			// remove MMMM, MMM, dddd, ddd, tt, t
-			pattern = pattern.replace("MMMM", "\x01").replace("MMM", "\x02").replace("dddd", "\x03")
-				.replace("ddd", "\x04");
-			if (pattern.indexOf("t") >= 0) {
-				am = (h >= 12) ? reg.pm : reg.am;
-				am = am || " ";
-				if (pattern.indexOf("tt") >= 0) {
-					pattern = pattern.replace("tt", "t");
-				} else if (am.length > 1) {
-					am = am.substring(0, 1);
-				}
-				pattern = pattern.replace("t", "\x05");
-			}
-			if (pattern.indexOf("h") >= 0) {
-				if (h > 12) {
-					h -= 12;
-				}
-
-				// M.P. 2 August 2013 - Fix for bug #147778 Incorrect date formatting when 12 hour format is used
-				if (h === 0) {
-					h = 12;
-				}
-			}
-			pattern = pattern.replace(/H/g, "h");
-
-			// L.A. 23 October 2012 - Fixing bug #125273 Missing leading zeros when using format MM/dd/yyyy for dates before 1000
-			pattern = pattern
-				.replace("yyyy", y < 10 ? "000" + y : y < 100 ? "00" + y : y < 1000 ? "0" + y : y)
-				.replace("yy", ((y = y % 100) < 10) ? "0" + y : y).replace("y", y % 100)
-				.replace("MM", (m < 10) ? "0" + m : m).replace("M", m);
-			pattern = pattern.replace("dd", (d < 10) ? "0" + d : d).replace("d", d);
-			pattern = pattern.replace("hh", (h < 10) ? "0" + h : h).replace("h", h)
-				.replace("mm", (min < 10) ? "0" + min : min).replace("m", min)
-				.replace("ss", (s < 10) ? "0" + s : s).replace("s", s);
-			pattern = pattern.replace("fff", (ms < 10) ? "00" + ms : ((ms < 100) ? "0" + ms : ms))
-				.replace("ff", ((ms = Math.round(ms / 10)) < 10) ? "0" + ms : ms)
-				.replace("f", Math.round(ms / 100));
-			pattern = pattern.replace("\x01", reg.monthNames[ m - 1 ])
-				.replace("\x02", reg.monthNamesShort[ m - 1 ]).replace("\x05", am);
-			pattern = pattern.replace("\x03", reg.dayNames[ day ]).replace("\x04", reg.dayNamesShort[ day ]);
-			pattern = pattern.replace(/\x06/g, "d").replace(/\x07/g, "y").replace(/\x08/g, "M")
-				.replace(/\x09/g, "m").replace(/\x0A/g, "t").replace(/\x0B/g, "s")
-				.replace(/\x0C/g, "f").replace("\x0D", "h").replace("\x0E", "H");
-			return pattern;
-		}
-		d = format === "double";
-		if (!d) {
-			cur = format === (curS = "currency");
-			if (!cur) {
-				perc = format === (percS = "percent");
-				if (!perc) {
-					i = format === "int";
-				}
-			}
-		}
-		n = typeof val === "number";
-		if (d || n || i || cur || perc || type === "number") {
-			if (!n) {
-
-				// N.A. 26 April 2013 - Fixing bug #139790 When regional settings, different from english, are used and the decimal separator is different than "." the value is calculated wrong
-				// keep only e, E, -, +, decimal separator and digits
-				val = parseFloat(val.replace("(", "-")
-					.replace(new RegExp("[^0-9\\-eE\\" +
-						reg.numericDecimalSeparator + "\\+]", "gm"), "")
-					.replace(reg.numericDecimalSeparator, "."));
-			}
-			if (isNaN(val)) {
-				return "&nbsp;";
-			}
-
-			// M.H. 27 Oct 2014 Fix for bug #183668: when setting column format to percent the formatted value doesn"t reflect proper math to address decimal placement
-			if (perc) {
-				val *= 100;
-			}
-			prefix = cur ? curS : (perc ? percS : "numeric");
-			pattern = reg[ prefix + ((val < 0) ? "Negative" : "Positive") + "Pattern" ] || "n";
-			len = format ? format.length : 0;
-
-			// calculate maximum number of decimals
-			if (len > 0 && ((s = format.charAt(0)) === "0" || s === "#")) {
-				min = m = 0;
-				dot = format.indexOf(".");
-				if (dot > 0) {
-					m = len - 1 - dot;
-					while (++dot < len) {
-						if (format.charAt(dot) !== "0") {
-							break;
-						}
-						min++;
-					}
-				}
-			} else {
-				min = reg[ prefix + "MinDecimals" ] || 0;
-				if (d) {
-					m = 999;
-				} else {
-					m = reg[ prefix + "MaxDecimals" ];
-					m = (m && !i) ? m : 0;
-				}
-			}
-			if (val < 0) {
-				val = -val;
-			}
-
-			// S.S. March 26, 2013 Bug #137025. IE8 and below do not round numbers in toFixed() so we need to round
-			// them first before passing them to toFixed()
-			// val = (m === 999) ? val.toString(10) : val.toFixed(m);
-			if (m === 999) {
-				val = val.toString(10);
-			} else {
-				if ($.ig.util.isIE && $.ig.util.browserVersion <= 8) {
-					pow = Math.pow(10, m);
-					val = (Math.round(pow * val) / pow).toFixed(m);
-				} else {
-					val = val.toFixed(m);
-				}
-			}
-			if ((i = val.indexOf("E")) < 0) {
-				i = val.indexOf("e");
-			}
-
-			// cut-off E-power (e)
-			e = "";
-			if (i > 0) {
-				e = val.substring(i);
-				val = val.substring(0, i);
-			}
-			dot = val.indexOf(".");
-			len = val.length;
-			i = 0;
-
-			// remove trailing 0s
-			while (dot > 0 && m > min + i && val.charAt(len - 1 - i) === "0") {
-				i++;
-			}
-			if (i > 0) {
-				val = val.substring(0, len -= i);
-			}
-
-			// remove trailing .
-			if (dot === len - 1) {
-				val = val.substring(0, dot);
-			}
-			if (dot > 0) {
-				len = dot;
-			}
-
-			// replace decimal separator
-			s = reg[ prefix + "DecimalSeparator" ];
-			if (s) {
-				val = val.replace(".", s);
-			}
-
-			// insert group separators
-			s = reg[ prefix + "GroupSeparator" ];
-			grps = s ? reg[ prefix + "Groups" ] : "";
-			gr = gr0 = (grps.length > 0) ? grps[ i = 0 ] : 0;
-			while (gr > 0 && --len > 0) {
-				if (--gr === 0) {
-					val = val.substring(0, len) + s + val.substring(len);
-					gr = grps[ ++i ];
-					if (!gr || gr < 1) {
-						gr = gr0;
-					} else {
-						gr0 = gr;
-					}
-				}
-			}
-
-			// replace "n" by number, "$" by symbol and "-" by negative sign
-			s = reg[ prefix + "Symbol" ] || "";
-			return pattern.replace("-", reg.negativeSign).replace("n", val + e).replace("$", s);
-		}
-		if (format) {
-			if (format.indexOf(s = "{0}") >= 0) {
-				return format.replace(s, val);
-			}
-			if (format.indexOf(s = "[0]") >= 0) {
-				return format.replace(s, val);
-			}
-		}
-		return (val || val === 0) ? val : "&nbsp;";
-	};
-	$.ig._regional = {
-		monthNames: [ "January", "February", "March", "April", "May", "June",
-			"July", "August", "September", "October", "November", "December" ],
-		monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
-		dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday",
-			"Thursday", "Friday", "Saturday" ],
-		dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
-		am: "AM",
-		pm: "PM",
-		datePattern: "M/d/yyyy",
-		dateLongPattern: "dddd, MMMM dd, yyyy",
-		dateTimePattern: "M/d/yyyy h:mm tt",
-		timePattern: "h:mm tt",
-		timeLongPattern: "h:mm:ss tt",
-		negativeSign: "-",
-		numericNegativePattern: "-$n",
-		numericDecimalSeparator: ".",
-		numericGroupSeparator: ",",
-		numericGroups: [ 3 ],
-		numericMaxDecimals: 2,
-		numericMinDecimals: 0,
-		currencyPositivePattern: "$n",
-		currencyNegativePattern: "-$n",
-		currencySymbol: "$",
-		currencyDecimalSeparator: ".",
-		currencyGroupSeparator: ",",
-		currencyGroups: [ 3 ],
-		currencyMaxDecimals: 2,
-		currencyMinDecimals: 2,
-		percentPositivePattern: "n$",
-		percentNegativePattern: "-n$",
-		percentSymbol: "%",
-		percentDecimalSeparator: ".",
-		percentGroupSeparator: ",",
-		percentGroups: [ 3 ],
-		percentDisplayFactor: 100,
-		percentMaxDecimals: 2,
-		percentMinDecimals: 2
-	};
-	$.ig.regional = $.ig.regional || {};
-	$.ig.regional.defaults = $.ig._regional;
-	$.ig.setRegionalDefault = function (regional) {
-		if ($.ui && $.ui.igEditor) {
-			$.ui.igEditor.setDefaultCulture(regional);
-		} else {
-			$.ig.regional.defaults = $.extend($.ig._regional,
-				(typeof regional === "string") ? $.ig.regional[ regional ] : regional);
-		}
-	};
-	$.ig.calcSummaries = function (summaryFunction, data, caller, dataType) {
-		var sum = function (data) {
-			var sum = 0,
-				i;
-			for (i = 0; i < data.length; i++) {
-				sum += data[ i ];
-			}
-			return sum;
-		};
-
-		// M.H. 16 Nov. 2011 Fix for bug 97886
-		summaryFunction = summaryFunction.toLowerCase();
-		if (summaryFunction.startsWith("custom")) {
-			summaryFunction = "custom";
-		}
-
-		switch (summaryFunction) {
-			case "min":
-				if (data.length === 0) {
-					if (dataType === "date") {
-						return null;
-					}
-					return 0;
-				}
-				return Math.min.apply(Math, data);
-			case "max":
-				if (data.length === 0) {
-					if (dataType === "date") {
-						return null;
-					}
-					return 0;
-				}
-				return Math.max.apply(Math, data);
-			case "sum":
-				return sum(data);
-			case "avg":
-				if (data.length === 0) {
-					return 0;
-				}
-				return sum(data) / data.length;
-			case "count":
-				return data.length;
-			case "custom":
-
-				// M.H. 30 Sept. 2011 Fix for bug #88717 - fix when caller is string
-				if (caller !== undefined && caller !== null) {
-					if ($.type(caller) === "function") {
-						return caller(data);
-					}
-					if ($.type(caller) === "string") {
-						/*jshint evil:true */
-						caller = eval(caller);
-						return caller(data);
-					}
-				} else {
-					return null;
-				}
-				break;
-		}
-	};
-
-	// get max zIndex of ui-dialogs - method is usually called by feautures for configuring zIndex of modal dialogs(like filtering, feature chooser, hiding, etc.)
-	$.ig.getMaxZIndex = function (id) {
-		var maxZ = 10000, thisZ;
-		$(".ui-dialog").each(function () {
-			if (!id || $(this)[ 0 ].id !== id) {
-				thisZ = $(this).css("z-index");
-				if (!isNaN(thisZ)) {
-					maxZ = Math.max(maxZ, thisZ);
-				}
-			}
-		});
-		return maxZ;
-	};
-
-	// generate unique identifiers
-	$.ig.uid = function () {
-		return ((1 + Math.random()) * parseInt("10000", 16)).toString(16).substring(1, 5);
-	};
-
+	
 	$.ig.nextHashCode = 0;
 	$.ig.util.ensureUniqueId = function (obj) {
 		if (!obj.getHashCode) {
@@ -773,25 +336,6 @@
 				return code;
 			};
 		}
-	};
-
-	$.ig.getColType = function (o) {
-		var t = typeof o;
-		if (t === "undefined") {
-			return "string";
-		} else if (o && o.getTime && !isNaN(o.getTime()) &&
-			Object.prototype.toString.call(o) === "[object Date]") {
-			return "date";
-		} else if (t === "boolean") {
-			return "bool";
-		} else if (t === "number") {
-			return t;
-		} else if (t === "object") {
-			return "object";
-		} else {
-			return "string";
-		}
-
 	};
 
 	$.ig.typeIdentifierCache = {};
@@ -3432,58 +2976,6 @@
 		return !!(canvas.getContext && canvas.getContext("2d"));
 	};
 
-	$.ig.util._renderUnsupportedBrowser = function (widget, locale) {
-		if (!widget.events || !widget.events.browserNotSupported ||
-			widget._trigger(widget.events.browserNotSupported)) {
-			var elem = widget.element, o = widget.options,
-				container = $("<div></div>").css("overflow", "auto")
-					.addClass(widget.css.unsupportedBrowserClass).appendTo(elem),
-				ul, browserUnsupported;
-			locale = locale || $.ig.util.locale;
-			if ($.ig.util.isIE) {
-				browserUnsupported = "Internet Explorer " + $.ig.util.browserVersion;
-			} else if ($.ig.util.isOpera) {
-				browserUnsupported = "Opera " + $.ig.util.browserVersion;
-			} else if ($.ig.util.isWebKit) {
-				browserUnsupported = "Webkit " + $.ig.util.browserVersion;
-			} else if ($.ig.util.isFF) {
-				browserUnsupported = "Mozilla Firefox " + $.ig.util.browserVersion;
-			} else {
-				browserUnsupported = $.ig.util.browserVersion;
-			}
-
-			$("<div></div>").addClass("ui-html5-current-browser-label")
-				.html(locale.currentBrowser.replace("{0}", browserUnsupported))
-				.appendTo(container);
-			$("<div></div>").addClass("ui-html5-non-html5-text")
-				.html(locale.unsupportedBrowser).appendTo(container);
-			ul = $("<ul></ul>").addClass("ui-html5-browsers-list").appendTo(container);
-			$("<a></a>").attr("href", locale.chromeDownload).attr("target", "_blank")
-				.addClass("ui-html5-chrome-icon").html(locale.chrome8).appendTo($("<li></li>")
-				.addClass("ui-corner-all").appendTo(ul));
-			$("<a></a>").attr("href", locale.firefoxDownload).attr("target", "_blank")
-				.addClass("ui-html5-firefox-icon").html(locale.firefox36).appendTo($("<li></li>")
-				.addClass("ui-corner-all").appendTo(ul));
-			$("<a></a>").attr("href", locale.operaDownload).attr("target", "_blank")
-				.addClass("ui-html5-Opera-icon").html(locale.opera11).appendTo($("<li></li>")
-				.addClass("ui-corner-all").appendTo(ul));
-			$("<a></a>").attr("href", locale.safariDownload).attr("target", "_blank")
-				.addClass("ui-html5-safari-icon").html(locale.safari5).appendTo($("<li></li>")
-				.addClass("ui-corner-all").appendTo(ul));
-			$("<a></a>").attr("href", locale.ieDownload).attr("target", "_blank")
-				.addClass("ui-html5-ie-icon").html(locale.ie9).appendTo($("<li></li>")
-				.addClass("ui-corner-all").appendTo(ul));
-			if (widget.css.unsupportedBrowserClass.indexOf(" ui-html5-non-html5") === -1) {
-				elem.addClass("ui-html5-non-html5");
-			}
-			if (o.width) {
-				elem.css("width", o.width);
-			}
-			if (o.height) {
-				elem.css("height", o.height);
-			}
-		}
-	};
 	/*jshint -W100 */ // jscs:disable
 	var globalInfo = { "invariant": { c: "¤", d: "MM/dd/yyyy" }, 127: "invariant",
 		"af": { c: "R", d: "yyyy/MM/dd" }, 54: "af", "af-ZA": { c: "R", d: "yyyy/MM/dd" }, 1078: "af-ZA", "am": { c: "ETB", d: "d/M/yyyy" }, 94: "am", "am-ET": { c: "ETB", d: "d/M/yyyy" }, 1118: "am-ET", "ar": { c: "ر.س.‏", d: "dd/MM/yy", n: "٠١٢٣٤٥٦٧٨٩" }, 1: "ar", "ar-AE": { c: "د.إ.‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 14337: "ar-AE", "ar-BH": { c: "د.ب.‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 15361: "ar-BH", "ar-DZ": { c: "د.ج.‏", d: "dd-MM-yyyy" }, 5121: "ar-DZ", "ar-EG": { c: "ج.م.‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 3073: "ar-EG", "ar-IQ": { c: "د.ع.‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 2049: "ar-IQ", "ar-JO": { c: "د.ا.‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 11265: "ar-JO", "ar-KW": { c: "د.ك.‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 13313: "ar-KW", "ar-LB": { c: "ل.ل.‏‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 12289: "ar-LB", "ar-LY": { c: "د.ل.‏‏", d: "dd/MM/yyyy" }, 4097: "ar-LY", "ar-MA": { c: "د.م.‏‏", d: "dd-MM-yyyy" }, 6145: "ar-MA", "arn": { c: "$", d: "dd-MM-yyyy" }, 122: "arn", "arn-CL": { c: "$", d: "dd-MM-yyyy" }, 1146: "arn-CL", "ar-OM": { c: "ر.ع.‏‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 8193: "ar-OM", "ar-QA": { c: "ر.ق.‏‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 16385: "ar-QA", "ar-SA": { c: "ر.س.‏", d: "dd/MM/yy", n: "٠١٢٣٤٥٦٧٨٩" }, 1025: "ar-SA", "ar-SY": { c: "ل.س.‏‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 10241: "ar-SY", "ar-TN": { c: "د.ت.‏‏", d: "dd-MM-yyyy" }, 7169: "ar-TN", "ar-YE": { c: "ر.ي.‏‏", d: "dd/MM/yyyy", n: "٠١٢٣٤٥٦٧٨٩" }, 9217: "ar-YE", "as": { c: "₹", d: "dd-MM-yyyy", n: "০১২৩৪৫৬৭৮৯" }, 77: "as", "as-IN": { c: "₹", d: "dd-MM-yyyy", n: "০১২৩৪৫৬৭৮৯" }, 1101: "as-IN", "az": { c: "man.", d: "dd.MM.yyyy" }, 44: "az", "az-Cyrl": { c: "ман.", d: "dd.MM.yyyy" }, 29740: "az-Cyrl", "az-Cyrl-AZ": { c: "ман.", d: "dd.MM.yyyy" }, 2092: "az-Cyrl-AZ", "az-Latn": { c: "man.", d: "dd.MM.yyyy" }, 30764: "az-Latn", "az-Latn-AZ": { c: "man.", d: "dd.MM.yyyy" }, 1068: "az-Latn-AZ", "ba": { c: "₽", d: "dd.MM.yy" }, 109: "ba", "ba-RU": { c: "₽", d: "dd.MM.yy" }, 1133: "ba-RU", "be": { c: "Br", d: "dd.MM.yy" }, 35: "be", "be-BY": { c: "Br", d: "dd.MM.yy" }, 1059: "be-BY", "bg": { c: "лв.", d: "d.M.yyyy \"г.\"" }, 2: "bg", "bg-BG": { c: "лв.", d: "d.M.yyyy \"г.\"" }, 1026: "bg-BG", "bn": { c: "₹", d: "dd-MM-yy", n: "০১২৩৪৫৬৭৮৯" }, 69: "bn", "bn-BD": { c: "৳", d: "dd-MM-yy", n: "০১২৩৪৫৬৭৮৯" }, 2117: "bn-BD", "bn-IN": { c: "₹", d: "dd-MM-yy", n: "০১২৩৪৫৬৭৮৯" }, 1093: "bn-IN", "bo": { c: "¥", d: "yyyy/M/d", n: "༠༡༢༣༤༥༦༧༨༩" }, 81: "bo", "bo-CN": { c: "¥", d: "yyyy/M/d", n: "༠༡༢༣༤༥༦༧༨༩" }, 1105: "bo-CN", "br": { c: "€", d: "dd/MM/yyyy" }, 126: "br", "br-FR": { c: "€", d: "dd/MM/yyyy" }, 1150: "br-FR", "bs": { c: "KM", d: "d.M.yyyy" }, 30746: "bs", "bs-Cyrl": { c: "КМ", d: "d.M.yyyy" }, 25626: "bs-Cyrl", "bs-Cyrl-BA": { c: "КМ", d: "d.M.yyyy" }, 8218: "bs-Cyrl-BA", "bs-Latn": { c: "KM", d: "d.M.yyyy" }, 26650: "bs-Latn", "bs-Latn-BA": { c: "KM", d: "d.M.yyyy" }, 5146: "bs-Latn-BA", "ca": { c: "€", d: "dd/MM/yyyy" }, 3: "ca", "ca-ES": { c: "€", d: "dd/MM/yyyy" }, 1027: "ca-ES", "ca-ES-valencia": { c: "€", d: "dd/MM/yy" }, 2051: "ca-ES-valencia", "chr": { c: "$", d: "M/d/yyyy" }, 92: "chr", "chr-Cher": { c: "$", d: "M/d/yyyy" }, 31836: "chr-Cher", "chr-Cher-US": { c: "$", d: "M/d/yyyy" }, 1116: "chr-Cher-US", "co": { c: "€", d: "dd/MM/yyyy" }, 131: "co", "co-FR": { c: "€", d: "dd/MM/yyyy" }, 1155: "co-FR", "cs": { c: "Kč", d: "d. M. yyyy" }, 5: "cs", "cs-CZ": { c: "Kč", d: "d. M. yyyy" }, 1029: "cs-CZ", "cy": { c: "£", d: "dd/MM/yy" }, 82: "cy", "cy-GB": { c: "£", d: "dd/MM/yy" }, 1106: "cy-GB", "da": { c: "kr.", d: "dd-MM-yyyy" }, 6: "da", "da-DK": { c: "kr.", d: "dd-MM-yyyy" }, 1030: "da-DK", "de": { c: "€", d: "dd.MM.yyyy" }, 7: "de", "de-AT": { c: "€", d: "dd.MM.yyyy" }, 3079: "de-AT", "de-CH": { c: "Fr.", d: "dd.MM.yyyy" }, 2055: "de-CH", "de-DE": { c: "€", d: "dd.MM.yyyy" }, 1031: "de-DE", "de-LI": { c: "CHF", d: "dd.MM.yyyy" }, 5127: "de-LI", "de-LU": { c: "€", d: "dd.MM.yyyy" }, 4103: "de-LU", "dsb": { c: "€", d: "d. M. yyyy" }, 31790: "dsb", "dsb-DE": { c: "€", d: "d. M. yyyy" }, 2094: "dsb-DE", "dv": { c: "ރ.", d: "dd/MM/yy" }, 101: "dv", "dv-MV": { c: "ރ.", d: "dd/MM/yy" }, 1125: "dv-MV", "el": { c: "€", d: "d/M/yyyy" }, 8: "el", "el-GR": { c: "€", d: "d/M/yyyy" }, 1032: "el-GR", "en": { c: "$", d: "M/d/yyyy" }, 9: "en", "en-029": { c: "EC$", d: "dd/MM/yyyy" }, 9225: "en-029", "en-AU": { c: "$", d: "d/MM/yyyy" }, 3081: "en-AU", "en-BZ": { c: "BZ$", d: "dd/MM/yyyy" }, 10249: "en-BZ", "en-CA": { c: "$", d: "yyyy-MM-dd" }, 4105: "en-CA", "en-GB": { c: "£", d: "dd/MM/yyyy" }, 2057: "en-GB", "en-HK": { c: "$", d: "d/M/yy" }, 15369: "en-HK", "en-IE": { c: "€", d: "dd/MM/yyyy" }, 6153: "en-IE", "en-IN": { c: "₹", d: "dd-MM-yyyy" }, 16393: "en-IN", "en-JM": { c: "J$", d: "dd/MM/yyyy" }, 8201: "en-JM", "en-MY": { c: "RM", d: "d/M/yyyy" }, 17417: "en-MY", "en-NZ": { c: "$", d: "d/MM/yyyy" }, 5129: "en-NZ", "en-PH": { c: "₱", d: "M/d/yyyy" }, 13321: "en-PH", "en-SG": { c: "$", d: "d/M/yyyy" }, 18441: "en-SG", "en-TT": { c: "TT$", d: "dd/MM/yyyy" }, 11273: "en-TT", "en-US": { c: "$", d: "M/d/yyyy" }, 1033: "en-US", "en-ZA": { c: "R", d: "yyyy-MM-dd" }, 7177: "en-ZA", "en-ZW": { c: "$", d: "dd/MM/yyyy" }, 12297: "en-ZW", "es": { c: "€", d: "dd/MM/yyyy" }, 10: "es", "es-419": { c: "US$", d: "dd/MM/yy" }, 22538: "es-419", "es-AR": { c: "$", d: "dd/MM/yyyy" }, 11274: "es-AR", "es-BO": { c: "Bs.", d: "dd/MM/yyyy" }, 16394: "es-BO", "es-CL": { c: "$", d: "dd-MM-yyyy" }, 13322: "es-CL", "es-CO": { c: "$", d: "dd/MM/yyyy" }, 9226: "es-CO", "es-CR": { c: "₡", d: "dd/MM/yyyy" }, 5130: "es-CR", "es-DO": { c: "RD$", d: "d/M/yy" }, 7178: "es-DO", "es-EC": { c: "$", d: "dd/MM/yyyy" }, 12298: "es-EC", "es-ES": { c: "€", d: "dd/MM/yyyy" }, 3082: "es-ES", "es-GT": { c: "Q", d: "dd/MM/yyyy" }, 4106: "es-GT", "es-HN": { c: "L.", d: "dd/MM/yyyy" }, 18442: "es-HN", "es-MX": { c: "$", d: "dd/MM/yyyy" }, 2058: "es-MX", "es-NI": { c: "C$", d: "dd/MM/yyyy" }, 19466: "es-NI", "es-PA": { c: "B/.", d: "d/M/yy" }, 6154: "es-PA", "es-PE": { c: "S/.", d: "dd/MM/yyyy" }, 10250: "es-PE", "es-PR": { c: "$", d: "dd/MM/yyyy" }, 20490: "es-PR", "es-PY": { c: "₲", d: "dd/MM/yyyy" }, 15370: "es-PY", "es-SV": { c: "$", d: "dd/MM/yyyy" }, 17418: "es-SV", "es-US": { c: "$", d: "M/d/yyyy" }, 21514: "es-US", "es-UY": { c: "$U", d: "dd/MM/yyyy" }, 14346: "es-UY", "es-VE": { c: "Bs.F.", d: "dd-MM-yyyy" }, 8202: "es-VE", "et": { c: "€", d: "d.MM.yyyy" }, 37: "et", "et-EE": { c: "€", d: "d.MM.yyyy" }, 1061: "et-EE", "eu": { c: "€", d: "yyyy/MM/dd" }, 45: "eu", "eu-ES": { c: "€", d: "yyyy/MM/dd" }, 1069: "eu-ES", "fa": { c: "ريال", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 41: "fa", "fa-IR": { c: "ريال", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 1065: "fa-IR", "ff": { c: "CFA", d: "dd/MM/yyyy" }, 103: "ff", "ff-Latn": { c: "CFA", d: "dd/MM/yyyy" }, 31847: "ff-Latn", "ff-Latn-SN": { c: "CFA", d: "dd/MM/yyyy" }, 2151: "ff-Latn-SN", "fi": { c: "€", d: "d.M.yyyy" }, 11: "fi", "fi-FI": { c: "€", d: "d.M.yyyy" }, 1035: "fi-FI", "fil": { c: "₱", d: "M/d/yyyy" }, 100: "fil", "fil-PH": { c: "₱", d: "M/d/yyyy" }, 1124: "fil-PH", "fo": { c: "kr.", d: "dd-MM-yyyy" }, 56: "fo", "fo-FO": { c: "kr.", d: "dd-MM-yyyy" }, 1080: "fo-FO", "fr": { c: "€", d: "dd/MM/yyyy" }, 12: "fr", "fr-BE": { c: "€", d: "dd-MM-yy" }, 2060: "fr-BE", "fr-CA": { c: "$", d: "yyyy-MM-dd" }, 3084: "fr-CA", "fr-CD": { c: "FC", d: "dd/MM/yyyy" }, 9228: "fr-CD", "fr-CH": { c: "fr.", d: "dd.MM.yyyy" }, 4108: "fr-CH", "fr-CI": { c: "CFA", d: "dd/MM/yyyy" }, 12300: "fr-CI", "fr-CM": { c: "FCFA", d: "dd/MM/yyyy" }, 11276: "fr-CM", "fr-FR": { c: "€", d: "dd/MM/yyyy" }, 1036: "fr-FR", "fr-HT": { c: "G", d: "dd/MM/yyyy" }, 15372: "fr-HT", "fr-LU": { c: "€", d: "dd/MM/yyyy" }, 5132: "fr-LU", "fr-MA": { c: "DH", d: "dd/MM/yyyy" }, 14348: "fr-MA", "fr-MC": { c: "€", d: "dd/MM/yyyy" }, 6156: "fr-MC", "fr-ML": { c: "CFA", d: "dd/MM/yyyy" }, 13324: "fr-ML", "fr-RE": { c: "€", d: "dd/MM/yyyy" }, 8204: "fr-RE", "fr-SN": { c: "CFA", d: "dd/MM/yyyy" }, 10252: "fr-SN", "fy": { c: "€", d: "d-M-yyyy" }, 98: "fy", "fy-NL": { c: "€", d: "d-M-yyyy" }, 1122: "fy-NL", "ga": { c: "€", d: "dd/MM/yyyy" }, 60: "ga", "ga-IE": { c: "€", d: "dd/MM/yyyy" }, 2108: "ga-IE", "gd": { c: "£", d: "dd/MM/yyyy" }, 145: "gd", "gd-GB": { c: "£", d: "dd/MM/yyyy" }, 1169: "gd-GB", "gl": { c: "€", d: "dd/MM/yyyy" }, 86: "gl", "gl-ES": { c: "€", d: "dd/MM/yyyy" }, 1110: "gl-ES", "gn": { c: "₲", d: "dd/MM/yyyy" }, 116: "gn", "gn-PY": { c: "₲", d: "dd/MM/yyyy" }, 1140: "gn-PY", "gsw": { c: "€", d: "dd/MM/yyyy" }, 132: "gsw", "gsw-FR": { c: "€", d: "dd/MM/yyyy" }, 1156: "gsw-FR", "gu": { c: "₹", d: "dd-MM-yy", n: "૦૧૨૩૪૫૬૭૮૯" }, 71: "gu", "gu-IN": { c: "₹", d: "dd-MM-yy", n: "૦૧૨૩૪૫૬૭૮૯" }, 1095: "gu-IN", "ha": { c: "₦", d: "d/M/yyyy" }, 104: "ha", "ha-Latn": { c: "₦", d: "d/M/yyyy" }, 31848: "ha-Latn", "ha-Latn-NG": { c: "₦", d: "d/M/yyyy" }, 1128: "ha-Latn-NG", "haw": { c: "$", d: "M/d/yyyy" }, 117: "haw", "haw-US": { c: "$", d: "M/d/yyyy" }, 1141: "haw-US", "he": { c: "₪", d: "dd/MM/yyyy" }, 13: "he", "he-IL": { c: "₪", d: "dd/MM/yyyy" }, 1037: "he-IL", "hi": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 57: "hi", "hi-IN": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 1081: "hi-IN", "hr": { c: "kn", d: "d.M.yyyy." }, 26: "hr", "hr-BA": { c: "KM", d: "d.M.yyyy." }, 4122: "hr-BA", "hr-HR": { c: "kn", d: "d.M.yyyy." }, 1050: "hr-HR", "hsb": { c: "€", d: "d. M. yyyy" }, 46: "hsb", "hsb-DE": { c: "€", d: "d. M. yyyy" }, 1070: "hsb-DE", "hu": { c: "Ft", d: "yyyy.MM.dd." }, 14: "hu", "hu-HU": { c: "Ft", d: "yyyy.MM.dd." }, 1038: "hu-HU", "hy": { c: "֏", d: "dd.MM.yyyy" }, 43: "hy", "hy-AM": { c: "֏", d: "dd.MM.yyyy" }, 1067: "hy-AM", "id": { c: "Rp", d: "dd/MM/yyyy" }, 33: "id", "id-ID": { c: "Rp", d: "dd/MM/yyyy" }, 1057: "id-ID", "ig": { c: "₦", d: "d/M/yyyy" }, 112: "ig", "ig-NG": { c: "₦", d: "d/M/yyyy" }, 1136: "ig-NG", "ii": { c: "¥", d: "yyyy/M/d" }, 120: "ii", "ii-CN": { c: "¥", d: "yyyy/M/d" }, 1144: "ii-CN", "is": { c: "kr.", d: "d.M.yyyy" }, 15: "is", "is-IS": { c: "kr.", d: "d.M.yyyy" }, 1039: "is-IS", "it": { c: "€", d: "dd/MM/yyyy" }, 16: "it", "it-CH": { c: "fr.", d: "dd.MM.yyyy" }, 2064: "it-CH", "it-IT": { c: "€", d: "dd/MM/yyyy" }, 1040: "it-IT", "iu": { c: "$", d: "d/MM/yyyy" }, 93: "iu", "iu-Cans": { c: "$", d: "d/M/yyyy" }, 30813: "iu-Cans", "iu-Cans-CA": { c: "$", d: "d/M/yyyy" }, 1117: "iu-Cans-CA", "iu-Latn": { c: "$", d: "d/MM/yyyy" }, 31837: "iu-Latn", "iu-Latn-CA": { c: "$", d: "d/MM/yyyy" }, 2141: "iu-Latn-CA", "ja": { c: "¥", d: "yyyy/MM/dd" }, 17: "ja", "ja-JP": { c: "¥", d: "yyyy/MM/dd" }, 1041: "ja-JP", "jv": { c: "Rp", d: "dd/MM/yyyy" }, 4096: "jv", "jv-Latn": { c: "Rp", d: "dd/MM/yyyy" }, "jv-Latn-ID": { c: "Rp", d: "dd/MM/yyyy" }, "ka": { c: "ლ.", d: "dd.MM.yyyy" }, 55: "ka", "ka-GE": { c: "ლ.", d: "dd.MM.yyyy" }, 1079: "ka-GE", "kk": { c: "₸", d: "d-MMM-yy" }, 63: "kk", "kk-KZ": { c: "₸", d: "d-MMM-yy" }, 1087: "kk-KZ", "kl": { c: "kr.", d: "dd-MM-yyyy" }, 111: "kl", "kl-GL": { c: "kr.", d: "dd-MM-yyyy" }, 1135: "kl-GL", "km": { c: "៛", d: "dd/MM/yy", n: "០១២៣៤៥៦៧៨៩" }, 83: "km", "km-KH": { c: "៛", d: "dd/MM/yy", n: "០១២៣៤៥៦៧៨៩" }, 1107: "km-KH", "kn": { c: "₹", d: "dd-MM-yy", n: "೦೧೨೩೪೫೬೭೮೯" }, 75: "kn", "kn-IN": { c: "₹", d: "dd-MM-yy", n: "೦೧೨೩೪೫೬೭೮೯" }, 1099: "kn-IN", "ko": { c: "₩", d: "yyyy-MM-dd" }, 18: "ko", "kok": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 87: "kok", "kok-IN": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 1111: "kok-IN", "ko-KR": { c: "₩", d: "yyyy-MM-dd" }, 1042: "ko-KR", "ku": { c: "د.ع.‏", d: "yyyy/MM/dd", n: "٠١٢٣٤٥٦٧٨٩" }, 146: "ku", "ku-Arab": { c: "د.ع.‏", d: "yyyy/MM/dd", n: "٠١٢٣٤٥٦٧٨٩" }, 31890: "ku-Arab", "ku-Arab-IQ": { c: "د.ع.‏", d: "yyyy/MM/dd", n: "٠١٢٣٤٥٦٧٨٩" }, 1170: "ku-Arab-IQ", "ky": { c: "сом", d: "d-MMM yy" }, 64: "ky", "ky-KG": { c: "сом", d: "d-MMM yy" }, 1088: "ky-KG", "lb": { c: "€", d: "dd.MM.yy" }, 110: "lb", "lb-LU": { c: "€", d: "dd.MM.yy" }, 1134: "lb-LU", "lo": { c: "₭", d: "dd/MM/yyyy", n: "໐໑໒໓໔໕໖໗໘໙" }, 84: "lo", "lo-LA": { c: "₭", d: "dd/MM/yyyy", n: "໐໑໒໓໔໕໖໗໘໙" }, 1108: "lo-LA", "lt": { c: "Lt", d: "yyyy-MM-dd" }, 39: "lt", "lt-LT": { c: "Lt", d: "yyyy-MM-dd" }, 1063: "lt-LT", "lv": { c: "€", d: "dd.MM.yyyy." }, 38: "lv", "lv-LV": { c: "€", d: "dd.MM.yyyy." }, 1062: "lv-LV", "mg": { c: "Ar", d: "d/M/yyyy" }, "mg-MG": { c: "Ar", d: "d/M/yyyy" }, "mi": { c: "$", d: "dd/MM/yyyy" }, 129: "mi", "mi-NZ": { c: "$", d: "dd/MM/yyyy" }, 1153: "mi-NZ", "mk": { c: "ден.", d: "dd.MM.yyyy" }, 47: "mk", "mk-MK": { c: "ден.", d: "dd.MM.yyyy" }, 1071: "mk-MK", "ml": { c: "₹", d: "dd-MM-yy", n: "൦൧൨൩൪൫൬൭൮൯" }, 76: "ml", "ml-IN": { c: "₹", d: "dd-MM-yy", n: "൦൧൨൩൪൫൬൭൮൯" }, 1100: "ml-IN", "mn": { c: "₮", d: "yyyy-MM-dd" }, 80: "mn", "mn-Cyrl": { c: "₮", d: "yyyy-MM-dd" }, 30800: "mn-Cyrl", "mn-MN": { c: "₮", d: "yyyy-MM-dd" }, 1104: "mn-MN", "mn-Mong": { c: "¥", d: "yyyy/M/d" }, 31824: "mn-Mong", "mn-Mong-CN": { c: "¥", d: "yyyy/M/d" }, 2128: "mn-Mong-CN", "mn-Mong-MN": { c: "₮", d: "yyyy/M/d" }, 3152: "mn-Mong-MN", "moh": { c: "$", d: "M/d/yyyy" }, 124: "moh", "moh-CA": { c: "$", d: "M/d/yyyy" }, 1148: "moh-CA", "mr": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 78: "mr", "mr-IN": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 1102: "mr-IN", "ms": { c: "RM", d: "dd/MM/yyyy" }, 62: "ms", "ms-BN": { c: "$", d: "dd/MM/yyyy" }, 2110: "ms-BN", "ms-MY": { c: "RM", d: "dd/MM/yyyy" }, 1086: "ms-MY", "mt": { c: "€", d: "dd/MM/yyyy" }, 58: "mt", "mt-MT": { c: "€", d: "dd/MM/yyyy" }, 1082: "mt-MT", "my": { c: "K", d: "dd-MM-yyyy", n: "၀၁၂၃၄၅၆၇၈၉" }, 85: "my", "my-MM": { c: "K", d: "dd-MM-yyyy", n: "၀၁၂၃၄၅၆၇၈၉" }, 1109: "my-MM", "nb": { c: "kr", d: "dd.MM.yyyy" }, 31764: "nb", "nb-NO": { c: "kr", d: "dd.MM.yyyy" }, 1044: "nb-NO", "ne": { c: "रु", d: "M/d/yyyy", n: "०१२३४५६७८९" }, 97: "ne", "ne-IN": { c: "₹", d: "yyyy-MM-dd", n: "०१२३४५६७८९" }, 2145: "ne-IN", "ne-NP": { c: "रु", d: "M/d/yyyy", n: "०१२३४५६७८९" }, 1121: "ne-NP", "nl": { c: "€", d: "d-M-yyyy" }, 19: "nl", "nl-BE": { c: "€", d: "d/MM/yyyy" }, 2067: "nl-BE", "nl-NL": { c: "€", d: "d-M-yyyy" }, 1043: "nl-NL", "nn": { c: "kr", d: "dd.MM.yyyy" }, 30740: "nn", "nn-NO": { c: "kr", d: "dd.MM.yyyy" }, 2068: "nn-NO", "no": { c: "kr", d: "dd.MM.yyyy" }, 20: "no", "nqo": { c: "ߖߕ.", d: "dd/MM/yyyy", n: "߀߁߂߃߄߅߆߇߈߉" }, "nqo-GN": { c: "ߖߕ.", d: "dd/MM/yyyy", n: "߀߁߂߃߄߅߆߇߈߉" }, "nso": { c: "R", d: "dd/MM/yy" }, 108: "nso", "nso-ZA": { c: "R", d: "dd/MM/yy" }, 1132: "nso-ZA", "oc": { c: "€", d: "dd/MM/yyyy" }, 130: "oc", "oc-FR": { c: "€", d: "dd/MM/yyyy" }, 1154: "oc-FR", "om": { c: "Br", d: "dd/MM/yy" }, 114: "om", "om-ET": { c: "Br", d: "dd/MM/yy" }, 1138: "om-ET", "or": { c: "₹", d: "dd-MM-yy", n: "୦୧୨୩୪୫୬୭୮୯" }, 72: "or", "or-IN": { c: "₹", d: "dd-MM-yy", n: "୦୧୨୩୪୫୬୭୮୯" }, 1096: "or-IN", "pa": { c: "₹", d: "dd-MM-yy", n: "੦੧੨੩੪੫੬੭੮੯" }, 70: "pa", "pa-Arab": { c: "Rs", d: "dd-MM-yy", n: "۰۱۲۳۴۵۶۷۸۹" }, 31814: "pa-Arab", "pa-Arab-PK": { c: "Rs", d: "dd-MM-yy", n: "۰۱۲۳۴۵۶۷۸۹" }, 2118: "pa-Arab-PK", "pa-IN": { c: "₹", d: "dd-MM-yy", n: "੦੧੨੩੪੫੬੭੮੯" }, 1094: "pa-IN", "pl": { c: "zł", d: "yyyy-MM-dd" }, 21: "pl", "pl-PL": { c: "zł", d: "yyyy-MM-dd" }, 1045: "pl-PL", "prs": { c: "؋", d: "yyyy/M/d", n: "٠١٢٣٤٥٦٧٨٩" }, 140: "prs", "prs-AF": { c: "؋", d: "yyyy/M/d", n: "٠١٢٣٤٥٦٧٨٩" }, 1164: "prs-AF", "ps": { c: "؋", d: "yyyy/M/d", n: "٠١٢٣٤٥٦٧٨٩" }, 99: "ps", "ps-AF": { c: "؋", d: "yyyy/M/d", n: "٠١٢٣٤٥٦٧٨٩" }, 1123: "ps-AF", "pt": { c: "R$", d: "dd/MM/yyyy" }, 22: "pt", "pt-AO": { c: "Kz", d: "dd/MM/yy" }, "pt-BR": { c: "R$", d: "dd/MM/yyyy" }, 1046: "pt-BR", "pt-PT": { c: "€", d: "dd/MM/yyyy" }, 2070: "pt-PT", "qut": { c: "Q", d: "dd/MM/yyyy" }, 134: "qut", "qut-GT": { c: "Q", d: "dd/MM/yyyy" }, 1158: "qut-GT", "quz": { c: "Bs.", d: "dd/MM/yyyy" }, 107: "quz", "quz-BO": { c: "Bs.", d: "dd/MM/yyyy" }, 1131: "quz-BO", "quz-EC": { c: "$", d: "dd/MM/yyyy" }, 2155: "quz-EC", "quz-PE": { c: "S/.", d: "dd/MM/yyyy" }, 3179: "quz-PE", "rm": { c: "fr.", d: "dd-MM-yyyy" }, 23: "rm", "rm-CH": { c: "fr.", d: "dd-MM-yyyy" }, 1047: "rm-CH", "ro": { c: "lei", d: "dd.MM.yyyy" }, 24: "ro", "ro-MD": { c: "L", d: "dd.MM.yyyy" }, 2072: "ro-MD", "ro-RO": { c: "lei", d: "dd.MM.yyyy" }, 1048: "ro-RO", "ru": { c: "₽", d: "dd.MM.yyyy" }, 25: "ru", "ru-RU": { c: "₽", d: "dd.MM.yyyy" }, 1049: "ru-RU", "rw": { c: "RWF", d: "d/MM/yyyy" }, 135: "rw", "rw-RW": { c: "RWF", d: "d/MM/yyyy" }, 1159: "rw-RW", "sa": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 79: "sa", "sah": { c: "₽", d: "dd.MM.yyyy" }, 133: "sah", "sah-RU": { c: "₽", d: "dd.MM.yyyy" }, 1157: "sah-RU", "sa-IN": { c: "₹", d: "dd-MM-yyyy", n: "०१२३४५६७८९" }, 1103: "sa-IN", "sd": { c: "Rs", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 89: "sd", "sd-Arab": { c: "Rs", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 31833: "sd-Arab", "sd-Arab-PK": { c: "Rs", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 2137: "sd-Arab-PK", "se": { c: "kr", d: "dd.MM.yyyy" }, 59: "se", "se-FI": { c: "€", d: "d.M.yyyy" }, 3131: "se-FI", "se-NO": { c: "kr", d: "dd.MM.yyyy" }, 1083: "se-NO", "se-SE": { c: "kr", d: "yyyy-MM-dd" }, 2107: "se-SE", "si": { c: "රු.", d: "yyyy-MM-dd" }, 91: "si", "si-LK": { c: "රු.", d: "yyyy-MM-dd" }, 1115: "si-LK", "sk": { c: "EUR", d: "d.M.yyyy" }, 27: "sk", "sk-SK": { c: "EUR", d: "d.M.yyyy" }, 1051: "sk-SK", "sl": { c: "€", d: "d.M.yyyy" }, 36: "sl", "sl-SI": { c: "€", d: "d.M.yyyy" }, 1060: "sl-SI", "sma": { c: "kr", d: "yyyy-MM-dd" }, 30779: "sma", "sma-NO": { c: "kr", d: "dd.MM.yyyy" }, 6203: "sma-NO", "sma-SE": { c: "kr", d: "yyyy-MM-dd" }, 7227: "sma-SE", "smj": { c: "kr", d: "yyyy-MM-dd" }, 31803: "smj", "smj-NO": { c: "kr", d: "dd.MM.yyyy" }, 4155: "smj-NO", "smj-SE": { c: "kr", d: "yyyy-MM-dd" }, 5179: "smj-SE", "smn": { c: "€", d: "d.M.yyyy" }, 28731: "smn", "smn-FI": { c: "€", d: "d.M.yyyy" }, 9275: "smn-FI", "sms": { c: "€", d: "d.M.yyyy" }, 29755: "sms", "sms-FI": { c: "€", d: "d.M.yyyy" }, 8251: "sms-FI", "sn": { c: "US$", d: "dd/MM/yyyy" }, "sn-Latn": { c: "US$", d: "dd/MM/yyyy" }, "sn-Latn-ZW": { c: "US$", d: "dd/MM/yyyy" }, "so": { c: "S", d: "dd/MM/yy" }, 119: "so", "so-SO": { c: "S", d: "dd/MM/yy" }, 1143: "so-SO", "sq": { c: "Lek", d: "d.M.yyyy" }, 28: "sq", "sq-AL": { c: "Lek", d: "d.M.yyyy" }, 1052: "sq-AL", "sr": { c: "din.", d: "d.M.yyyy." }, 31770: "sr", "sr-Cyrl": { c: "дин.", d: "d.M.yyyy." }, 27674: "sr-Cyrl", "sr-Cyrl-BA": { c: "КМ", d: "d.M.yyyy." }, 7194: "sr-Cyrl-BA", "sr-Cyrl-CS": { c: "дин.", d: "d.M.yyyy." }, 3098: "sr-Cyrl-CS", "sr-Cyrl-ME": { c: "€", d: "d.M.yyyy." }, 12314: "sr-Cyrl-ME", "sr-Cyrl-RS": { c: "дин.", d: "d.M.yyyy." }, 10266: "sr-Cyrl-RS", "sr-Latn": { c: "din.", d: "d.M.yyyy." }, 28698: "sr-Latn", "sr-Latn-BA": { c: "KM", d: "d.M.yyyy." }, 6170: "sr-Latn-BA", "sr-Latn-CS": { c: "din.", d: "d.M.yyyy." }, 2074: "sr-Latn-CS", "sr-Latn-ME": { c: "€", d: "d.M.yyyy." }, 11290: "sr-Latn-ME", "sr-Latn-RS": { c: "din.", d: "d.M.yyyy." }, 9242: "sr-Latn-RS", "st": { c: "R", d: "yyyy-MM-dd" }, 48: "st", "st-ZA": { c: "R", d: "yyyy-MM-dd" }, 1072: "st-ZA", "sv": { c: "kr", d: "yyyy-MM-dd" }, 29: "sv", "sv-FI": { c: "€", d: "d.M.yyyy" }, 2077: "sv-FI", "sv-SE": { c: "kr", d: "yyyy-MM-dd" }, 1053: "sv-SE", "sw": { c: "KSh", d: "M/d/yyyy" }, 65: "sw", "sw-KE": { c: "KSh", d: "M/d/yyyy" }, 1089: "sw-KE", "syr": { c: "ܠ.ܣ.‏", d: "dd/MM/yyyy" }, 90: "syr", "syr-SY": { c: "ܠ.ܣ.‏", d: "dd/MM/yyyy" }, 1114: "syr-SY", "ta": { c: "₹", d: "dd-MM-yyyy", n: "௦௧௨௩௪௫௬௭௮௯" }, 73: "ta", "ta-IN": { c: "₹", d: "dd-MM-yyyy", n: "௦௧௨௩௪௫௬௭௮௯" }, 1097: "ta-IN", "ta-LK": { c: "Rs", d: "dd-MM-yyyy", n: "௦௧௨௩௪௫௬௭௮௯" }, 2121: "ta-LK", "te": { c: "₹", d: "dd-MM-yy", n: "౦౧౨౩౪౫౬౭౮౯" }, 74: "te", "te-IN": { c: "₹", d: "dd-MM-yy", n: "౦౧౨౩౪౫౬౭౮౯" }, 1098: "te-IN", "tg": { c: "смн", d: "dd.MM.yyyy" }, 40: "tg", "tg-Cyrl": { c: "смн", d: "dd.MM.yyyy" }, 31784: "tg-Cyrl", "tg-Cyrl-TJ": { c: "смн", d: "dd.MM.yyyy" }, 1064: "tg-Cyrl-TJ", "th": { c: "฿", d: "d/M/yyyy", n: "๐๑๒๓๔๕๖๗๘๙" }, 30: "th", "th-TH": { c: "฿", d: "d/M/yyyy", n: "๐๑๒๓๔๕๖๗๘๙" }, 1054: "th-TH", "ti": { c: "ERN", d: "d/M/yyyy" }, 115: "ti", "ti-ER": { c: "ERN", d: "d/M/yyyy" }, 2163: "ti-ER", "ti-ET": { c: "ብር", d: "d/M/yyyy" }, 1139: "ti-ET", "tk": { c: "m.", d: "dd.MM.yy \"ý.\"" }, 66: "tk", "tk-TM": { c: "m.", d: "dd.MM.yy \"ý.\"" }, 1090: "tk-TM", "tn": { c: "R", d: "dd/MM/yy" }, 50: "tn", "tn-BW": { c: "P", d: "dd/MM/yy" }, 2098: "tn-BW", "tn-ZA": { c: "R", d: "dd/MM/yy" }, 1074: "tn-ZA", "tr": { c: "₺", d: "d.M.yyyy" }, 31: "tr", "tr-TR": { c: "₺", d: "d.M.yyyy" }, 1055: "tr-TR", "ts": { c: "R", d: "yyyy-MM-dd" }, 49: "ts", "ts-ZA": { c: "R", d: "yyyy-MM-dd" }, 1073: "ts-ZA", "tt": { c: "₽", d: "dd.MM.yyyy" }, 68: "tt", "tt-RU": { c: "₽", d: "dd.MM.yyyy" }, 1092: "tt-RU", "tzm": { c: "DA", d: "dd-MM-yyyy" }, 95: "tzm", "tzm-Latn": { c: "DA", d: "dd-MM-yyyy" }, 31839: "tzm-Latn", "tzm-Latn-DZ": { c: "DA", d: "dd-MM-yyyy" }, 2143: "tzm-Latn-DZ", "tzm-Tfng": { c: "ⴷⵔ", d: "dd-MM-yyyy" }, 30815: "tzm-Tfng", "tzm-Tfng-MA": { c: "ⴷⵔ", d: "dd-MM-yyyy" }, 4191: "tzm-Tfng-MA", "ug": { c: "¥", d: "yyyy-M-d" }, 128: "ug", "ug-CN": { c: "¥", d: "yyyy-M-d" }, 1152: "ug-CN", "uk": { c: "₴", d: "dd.MM.yyyy" }, 34: "uk", "uk-UA": { c: "₴", d: "dd.MM.yyyy" }, 1058: "uk-UA", "ur": { c: "Rs", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 32: "ur", "ur-IN": { c: "₹", d: "d/M/yy", n: "۰۱۲۳۴۵۶۷۸۹" }, 2080: "ur-IN", "ur-PK": { c: "Rs", d: "dd/MM/yyyy", n: "۰۱۲۳۴۵۶۷۸۹" }, 1056: "ur-PK", "uz": { c: "so\"m", d: "dd.MM.yyyy" }, 67: "uz", "uz-Cyrl": { c: "сўм", d: "dd.MM.yyyy" }, 30787: "uz-Cyrl", "uz-Cyrl-UZ": { c: "сўм", d: "dd.MM.yyyy" }, 2115: "uz-Cyrl-UZ", "uz-Latn": { c: "so\"m", d: "dd.MM.yyyy" }, 31811: "uz-Latn", "uz-Latn-UZ": { c: "so\"m", d: "dd.MM.yyyy" }, 1091: "uz-Latn-UZ", "vi": { c: "₫", d: "dd/MM/yyyy" }, 42: "vi", "vi-VN": { c: "₫", d: "dd/MM/yyyy" }, 1066: "vi-VN", "wo": { c: "CFA", d: "dd/MM/yyyy" }, 136: "wo", "wo-SN": { c: "CFA", d: "dd/MM/yyyy" }, 1160: "wo-SN", "xh": { c: "R", d: "yyyy/MM/dd" }, 52: "xh", "xh-ZA": { c: "R", d: "yyyy/MM/dd" }, 1076: "xh-ZA", "yo": { c: "₦", d: "d/M/yyyy" }, 106: "yo", "yo-NG": { c: "₦", d: "d/M/yyyy" }, 1130: "yo-NG", "zgh": { c: "ⴷⵔⵎ", d: "dd-MM-yyyy" }, "zgh-Tfng": { c: "ⴷⵔⵎ", d: "dd-MM-yyyy" }, "zgh-Tfng-MA": { c: "ⴷⵔⵎ", d: "dd-MM-yyyy" }, "zh": { c: "¥", d: "yyyy/M/d" }, 30724: "zh", "zh-CHS": { c: "¥", d: "yyyy/M/d" }, 4: "zh-CHS", "zh-CHT": { c: "HK$", d: "d/M/yyyy" }, 31748: "zh-CHT", "zh-CN": { c: "¥", d: "yyyy/M/d" }, 2052: "zh-CN", "zh-Hans": { c: "¥", d: "yyyy/M/d" }, "zh-Hant": { c: "HK$", d: "d/M/yyyy" }, "zh-HK": { c: "HK$", d: "d/M/yyyy" }, 3076: "zh-HK", "zh-MO": { c: "MOP", d: "d/M/yyyy" }, 5124: "zh-MO", "zh-SG": { c: "$", d: "d/M/yyyy" }, 4100: "zh-SG", "zh-TW": { c: "NT$", d: "yyyy/M/d" }, 1028: "zh-TW", "zu": { c: "R", d: "dd-MM-yyyy" }, 53: "zu", "zu-ZA": { c: "R", d: "dd-MM-yyyy" }, 1077: "zu-ZA" };
@@ -3958,64 +3450,7 @@
 		$type: new $.ig.Type("Stream", $.ig.Object.prototype.$type)
 	}, true);
 
-	(function ($) {
-
-		$.ig.util.profiler = {};
-
-		var methods = {};
-
-		$.ig.util.profiler.recordTime = function (methodName, time) {
-			var key = "meth: " + methodName;
-			if (!methods[ key ]) {
-				methods[ key ] = [ ];
-			}
-			methods[ key ][ methods[ key ].length ] = time;
-		};
-
-		$.ig.util.profiler.reset = function () {
-			methods = {};
-		};
-
-		$.ig.util.profiler.logReport = function () {
-			var meths = [ ];
-			var j = 0;
-			var sum = 0;
-			var avg = 0;
-			for (var prop in methods) {
-				if (prop.indexOf("meth:") === 0) {
-					var meth = {};
-					meth.name = prop.substr(5);
-
-					sum = 0;
-					for (var i = 0; i < methods[ prop ].length; i++) {
-						sum = sum + methods[ prop ][ i ];
-					}
-					avg = sum / methods[ prop ].length;
-					meth.avg = avg;
-					meth.callCount = methods[ prop ].length;
-					meths[ j ] = meth;
-					j++;
-				}
-			}
-
-			meths.sort(function (m1, m2) {
-				if (m1.avg < m2.avg) {
-					return 1;
-				}
-				if (m1.avg > m2.avg) {
-					return -1;
-				}
-				if (m1.avg == m2.avg) {
-					return 0;
-				}
-			});
-
-			for (var k = 0; k < Math.min(200, meths.length) ; k++) {
-				console.log(meths[ k ].name + " avg: " + meths[ k ].avg +
-					" callCount: " + meths[ k ].callCount);
-			}
-		};
-	}(jQuery));
+	
 
 	/*
 	Function.prototype.invoke = function () {
@@ -4118,7 +3553,7 @@
 		var args = [ " " ];
 		if (arguments.length > 0) {
 			args = Array.prototype.slice.call(arguments);
-			if (args.length === 1 && $.isArray(args[ 0 ])) {
+			if (args.length === 1 && Array.isArray(args[ 0 ])) {
 				args = args[ 0 ];
 			}
 		}
@@ -4134,7 +3569,7 @@
 		var args = [ " " ];
 		if (arguments.length > 0) {
 			args = Array.prototype.slice.call(arguments);
-			if (args.length === 1 && $.isArray(args[ 0 ])) {
+			if (args.length === 1 && Array.isArray(args[ 0 ])) {
 				args = args[ 0 ];
 			}
 		}
@@ -4230,29 +3665,6 @@
 		};
 	}
 
-	/*
-	Array.prototype.insertRange = function (index, items) {
-		var i = 0;
-		if (this.length == 0) {
-			for (i = 0; i < items.length; i++) {
-			this[ index++ ] = items[ i ];
-		}
-		} else {
-			for (i = 0; i < items.length; i++) {
-				this.splice(index++, 0, items[ i ]);
-	}
-		}
-	};
-
-	Array.prototype.clone = function () {
-		return $.extend(true, [ ], this);
-	};
-
-	Array.prototype.clear = function () {
-		this.length = 0;
-	};
-	*/
-
 	/* S.S. March 12, 2013 - Bug #134399 Adding filter for older browsers */
 	if (!Array.prototype.filter) {
 		Array.prototype.filter = function (fun/*, thisp */) {
@@ -4308,9 +3720,13 @@
 		}
 	});
 
-	$.ig.extendNativePrototype(Array.prototype, "clone", function () {
-		return $.extend(true, [ ], this);
-	});
+	$.ig.util.shallowClone = function (arr) {
+		var newArr = [];
+		for (var i = 0; i < arr.length; i++) {
+			newArr[i] = arr[i];
+		}
+		return newArr;
+	};
 
 	$.ig.extendNativePrototype(Array.prototype, "clear", function () {
 		this.length = 0;
@@ -4384,7 +3800,7 @@
 	}
 
 	Boolean.prototype.getType = function () {
-		return jQuery.ig.Boolean.prototype.$type;
+		return $.ig.Boolean.prototype.$type;
 	};
 
 	Number.prototype.getType = function () {
@@ -4410,581 +3826,10 @@
 	window.MSApp.execUnsafeLocalFunction = window.MSApp.execUnsafeLocalFunction ||
 		function (fn) { fn.apply(); };
 
-	// N.A. 10/17/2013 - Bug #155039: The property "offset" is deprecated in 1.9.
-	$.ig.util.jQueryUIMainVersion = $.ui && $.ui.version &&
-		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 1)[ 0 ], 10) : null;
-	$.ig.util.jQueryUISubVersion = $.ui && $.ui.version &&
-		$.ui.version.length > 0 ? parseInt($.ui.version.split(".", 2)[ 1 ], 10) : null;
+	
+	
 
-	$.ig.util.jQueryMainVersion = $.fn.jquery &&
-		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 1)[ 0 ], 10) : null;
-	$.ig.util.jQuerySubVersion = $.fn.jquery &&
-		$.fn.jquery.length ? parseInt($.fn.jquery.split(".", 2)[ 1 ], 10) : null;
-
-	//A CommonJS Promises/A implementation that will be used with jquery versions prior to 1.5
-	//that do not have a $.Deferred implementation
-
-	// String to Object flags format cache
-	$.ig.util.jqueryFlagsCache = {};
-
-	// Convert String-formatted flags into Object-formatted ones and store in cache
-	$.ig.util.jqueryCreateFlags = function (flags) {
-		var object = $.ig.util.jqueryFlagsCache[ flags ] = {},
-				i, length;
-		flags = flags.split(/\s+/);
-		for (i = 0, length = flags.length; i < length; i++) {
-			object[ flags[ i ] ] = true;
-		}
-		return object;
-	};
-
-	/*
-	 * Create a callback list using the following parameters:
-	 *
-	 *	flags:	an optional list of space-separated flags that will change how
-	 *			the callback list behaves
-	 *
-	 * By default a callback list will act like an event callback list and can be
-	 * "fired" multiple times.
-	 *
-	 * Possible flags:
-	 *
-	 *	once:			will ensure the callback list can only be fired once (like a Deferred)
-	 *
-	 *	memory:			will keep track of previous values and will call any callback added
-	 *					after the list has been fired right away with the latest "memorized"
-	 *					values (like a Deferred)
-	 *
-	 *	unique:			will ensure a callback can only be added once (no duplicate in the list)
-	 *
-	 *	stopOnFalse:	interrupt callings when a callback returns false
-	 *
-	 */
-		$.ig.util.jqueryCallbacks = function( flags ) {
-
-		// Convert flags from String-formatted to Object-formatted
-		// (we check in cache first)
-			flags = flags ? ($.ig.util.jqueryFlagsCache[ flags ] ||
-				$.ig.util.jqueryCreateFlags(flags)) : { };
-
-		var // Actual Callbacks object
-			self,
-
-			// Actual callback list
-			list = [ ],
-
-			// Stack of fire calls for repeatable lists
-			stack = [ ],
-
-			// Last fire value (for non-forgettable lists)
-			memory,
-
-			// Flag to know if list was already fired
-			fired,
-
-			// Flag to know if list is currently firing
-			firing,
-
-			// First callback to fire (used internally by add and fireWith)
-			firingStart,
-
-			// End of the loop when firing
-			firingLength,
-
-			// Index of currently firing callback (modified by remove if needed)
-			firingIndex,
-
-			// Add one or several callbacks to the list
-			add = function( args ) {
-				var i,
-					length,
-					elem,
-					type,
-					actual;
-				for ( i = 0, length = args.length; i < length; i++ ) {
-					elem = args[ i ];
-					type = jQuery.type( elem );
-					if (type === "array") {
-
-						// Inspect recursively
-						add( elem );
-					} else if (type === "function") {
-
-						// Add if not in unique mode and callback is not in
-						if ( !flags.unique || !self.has( elem ) ) {
-							list.push( elem );
-						}
-					}
-				}
-			},
-
-			// Fire callbacks
-			fire = function( context, args ) {
-				args = args || [ ];
-				memory = !flags.memory || [ context, args ];
-				fired = true;
-				firing = true;
-				firingIndex = firingStart || 0;
-				firingStart = 0;
-				firingLength = list.length;
-				for ( ; list && firingIndex < firingLength; firingIndex++ ) {
-					if ( list[ firingIndex ].apply( context, args ) === false && flags.stopOnFalse ) {
-						memory = true; // Mark as halted
-						break;
-					}
-				}
-				firing = false;
-				if ( list ) {
-					if ( !flags.once ) {
-						if ( stack && stack.length ) {
-							memory = stack.shift();
-							self.fireWith( memory[ 0 ], memory[ 1 ] );
-						}
-					} else if ( memory === true ) {
-						self.disable();
-					} else {
-						list = [ ];
-					}
-				}
-			};
-
-			// Actual Callbacks object
-			self = {
-				// Add a callback or a collection of callbacks to the list
-				add: function() {
-					if ( list ) {
-						var length = list.length;
-						add(arguments);
-
-						// Do we need to add the callbacks to the
-						// current firing batch?
-						if ( firing ) {
-							firingLength = list.length;
-
-						// With memory, if we're not firing then
-						// we should call right away, unless previous
-						// firing was halted (stopOnFalse)
-						} else if ( memory && memory !== true ) {
-							firingStart = length;
-							fire( memory[ 0 ], memory[ 1 ] );
-						}
-					}
-					return this;
-				},
-
-				// Remove a callback from the list
-				remove: function() {
-					if ( list ) {
-						var args = arguments,
-							argIndex = 0,
-							argLength = args.length;
-						for ( ; argIndex < argLength ; argIndex++ ) {
-							for ( var i = 0; i < list.length; i++ ) {
-								if (args[ argIndex ] === list[ i ]) {
-
-									// Handle firingIndex and firingLength
-									if ( firing ) {
-										if ( i <= firingLength ) {
-											firingLength--;
-											if ( i <= firingIndex ) {
-												firingIndex--;
-											}
-										}
-									}
-
-									// Remove the element
-									list.splice(i--, 1);
-
-									// If we have some unicity property then
-									// we only need to do this once
-									if ( flags.unique ) {
-										break;
-									}
-								}
-							}
-						}
-					}
-					return this;
-				},
-
-				// Control if a given callback is in the list
-				has: function( fn ) {
-					if ( list ) {
-						var i = 0,
-							length = list.length;
-						for ( ; i < length; i++ ) {
-							if ( fn === list[ i ] ) {
-								return true;
-							}
-						}
-					}
-					return false;
-				},
-
-				// Remove all callbacks from the list
-				empty: function () {
-					list = [ ];
-					return this;
-				},
-
-				// Have the list do nothing anymore
-				disable: function () {
-					list = stack = memory = undefined;
-					return this;
-				},
-
-				// Is it disabled?
-				disabled: function () {
-					return !list;
-				},
-
-				// Lock the list in its current state
-				lock: function () {
-					stack = undefined;
-					if ( !memory || memory === true ) {
-						self.disable();
-					}
-					return this;
-				},
-
-				// Is it locked?
-				locked: function () {
-					return !stack;
-				},
-
-				// Call all callbacks with the given context and arguments
-				fireWith: function( context, args ) {
-					if ( stack ) {
-						if ( firing ) {
-							if ( !flags.once ) {
-								stack.push( [ context, args ] );
-							}
-						} else if ( !( flags.once && memory ) ) {
-							fire( context, args );
-						}
-					}
-					return this;
-				},
-
-				// Call all the callbacks with the given arguments
-				fire: function () {
-					self.fireWith( this, arguments );
-					return this;
-				},
-
-				// To know if the callbacks have already been called at least once
-				fired: function () {
-					return !!fired;
-				}
-			};
-
-		return self;
-	};
-
-	$.ig.util.jqueryDeferred = function( func ) {
-		var deferred,
-			doneList = $.ig.util.jqueryCallbacks( "once memory" ),
-			failList = $.ig.util.jqueryCallbacks( "once memory" ),
-			progressList = $.ig.util.jqueryCallbacks( "memory" ),
-			state = "pending",
-			lists = {
-				resolve: doneList,
-				reject: failList,
-				notify: progressList
-			},
-			promise = {
-				done: doneList.add,
-				fail: failList.add,
-				progress: progressList.add,
-
-				state: function () {
-					return state;
-				},
-
-				// Deprecated
-				isResolved: doneList.fired,
-				isRejected: failList.fired,
-
-				then: function ( doneCallbacks, failCallbacks, progressCallbacks ) {
-					deferred.done( doneCallbacks ).fail( failCallbacks ).progress( progressCallbacks );
-					return this;
-				},
-				always: function () {
-					deferred.done.apply( deferred, arguments ).fail.apply(deferred, arguments);
-					return this;
-				},
-				pipe: function ( fnDone, fnFail, fnProgress ) {
-					return $.ig.util.jqueryDeferred(function ( newDefer ) {
-						jQuery.each( {
-							done: [ fnDone, "resolve" ],
-							fail: [ fnFail, "reject" ],
-							progress: [ fnProgress, "notify" ]
-						}, function ( handler, data ) {
-							var fn = data[ 0 ],
-								action = data[ 1 ],
-								returned;
-							if ( jQuery.isFunction( fn ) ) {
-								deferred[ handler ](function () {
-									returned = fn.apply( this, arguments );
-									if ( returned && jQuery.isFunction( returned.promise ) ) {
-										returned.promise().then( newDefer.resolve, newDefer.reject, newDefer.notify );
-									} else {
-										newDefer[ action + "With" ]( this === deferred ? newDefer : this, [ returned ] );
-									}
-								});
-							} else {
-								deferred[ handler ]( newDefer[ action ] );
-							}
-						});
-					}).promise();
-				},
-
-				// Get a promise for this deferred
-				// If obj is provided, the promise aspect is added to the object
-				promise: function ( obj ) {
-					if (obj === undefined || obj === null) {
-						obj = promise;
-					} else {
-						for ( var key in promise ) {
-							obj[ key ] = promise[ key ];
-						}
-					}
-					return obj;
-				}
-			},
-			key;
-
-			deferred = promise.promise({});
-
-		for ( key in lists ) {
-			deferred[ key ] = lists[ key ].fire;
-			deferred[ key + "With" ] = lists[ key ].fireWith;
-		}
-
-		// Handle state
-		deferred.done(function () {
-			state = "resolved";
-		}, failList.disable, progressList.lock).fail(function () {
-			state = "rejected";
-		}, doneList.disable, progressList.lock);
-
-		// Call given func if any
-		if ( func ) {
-			func.call( deferred, deferred );
-		}
-
-		// All done!
-		return deferred;
-	};
-
-	// PA 7/8/2013 - fix for jQuery versions in the interval (1.4.4, 1.7.0) where $.Deferred is defined, but has some missing members that we need
-	$.ig.util.checkDeferred = function () {
-		$.ig.util.deferredDefined = !!($.Deferred !== undefined && $.Deferred().state);
-	};
-
-	$.ig.util.deferred = function () {
-		if ($.ig.util.deferredDefined === undefined) {
-			$.ig.util.checkDeferred();
-		}
-
-		if ($.ig.util.deferredDefined) {
-			return $.Deferred();
-		} else {
-			return $.ig.util.jqueryDeferred();
-		}
-	};
-
-	$.ig.util.ajax = function (url, contentType, data, method, requestOptions) {
-		//return $.ig.util.corsRequest(url, contentType, data, method, requestOptions);
-
-		var deferred = $.ig.util.deferred();
-		var isCrossDomain;
-		if (requestOptions && "isCrossDomain" in requestOptions) {
-			isCrossDomain = requestOptions.isCrossDomain;
-		} else {
-			isCrossDomain = $.support.cors;
-		}
-
-		var xhrObj = (function (rOptions) {
-			var xhr = new XMLHttpRequest();
-
-			// do not use XDomainRequest for IE8/IE9 if the user has specifed withCredentials in request options
-			// which is interpreted as XmlHttpRequest to be used against trusted domain
-			// since XDomainRequest does not support withCredentials
-			if (isCrossDomain &&
-				!(("withCredentials" in xhr) ||
-				(rOptions && "withCredentials" in rOptions && rOptions.withCredentials)) &&
-					typeof XDomainRequest != "undefined") {
-
-				// handle IE8/IE9 with anonymous authentication
-				xhr = new XDomainRequest();
-
-				// fix for jQuery.ajax() callback is expecting some methods and props are defined
-				// PP 12/05/2012 jQuery 1.4.4 fix
-				xhr.getResponseHeader = function () {
-					return null;
-				};
-
-				// M.S. July 24st, 2013 Bug #145199 Fixed the data loading from XMLA, when using jQuery 2.0.0 in IE9
-				xhr.setRequestHeader = function () {
-					xhr.status = 200;
-				};
-
-				xhr.getAllResponseHeaders = function () {
-					return null;
-				};
-
-				xhr.onload = function () {
-					xhr.readyState = 4;
-					xhr.status = 200;
-					xhr.statusText = "success";
-					xhr.getAllResponseHeaders = function () {
-					};
-					xhr.onreadystatechange();
-				};
-
-				xhr.onerror = function () {
-					xhr.readyState = 4;
-					xhr.status = 0;
-					xhr.statusText = "error";
-					xhr.getAllResponseHeaders = function () {
-					};
-					xhr.onreadystatechange();
-				};
-
-				xhr.ontimeout = function () {
-					xhr.readyState = 4;
-					xhr.status = 0;
-					xhr.statusText = "timeout";
-					xhr.getAllResponseHeaders = function () {
-					};
-					xhr.onreadystatechange();
-				};
-
-				// keep this callback because otherwise XDomainRequest is aborted
-				// it's a bug in XDomainRequest
-				xhr.onprogress = function () {
-				};
-			}
-
-			return xhr;
-		})(requestOptions);
-
-		var xhrFields;
-
-		// when credentials are specified that will work with Chrome/FireFox/IE10
-		if ("withCredentials" in xhrObj &&
-			requestOptions && "withCredentials" in requestOptions &&
-		requestOptions.withCredentials) {
-
-			xhrFields = {
-				withCredentials: true
-			};
-		}
-
-		var beforeSend = function (jqXHR, options) {
-			if (requestOptions) {
-
-				if ($.isFunction(requestOptions.beforeSend)) {
-					jqXHR.setRequestHeader("Content-Type", contentType);
-					requestOptions.beforeSend.call(this, jqXHR, options, requestOptions);
-				}
-			}
-		};
-
-		$.ajax({
-			crossDomain: (isCrossDomain ? true : false),
-			isLocal: false,
-			url: url,
-			contentType: contentType,
-			data: data,
-			type: method,
-			dataType: "text",
-			xhrFields: xhrFields,
-			beforeSend: beforeSend,
-			xhr: function () {
-				return xhrObj;
-			},
-			success: function (responce, textStatus, jqXHR) {
-				deferred.resolve(responce);
-			},
-			error: function (jqXHR, textStatus, errorThrown) {
-				deferred.reject(errorThrown);
-			}
-		});
-
-		return deferred.promise();
-	};
-
-    // Ajdusts jQuery.offset in IE10/IE11/Edge.
-    // jQuery.offset function calculates the coordinates by using element.getBoundingClientRect()
-	// function and adding the page scrolls offests (window.pageXOffset and window.pageYOffset).
-    // When zooming in/out the offset is incorrect because window.pageXOffset and
-	// window.pageYOffset values increase when the user zooms in/out. They should not.
-    // Below we calculate the element coordinates by adding the real page scroll offsets.
-    // The page zoom is detected by using the the inner window's width which reacts to
-	// zooming in/out the page.
-	// e: jquery object/element
-	// xy: optional precalculated e.offset or existing position/point with members left/top
-	$.ig.util.offset = function (e, xy) {
-	    var doc = e ? e[ 0 ].ownerDocument : document,
-            windowBorderWidth = 8,
-            zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth;
-
-	    xy = xy || e.offset();
-
-	    if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {
-		    if ($.ig.util.isIE) {
-		        xy.documentScrollLeft = doc.documentElement.scrollLeft;
-		        xy.documentScrollTop = doc.documentElement.scrollTop;
-		    } else if ($.ig.util.isEdge) {
-		        xy.documentScrollLeft = doc.body.scrollLeft;
-		        xy.documentScrollTop = doc.body.scrollTop;
-            }
-
-		    xy.left += xy.documentScrollLeft - window.pageXOffset;
-		    xy.top += xy.documentScrollTop - window.pageYOffset;
-		}
-
-		return xy;
-	};
-
-	// Get relative offset of the passed element according to the closest parent element with relative position if any
-	// e: jquery element
-	$.ig.util.getRelativeOffset = function (e) {
-		var elem = e.parent(), o = { left: 0, top: 0 }, position,
-			 windowBorderWidth = 8,
-			 zoom = (window.outerWidth - (windowBorderWidth * 2)) / window.innerWidth,
-			 documentScrollLeft, documentScrollTop, doc = e.length > 0 ? e[ 0 ].ownerDocument : document;
-
-		while (elem[ 0 ] !== null && elem[ 0 ] !== undefined && elem[ 0 ].nodeName !== "#document") {
-			position = elem.css("position");
-			/* because the element which is passed as argument is supposed to be with position absolute we should find whether it has parent in the DOM tree which is with position which is not static - like relative, absolute, etc */
-			if (position !== "static" && position !== "") {
-				if (zoom && zoom > 1 && ($.ig.util.isIE10 || $.ig.util.isIE11 || $.ig.util.isEdge)) {
-					if ($.ig.util.isIE) {
-						documentScrollLeft = doc.documentElement.scrollLeft;
-						documentScrollTop = doc.documentElement.scrollTop;
-					} else if ($.ig.util.isEdge) {
-						documentScrollLeft = doc.body.scrollLeft;
-						documentScrollTop = doc.body.scrollTop;
-					}
-
-					o.left = elem.offset().left;
-					o.top = elem.offset().top;
-
-					o.left += documentScrollLeft - window.pageXOffset;
-					o.top += documentScrollTop - window.pageYOffset;
-				} else {
-					o.left = elem.offset().left - elem.scrollLeft();
-					o.top = elem.offset().top - elem.scrollTop();
-				}
-				break;
-			}
-			elem = elem.parent();
-		}
-		return o;
-	};
+    
 
 	// Synchronize width/height of widget with its chart/dv controller
 	// elem - jquery object which represents widget.element
@@ -5179,42 +4024,6 @@
 		return easingValue;
 	};
 
-	// Check if given element has vertical scrollbar
-	// elem - jQuery object
-	$.ig.util.hasVerticalScroll = function (elem) {
-		var overflow = $(elem).css("overflow-y");
-		return overflow === "scroll" ||
-			overflow === "auto" && elem[ 0 ].scrollHeight > elem[ 0 ].clientHeight;
-	};
-
-	// Check if given element has horizontal scrollbar
-	// elem - jQuery object
-	$.ig.util.hasHorizontalScroll = function (elem) {
-		var overflow = $(elem).css("overflow-x");
-		return overflow === "scroll" ||
-			overflow === "auto" && elem[ 0 ].scrollWidth > elem[ 0 ].clientWidth;
-	};
-
-	// Returns the width of the vertical scrollbar
-	$.ig.util.getScrollWidth = function () {
-		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
-			'top: -10000px; left: -10000px; overflow: scroll"></div>')
-			.appendTo($(document.body)), scrollWidth;
-		scrollWidth = el[ 0 ].offsetWidth - el[ 0 ].clientWidth;
-		el.remove();
-		return scrollWidth;
-	};
-
-	// Returns the height of the horizontal scrollbar
-	$.ig.util.getScrollHeight = function () {
-		var el = $('<div style="width: 100px; height: 100px; position: absolute; ' +
-			'top: -10000px; left: -10000px; overflow: scroll"></div>')
-			.appendTo($(document.body)), scrollHeight;
-		scrollHeight = el[ 0 ].offsetHeight - el[ 0 ].clientHeight;
-		el.remove();
-		return scrollHeight;
-	};
-
 	// Checks if given object is a DOM element
 	$.ig.util.isDomElement = function (o) {
 		return (
@@ -5263,27 +4072,6 @@
 		return (e === 2) ? 2 : (e ? 1 : 0);
 	};
 
-	// animates rotation
-	$.fn.animateRotate = function (startAngle, endAngle, duration, easing, complete) {
-		return this.each(function () {
-			var elem = $(this);
-			$({ deg: startAngle }).animate({ deg: endAngle }, {
-				duration: duration,
-				easing: easing,
-				step: function (now) {
-					elem.css({
-						"-moz-transform": "rotate(" + now + "deg)",
-						"-webkit-transform": "rotate(" + now + "deg)",
-						"-o-transform": "rotate(" + now + "deg)",
-						"-ms-transform": "rotate(" + now + "deg)",
-						"transform": "rotate(" + now + "deg)"
-					});
-				},
-				complete: complete || $.noop
-			});
-		});
-	};
-
 	// returns date object(from string formatted in ISO8601)
 	$.ig.util.dateFromISO = function (obj) {
 		var //regexIso8601 = /^(\d{4}|\+\d{6})(?:-(\d{2})(?:-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2})\.(\d{1,7})(?:Z|([\-+])(\d{2}):(\d{2}))?)?)?)?$/,
@@ -5305,43 +4093,6 @@
 
 	$.ig.util.defaultDVDateParse = function (obj) {
 		return new Date(parseInt(obj.replace("/Date(", "").replace(")/", ""), 10));
-	};
-
-	// creates crc32 table
-	$.ig.util.makeCRCTable = function () {
-		var c, n, k, crcTable = [ ];
-		for (n = 0; n < 256; n++) {
-			c = n;
-			for (k = 0; k < 8; k++) {
-				/*jslint bitwise: true */
-				c = ((c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1));
-			}
-			crcTable[ n ] = c;
-		}
-		return crcTable;
-	};
-
-	// returns crc32 checksum for the input string
-	$.ig.util.crc32 = function (str) {
-		/*jslint bitwise: true */
-		var crcTable = $.ig.util.crcTable || ($.ig.util.crcTable = $.ig.util.makeCRCTable()),
-			crc = 0 ^ (-1), i;
-		str = unescape(encodeURIComponent(str));
-		for (i = 0; i < str.length; i++) {
-			crc = (crc >>> 8) ^ crcTable[ (crc ^ str.charCodeAt(i)) & 0xFF ];
-		}
-		return (crc ^ (-1)) >>> 0;
-	};
-
-	// returns checksum based on the string representations of an object's property values
-	$.ig.util.getCheckSumForObject = function (obj) {
-		var str = "", key;
-		for (key in obj) {
-			if (obj.hasOwnProperty(key) && typeof obj[ key ] !== "object"/* only stringify simple properties */) {
-				str += obj[ key ];
-			}
-		}
-		return $.ig.util.crc32(str);
 	};
 
 	$.ig.util.createGuid = function () {
@@ -5532,24 +4283,7 @@
 			return string.split("");
 		}
 	};
-	$.ig.util.IMEtoENNumbersMapping = function () {
-		return {
-			"１": "1", "２": "2", "３": "3", "４": "4", "５": "5",
-			"６": "6", "７": "7", "８": "8", "９": "9", "０": "0"
-		};
-	};
-	$.ig.util.IMEtoNumberString = function (stringValue, mapping) {
-		if (mapping === undefined) {
-			return stringValue;
-		}
-		if (stringValue) {
-			stringValue = stringValue.toString();
-			$.each(mapping, function (jpVal, engVal) {
-				stringValue = stringValue.replace(new RegExp(jpVal, "g"), engVal);
-			});
-		}
-		return stringValue;
-	};
+	
 	$.ig.util.stringCompare1 = function (strA, strB, comparisonType) {
 
 		if (!strA) {
@@ -6346,48 +5080,7 @@
 		return 0;
 	};
 
-	/*! unicode_hack.js
-	Copyright (C) 2010-2012,2014  Marcelo Gibson de Castro GonÃ§alves. All rights reserved.
-
-	Copying and distribution of this file, with or without modification,
-	are permitted in any medium without royalty provided the copyright
-	notice and this notice are preserved.  This file is offered as-is,
-	without any warranty.
-	*/
-
-	// jscs:disable
-	var unicodeCategories = {
-		Cn: "[\u0378\u0379\u037f-\u0383\u038b\u038d\u03a2\u0528-\u0530\u0557\u0558\u0560\u0588\u058b-\u0590\u05c8-\u05cf\u05eb-\u05ef\u05f5-\u05ff\u0604\u0605\u061c\u061d\u070e\u074b\u074c\u07b2-\u07bf\u07fb-\u07ff\u082e\u082f\u083f\u085c\u085d\u085f-\u08ff\u0978\u0980\u0984\u098d\u098e\u0991\u0992\u09a9\u09b1\u09b3-\u09b5\u09ba\u09bb\u09c5\u09c6\u09c9\u09ca\u09cf-\u09d6\u09d8-\u09db\u09de\u09e4\u09e5\u09fc-\u0a00\u0a04\u0a0b-\u0a0e\u0a11\u0a12\u0a29\u0a31\u0a34\u0a37\u0a3a\u0a3b\u0a3d\u0a43-\u0a46\u0a49\u0a4a\u0a4e-\u0a50\u0a52-\u0a58\u0a5d\u0a5f-\u0a65\u0a76-\u0a80\u0a84\u0a8e\u0a92\u0aa9\u0ab1\u0ab4\u0aba\u0abb\u0ac6\u0aca\u0ace\u0acf\u0ad1-\u0adf\u0ae4\u0ae5\u0af0\u0af2-\u0b00\u0b04\u0b0d\u0b0e\u0b11\u0b12\u0b29\u0b31\u0b34\u0b3a\u0b3b\u0b45\u0b46\u0b49\u0b4a\u0b4e-\u0b55\u0b58-\u0b5b\u0b5e\u0b64\u0b65\u0b78-\u0b81\u0b84\u0b8b-\u0b8d\u0b91\u0b96-\u0b98\u0b9b\u0b9d\u0ba0-\u0ba2\u0ba5-\u0ba7\u0bab-\u0bad\u0bba-\u0bbd\u0bc3-\u0bc5\u0bc9\u0bce\u0bcf\u0bd1-\u0bd6\u0bd8-\u0be5\u0bfb-\u0c00\u0c04\u0c0d\u0c11\u0c29\u0c34\u0c3a-\u0c3c\u0c45\u0c49\u0c4e-\u0c54\u0c57\u0c5a-\u0c5f\u0c64\u0c65\u0c70-\u0c77\u0c80\u0c81\u0c84\u0c8d\u0c91\u0ca9\u0cb4\u0cba\u0cbb\u0cc5\u0cc9\u0cce-\u0cd4\u0cd7-\u0cdd\u0cdf\u0ce4\u0ce5\u0cf0\u0cf3-\u0d01\u0d04\u0d0d\u0d11\u0d3b\u0d3c\u0d45\u0d49\u0d4f-\u0d56\u0d58-\u0d5f\u0d64\u0d65\u0d76-\u0d78\u0d80\u0d81\u0d84\u0d97-\u0d99\u0db2\u0dbc\u0dbe\u0dbf\u0dc7-\u0dc9\u0dcb-\u0dce\u0dd5\u0dd7\u0de0-\u0df1\u0df5-\u0e00\u0e3b-\u0e3e\u0e5c-\u0e80\u0e83\u0e85\u0e86\u0e89\u0e8b\u0e8c\u0e8e-\u0e93\u0e98\u0ea0\u0ea4\u0ea6\u0ea8\u0ea9\u0eac\u0eba\u0ebe\u0ebf\u0ec5\u0ec7\u0ece\u0ecf\u0eda\u0edb\u0ede-\u0eff\u0f48\u0f6d-\u0f70\u0f98\u0fbd\u0fcd\u0fdb-\u0fff\u10c6-\u10cf\u10fd-\u10ff\u1249\u124e\u124f\u1257\u1259\u125e\u125f\u1289\u128e\u128f\u12b1\u12b6\u12b7\u12bf\u12c1\u12c6\u12c7\u12d7\u1311\u1316\u1317\u135b\u135c\u137d-\u137f\u139a-\u139f\u13f5-\u13ff\u169d-\u169f\u16f1-\u16ff\u170d\u1715-\u171f\u1737-\u173f\u1754-\u175f\u176d\u1771\u1774-\u177f\u17de\u17df\u17ea-\u17ef\u17fa-\u17ff\u180f\u181a-\u181f\u1878-\u187f\u18ab-\u18af\u18f6-\u18ff\u191d-\u191f\u192c-\u192f\u193c-\u193f\u1941-\u1943\u196e\u196f\u1975-\u197f\u19ac-\u19af\u19ca-\u19cf\u19db-\u19dd\u1a1c\u1a1d\u1a5f\u1a7d\u1a7e\u1a8a-\u1a8f\u1a9a-\u1a9f\u1aae-\u1aff\u1b4c-\u1b4f\u1b7d-\u1b7f\u1bab-\u1bad\u1bba-\u1bbf\u1bf4-\u1bfb\u1c38-\u1c3a\u1c4a-\u1c4c\u1c80-\u1ccf\u1cf3-\u1cff\u1de7-\u1dfb\u1f16\u1f17\u1f1e\u1f1f\u1f46\u1f47\u1f4e\u1f4f\u1f58\u1f5a\u1f5c\u1f5e\u1f7e\u1f7f\u1fb5\u1fc5\u1fd4\u1fd5\u1fdc\u1ff0\u1ff1\u1ff5\u1fff\u2065-\u2069\u2072\u2073\u208f\u209d-\u209f\u20ba-\u20cf\u20f1-\u20ff\u218a-\u218f\u23f4-\u23ff\u2427-\u243f\u244b-\u245f\u2700\u27cb\u27cd\u2b4d-\u2b4f\u2b5a-\u2bff\u2c2f\u2c5f\u2cf2-\u2cf8\u2d26-\u2d2f\u2d66-\u2d6e\u2d71-\u2d7e\u2d97-\u2d9f\u2da7\u2daf\u2db7\u2dbf\u2dc7\u2dcf\u2dd7\u2ddf\u2e32-\u2e7f\u2e9a\u2ef4-\u2eff\u2fd6-\u2fef\u2ffc-\u2fff\u3040\u3097\u3098\u3100-\u3104\u312e-\u3130\u318f\u31bb-\u31bf\u31e4-\u31ef\u321f\u32ff\u4db6-\u4dbf\u9fcc-\u9fff\ua48d-\ua48f\ua4c7-\ua4cf\ua62c-\ua63f\ua674-\ua67b\ua698-\ua69f\ua6f8-\ua6ff\ua78f\ua792-\ua79f\ua7aa-\ua7f9\ua82c-\ua82f\ua83a-\ua83f\ua878-\ua87f\ua8c5-\ua8cd\ua8da-\ua8df\ua8fc-\ua8ff\ua954-\ua95e\ua97d-\ua97f\ua9ce\ua9da-\ua9dd\ua9e0-\ua9ff\uaa37-\uaa3f\uaa4e\uaa4f\uaa5a\uaa5b\uaa7c-\uaa7f\uaac3-\uaada\uaae0-\uab00\uab07\uab08\uab0f\uab10\uab17-\uab1f\uab27\uab2f-\uabbf\uabee\uabef\uabfa-\uabff\ud7a4-\ud7af\ud7c7-\ud7ca\ud7fc-\ud7ff\ufa2e\ufa2f\ufa6e\ufa6f\ufada-\ufaff\ufb07-\ufb12\ufb18-\ufb1c\ufb37\ufb3d\ufb3f\ufb42\ufb45\ufbc2-\ufbd2\ufd40-\ufd4f\ufd90\ufd91\ufdc8-\ufdef\ufdfe\ufdff\ufe1a-\ufe1f\ufe27-\ufe2f\ufe53\ufe67\ufe6c-\ufe6f\ufe75\ufefd\ufefe\uff00\uffbf-\uffc1\uffc8\uffc9\uffd0\uffd1\uffd8\uffd9\uffdd-\uffdf\uffe7\uffef-\ufff8\ufffe\uffff]",
-		Lu: "[\u0041-\u005a\u00c0-\u00d6\u00d8-\u00de\u0100\u0102\u0104\u0106\u0108\u010a\u010c\u010e\u0110\u0112\u0114\u0116\u0118\u011a\u011c\u011e\u0120\u0122\u0124\u0126\u0128\u012a\u012c\u012e\u0130\u0132\u0134\u0136\u0139\u013b\u013d\u013f\u0141\u0143\u0145\u0147\u014a\u014c\u014e\u0150\u0152\u0154\u0156\u0158\u015a\u015c\u015e\u0160\u0162\u0164\u0166\u0168\u016a\u016c\u016e\u0170\u0172\u0174\u0176\u0178\u0179\u017b\u017d\u0181\u0182\u0184\u0186\u0187\u0189-\u018b\u018e-\u0191\u0193\u0194\u0196-\u0198\u019c\u019d\u019f\u01a0\u01a2\u01a4\u01a6\u01a7\u01a9\u01ac\u01ae\u01af\u01b1-\u01b3\u01b5\u01b7\u01b8\u01bc\u01c4\u01c7\u01ca\u01cd\u01cf\u01d1\u01d3\u01d5\u01d7\u01d9\u01db\u01de\u01e0\u01e2\u01e4\u01e6\u01e8\u01ea\u01ec\u01ee\u01f1\u01f4\u01f6-\u01f8\u01fa\u01fc\u01fe\u0200\u0202\u0204\u0206\u0208\u020a\u020c\u020e\u0210\u0212\u0214\u0216\u0218\u021a\u021c\u021e\u0220\u0222\u0224\u0226\u0228\u022a\u022c\u022e\u0230\u0232\u023a\u023b\u023d\u023e\u0241\u0243-\u0246\u0248\u024a\u024c\u024e\u0370\u0372\u0376\u0386\u0388-\u038a\u038c\u038e\u038f\u0391-\u03a1\u03a3-\u03ab\u03cf\u03d2-\u03d4\u03d8\u03da\u03dc\u03de\u03e0\u03e2\u03e4\u03e6\u03e8\u03ea\u03ec\u03ee\u03f4\u03f7\u03f9\u03fa\u03fd-\u042f\u0460\u0462\u0464\u0466\u0468\u046a\u046c\u046e\u0470\u0472\u0474\u0476\u0478\u047a\u047c\u047e\u0480\u048a\u048c\u048e\u0490\u0492\u0494\u0496\u0498\u049a\u049c\u049e\u04a0\u04a2\u04a4\u04a6\u04a8\u04aa\u04ac\u04ae\u04b0\u04b2\u04b4\u04b6\u04b8\u04ba\u04bc\u04be\u04c0\u04c1\u04c3\u04c5\u04c7\u04c9\u04cb\u04cd\u04d0\u04d2\u04d4\u04d6\u04d8\u04da\u04dc\u04de\u04e0\u04e2\u04e4\u04e6\u04e8\u04ea\u04ec\u04ee\u04f0\u04f2\u04f4\u04f6\u04f8\u04fa\u04fc\u04fe\u0500\u0502\u0504\u0506\u0508\u050a\u050c\u050e\u0510\u0512\u0514\u0516\u0518\u051a\u051c\u051e\u0520\u0522\u0524\u0526\u0531-\u0556\u10a0-\u10c5\u1e00\u1e02\u1e04\u1e06\u1e08\u1e0a\u1e0c\u1e0e\u1e10\u1e12\u1e14\u1e16\u1e18\u1e1a\u1e1c\u1e1e\u1e20\u1e22\u1e24\u1e26\u1e28\u1e2a\u1e2c\u1e2e\u1e30\u1e32\u1e34\u1e36\u1e38\u1e3a\u1e3c\u1e3e\u1e40\u1e42\u1e44\u1e46\u1e48\u1e4a\u1e4c\u1e4e\u1e50\u1e52\u1e54\u1e56\u1e58\u1e5a\u1e5c\u1e5e\u1e60\u1e62\u1e64\u1e66\u1e68\u1e6a\u1e6c\u1e6e\u1e70\u1e72\u1e74\u1e76\u1e78\u1e7a\u1e7c\u1e7e\u1e80\u1e82\u1e84\u1e86\u1e88\u1e8a\u1e8c\u1e8e\u1e90\u1e92\u1e94\u1e9e\u1ea0\u1ea2\u1ea4\u1ea6\u1ea8\u1eaa\u1eac\u1eae\u1eb0\u1eb2\u1eb4\u1eb6\u1eb8\u1eba\u1ebc\u1ebe\u1ec0\u1ec2\u1ec4\u1ec6\u1ec8\u1eca\u1ecc\u1ece\u1ed0\u1ed2\u1ed4\u1ed6\u1ed8\u1eda\u1edc\u1ede\u1ee0\u1ee2\u1ee4\u1ee6\u1ee8\u1eea\u1eec\u1eee\u1ef0\u1ef2\u1ef4\u1ef6\u1ef8\u1efa\u1efc\u1efe\u1f08-\u1f0f\u1f18-\u1f1d\u1f28-\u1f2f\u1f38-\u1f3f\u1f48-\u1f4d\u1f59\u1f5b\u1f5d\u1f5f\u1f68-\u1f6f\u1fb8-\u1fbb\u1fc8-\u1fcb\u1fd8-\u1fdb\u1fe8-\u1fec\u1ff8-\u1ffb\u2102\u2107\u210b-\u210d\u2110-\u2112\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u2130-\u2133\u213e\u213f\u2145\u2183\u2c00-\u2c2e\u2c60\u2c62-\u2c64\u2c67\u2c69\u2c6b\u2c6d-\u2c70\u2c72\u2c75\u2c7e-\u2c80\u2c82\u2c84\u2c86\u2c88\u2c8a\u2c8c\u2c8e\u2c90\u2c92\u2c94\u2c96\u2c98\u2c9a\u2c9c\u2c9e\u2ca0\u2ca2\u2ca4\u2ca6\u2ca8\u2caa\u2cac\u2cae\u2cb0\u2cb2\u2cb4\u2cb6\u2cb8\u2cba\u2cbc\u2cbe\u2cc0\u2cc2\u2cc4\u2cc6\u2cc8\u2cca\u2ccc\u2cce\u2cd0\u2cd2\u2cd4\u2cd6\u2cd8\u2cda\u2cdc\u2cde\u2ce0\u2ce2\u2ceb\u2ced\ua640\ua642\ua644\ua646\ua648\ua64a\ua64c\ua64e\ua650\ua652\ua654\ua656\ua658\ua65a\ua65c\ua65e\ua660\ua662\ua664\ua666\ua668\ua66a\ua66c\ua680\ua682\ua684\ua686\ua688\ua68a\ua68c\ua68e\ua690\ua692\ua694\ua696\ua722\ua724\ua726\ua728\ua72a\ua72c\ua72e\ua732\ua734\ua736\ua738\ua73a\ua73c\ua73e\ua740\ua742\ua744\ua746\ua748\ua74a\ua74c\ua74e\ua750\ua752\ua754\ua756\ua758\ua75a\ua75c\ua75e\ua760\ua762\ua764\ua766\ua768\ua76a\ua76c\ua76e\ua779\ua77b\ua77d\ua77e\ua780\ua782\ua784\ua786\ua78b\ua78d\ua790\ua7a0\ua7a2\ua7a4\ua7a6\ua7a8\uff21-\uff3a]",
-		Ll: "[\u0061-\u007a\u00aa\u00b5\u00ba\u00df-\u00f6\u00f8-\u00ff\u0101\u0103\u0105\u0107\u0109\u010b\u010d\u010f\u0111\u0113\u0115\u0117\u0119\u011b\u011d\u011f\u0121\u0123\u0125\u0127\u0129\u012b\u012d\u012f\u0131\u0133\u0135\u0137\u0138\u013a\u013c\u013e\u0140\u0142\u0144\u0146\u0148\u0149\u014b\u014d\u014f\u0151\u0153\u0155\u0157\u0159\u015b\u015d\u015f\u0161\u0163\u0165\u0167\u0169\u016b\u016d\u016f\u0171\u0173\u0175\u0177\u017a\u017c\u017e-\u0180\u0183\u0185\u0188\u018c\u018d\u0192\u0195\u0199-\u019b\u019e\u01a1\u01a3\u01a5\u01a8\u01aa\u01ab\u01ad\u01b0\u01b4\u01b6\u01b9\u01ba\u01bd-\u01bf\u01c6\u01c9\u01cc\u01ce\u01d0\u01d2\u01d4\u01d6\u01d8\u01da\u01dc\u01dd\u01df\u01e1\u01e3\u01e5\u01e7\u01e9\u01eb\u01ed\u01ef\u01f0\u01f3\u01f5\u01f9\u01fb\u01fd\u01ff\u0201\u0203\u0205\u0207\u0209\u020b\u020d\u020f\u0211\u0213\u0215\u0217\u0219\u021b\u021d\u021f\u0221\u0223\u0225\u0227\u0229\u022b\u022d\u022f\u0231\u0233-\u0239\u023c\u023f\u0240\u0242\u0247\u0249\u024b\u024d\u024f-\u0293\u0295-\u02af\u0371\u0373\u0377\u037b-\u037d\u0390\u03ac-\u03ce\u03d0\u03d1\u03d5-\u03d7\u03d9\u03db\u03dd\u03df\u03e1\u03e3\u03e5\u03e7\u03e9\u03eb\u03ed\u03ef-\u03f3\u03f5\u03f8\u03fb\u03fc\u0430-\u045f\u0461\u0463\u0465\u0467\u0469\u046b\u046d\u046f\u0471\u0473\u0475\u0477\u0479\u047b\u047d\u047f\u0481\u048b\u048d\u048f\u0491\u0493\u0495\u0497\u0499\u049b\u049d\u049f\u04a1\u04a3\u04a5\u04a7\u04a9\u04ab\u04ad\u04af\u04b1\u04b3\u04b5\u04b7\u04b9\u04bb\u04bd\u04bf\u04c2\u04c4\u04c6\u04c8\u04ca\u04cc\u04ce\u04cf\u04d1\u04d3\u04d5\u04d7\u04d9\u04db\u04dd\u04df\u04e1\u04e3\u04e5\u04e7\u04e9\u04eb\u04ed\u04ef\u04f1\u04f3\u04f5\u04f7\u04f9\u04fb\u04fd\u04ff\u0501\u0503\u0505\u0507\u0509\u050b\u050d\u050f\u0511\u0513\u0515\u0517\u0519\u051b\u051d\u051f\u0521\u0523\u0525\u0527\u0561-\u0587\u1d00-\u1d2b\u1d62-\u1d77\u1d79-\u1d9a\u1e01\u1e03\u1e05\u1e07\u1e09\u1e0b\u1e0d\u1e0f\u1e11\u1e13\u1e15\u1e17\u1e19\u1e1b\u1e1d\u1e1f\u1e21\u1e23\u1e25\u1e27\u1e29\u1e2b\u1e2d\u1e2f\u1e31\u1e33\u1e35\u1e37\u1e39\u1e3b\u1e3d\u1e3f\u1e41\u1e43\u1e45\u1e47\u1e49\u1e4b\u1e4d\u1e4f\u1e51\u1e53\u1e55\u1e57\u1e59\u1e5b\u1e5d\u1e5f\u1e61\u1e63\u1e65\u1e67\u1e69\u1e6b\u1e6d\u1e6f\u1e71\u1e73\u1e75\u1e77\u1e79\u1e7b\u1e7d\u1e7f\u1e81\u1e83\u1e85\u1e87\u1e89\u1e8b\u1e8d\u1e8f\u1e91\u1e93\u1e95-\u1e9d\u1e9f\u1ea1\u1ea3\u1ea5\u1ea7\u1ea9\u1eab\u1ead\u1eaf\u1eb1\u1eb3\u1eb5\u1eb7\u1eb9\u1ebb\u1ebd\u1ebf\u1ec1\u1ec3\u1ec5\u1ec7\u1ec9\u1ecb\u1ecd\u1ecf\u1ed1\u1ed3\u1ed5\u1ed7\u1ed9\u1edb\u1edd\u1edf\u1ee1\u1ee3\u1ee5\u1ee7\u1ee9\u1eeb\u1eed\u1eef\u1ef1\u1ef3\u1ef5\u1ef7\u1ef9\u1efb\u1efd\u1eff-\u1f07\u1f10-\u1f15\u1f20-\u1f27\u1f30-\u1f37\u1f40-\u1f45\u1f50-\u1f57\u1f60-\u1f67\u1f70-\u1f7d\u1f80-\u1f87\u1f90-\u1f97\u1fa0-\u1fa7\u1fb0-\u1fb4\u1fb6\u1fb7\u1fbe\u1fc2-\u1fc4\u1fc6\u1fc7\u1fd0-\u1fd3\u1fd6\u1fd7\u1fe0-\u1fe7\u1ff2-\u1ff4\u1ff6\u1ff7\u210a\u210e\u210f\u2113\u212f\u2134\u2139\u213c\u213d\u2146-\u2149\u214e\u2184\u2c30-\u2c5e\u2c61\u2c65\u2c66\u2c68\u2c6a\u2c6c\u2c71\u2c73\u2c74\u2c76-\u2c7c\u2c81\u2c83\u2c85\u2c87\u2c89\u2c8b\u2c8d\u2c8f\u2c91\u2c93\u2c95\u2c97\u2c99\u2c9b\u2c9d\u2c9f\u2ca1\u2ca3\u2ca5\u2ca7\u2ca9\u2cab\u2cad\u2caf\u2cb1\u2cb3\u2cb5\u2cb7\u2cb9\u2cbb\u2cbd\u2cbf\u2cc1\u2cc3\u2cc5\u2cc7\u2cc9\u2ccb\u2ccd\u2ccf\u2cd1\u2cd3\u2cd5\u2cd7\u2cd9\u2cdb\u2cdd\u2cdf\u2ce1\u2ce3\u2ce4\u2cec\u2cee\u2d00-\u2d25\ua641\ua643\ua645\ua647\ua649\ua64b\ua64d\ua64f\ua651\ua653\ua655\ua657\ua659\ua65b\ua65d\ua65f\ua661\ua663\ua665\ua667\ua669\ua66b\ua66d\ua681\ua683\ua685\ua687\ua689\ua68b\ua68d\ua68f\ua691\ua693\ua695\ua697\ua723\ua725\ua727\ua729\ua72b\ua72d\ua72f-\ua731\ua733\ua735\ua737\ua739\ua73b\ua73d\ua73f\ua741\ua743\ua745\ua747\ua749\ua74b\ua74d\ua74f\ua751\ua753\ua755\ua757\ua759\ua75b\ua75d\ua75f\ua761\ua763\ua765\ua767\ua769\ua76b\ua76d\ua76f\ua771-\ua778\ua77a\ua77c\ua77f\ua781\ua783\ua785\ua787\ua78c\ua78e\ua791\ua7a1\ua7a3\ua7a5\ua7a7\ua7a9\ua7fa\ufb00-\ufb06\ufb13-\ufb17\uff41-\uff5a]",
-		Lt: "[\u01c5\u01c8\u01cb\u01f2\u1f88-\u1f8f\u1f98-\u1f9f\u1fa8-\u1faf\u1fbc\u1fcc\u1ffc]",
-		Lm: "[\u02b0-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0374\u037a\u0559\u0640\u06e5\u06e6\u07f4\u07f5\u07fa\u081a\u0824\u0828\u0971\u0e46\u0ec6\u10fc\u17d7\u1843\u1aa7\u1c78-\u1c7d\u1d2c-\u1d61\u1d78\u1d9b-\u1dbf\u2071\u207f\u2090-\u209c\u2c7d\u2d6f\u2e2f\u3005\u3031-\u3035\u303b\u309d\u309e\u30fc-\u30fe\ua015\ua4f8-\ua4fd\ua60c\ua67f\ua717-\ua71f\ua770\ua788\ua9cf\uaa70\uaadd\uff70\uff9e\uff9f]",
-		Lo: "[\u01bb\u01c0-\u01c3\u0294\u05d0-\u05ea\u05f0-\u05f2\u0620-\u063f\u0641-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u0800-\u0815\u0840-\u0858\u0904-\u0939\u093d\u0950\u0958-\u0961\u0972-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e45\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0edc\u0edd\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10d0-\u10fa\u1100-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17dc\u1820-\u1842\u1844-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bc0-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c77\u1ce9-\u1cec\u1cee-\u1cf1\u2135-\u2138\u2d30-\u2d65\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u3006\u303c\u3041-\u3096\u309f\u30a1-\u30fa\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcb\ua000-\ua014\ua016-\ua48c\ua4d0-\ua4f7\ua500-\ua60b\ua610-\ua61f\ua62a\ua62b\ua66e\ua6a0-\ua6e5\ua7fb-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa6f\uaa71-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb\uaadc\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa2d\ufa30-\ufa6d\ufa70-\ufad9\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff66-\uff6f\uff71-\uff9d\uffa0-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc]",
-		Mn: "[\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u064b-\u065f\u0670\u06d6-\u06dc\u06df-\u06e4\u06e7\u06e8\u06ea-\u06ed\u0711\u0730-\u074a\u07a6-\u07b0\u07eb-\u07f3\u0816-\u0819\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0859-\u085b\u0900-\u0902\u093a\u093c\u0941-\u0948\u094d\u0951-\u0957\u0962\u0963\u0981\u09bc\u09c1-\u09c4\u09cd\u09e2\u09e3\u0a01\u0a02\u0a3c\u0a41\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a70\u0a71\u0a75\u0a81\u0a82\u0abc\u0ac1-\u0ac5\u0ac7\u0ac8\u0acd\u0ae2\u0ae3\u0b01\u0b3c\u0b3f\u0b41-\u0b44\u0b4d\u0b56\u0b62\u0b63\u0b82\u0bc0\u0bcd\u0c3e-\u0c40\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62\u0c63\u0cbc\u0cbf\u0cc6\u0ccc\u0ccd\u0ce2\u0ce3\u0d41-\u0d44\u0d4d\u0d62\u0d63\u0dca\u0dd2-\u0dd4\u0dd6\u0e31\u0e34-\u0e3a\u0e47-\u0e4e\u0eb1\u0eb4-\u0eb9\u0ebb\u0ebc\u0ec8-\u0ecd\u0f18\u0f19\u0f35\u0f37\u0f39\u0f71-\u0f7e\u0f80-\u0f84\u0f86\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u102d-\u1030\u1032-\u1037\u1039\u103a\u103d\u103e\u1058\u1059\u105e-\u1060\u1071-\u1074\u1082\u1085\u1086\u108d\u109d\u135d-\u135f\u1712-\u1714\u1732-\u1734\u1752\u1753\u1772\u1773\u17b7-\u17bd\u17c6\u17c9-\u17d3\u17dd\u180b-\u180d\u18a9\u1920-\u1922\u1927\u1928\u1932\u1939-\u193b\u1a17\u1a18\u1a56\u1a58-\u1a5e\u1a60\u1a62\u1a65-\u1a6c\u1a73-\u1a7c\u1a7f\u1b00-\u1b03\u1b34\u1b36-\u1b3a\u1b3c\u1b42\u1b6b-\u1b73\u1b80\u1b81\u1ba2-\u1ba5\u1ba8\u1ba9\u1be6\u1be8\u1be9\u1bed\u1bef-\u1bf1\u1c2c-\u1c33\u1c36\u1c37\u1cd0-\u1cd2\u1cd4-\u1ce0\u1ce2-\u1ce8\u1ced\u1dc0-\u1de6\u1dfc-\u1dff\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2cef-\u2cf1\u2d7f\u2de0-\u2dff\u302a-\u302f\u3099\u309a\ua66f\ua67c\ua67d\ua6f0\ua6f1\ua802\ua806\ua80b\ua825\ua826\ua8c4\ua8e0-\ua8f1\ua926-\ua92d\ua947-\ua951\ua980-\ua982\ua9b3\ua9b6-\ua9b9\ua9bc\uaa29-\uaa2e\uaa31\uaa32\uaa35\uaa36\uaa43\uaa4c\uaab0\uaab2-\uaab4\uaab7\uaab8\uaabe\uaabf\uaac1\uabe5\uabe8\uabed\ufb1e\ufe00-\ufe0f\ufe20-\ufe26]",
-		Me: "[\u0488\u0489\u20dd-\u20e0\u20e2-\u20e4\ua670-\ua672]",
-		Mc: "[\u0903\u093b\u093e-\u0940\u0949-\u094c\u094e\u094f\u0982\u0983\u09be-\u09c0\u09c7\u09c8\u09cb\u09cc\u09d7\u0a03\u0a3e-\u0a40\u0a83\u0abe-\u0ac0\u0ac9\u0acb\u0acc\u0b02\u0b03\u0b3e\u0b40\u0b47\u0b48\u0b4b\u0b4c\u0b57\u0bbe\u0bbf\u0bc1\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcc\u0bd7\u0c01-\u0c03\u0c41-\u0c44\u0c82\u0c83\u0cbe\u0cc0-\u0cc4\u0cc7\u0cc8\u0cca\u0ccb\u0cd5\u0cd6\u0d02\u0d03\u0d3e-\u0d40\u0d46-\u0d48\u0d4a-\u0d4c\u0d57\u0d82\u0d83\u0dcf-\u0dd1\u0dd8-\u0ddf\u0df2\u0df3\u0f3e\u0f3f\u0f7f\u102b\u102c\u1031\u1038\u103b\u103c\u1056\u1057\u1062-\u1064\u1067-\u106d\u1083\u1084\u1087-\u108c\u108f\u109a-\u109c\u17b6\u17be-\u17c5\u17c7\u17c8\u1923-\u1926\u1929-\u192b\u1930\u1931\u1933-\u1938\u19b0-\u19c0\u19c8\u19c9\u1a19-\u1a1b\u1a55\u1a57\u1a61\u1a63\u1a64\u1a6d-\u1a72\u1b04\u1b35\u1b3b\u1b3d-\u1b41\u1b43\u1b44\u1b82\u1ba1\u1ba6\u1ba7\u1baa\u1be7\u1bea-\u1bec\u1bee\u1bf2\u1bf3\u1c24-\u1c2b\u1c34\u1c35\u1ce1\u1cf2\ua823\ua824\ua827\ua880\ua881\ua8b4-\ua8c3\ua952\ua953\ua983\ua9b4\ua9b5\ua9ba\ua9bb\ua9bd-\ua9c0\uaa2f\uaa30\uaa33\uaa34\uaa4d\uaa7b\uabe3\uabe4\uabe6\uabe7\uabe9\uabea\uabec]",
-		Nd: "[\u0030-\u0039\u0660-\u0669\u06f0-\u06f9\u07c0-\u07c9\u0966-\u096f\u09e6-\u09ef\u0a66-\u0a6f\u0ae6-\u0aef\u0b66-\u0b6f\u0be6-\u0bef\u0c66-\u0c6f\u0ce6-\u0cef\u0d66-\u0d6f\u0e50-\u0e59\u0ed0-\u0ed9\u0f20-\u0f29\u1040-\u1049\u1090-\u1099\u17e0-\u17e9\u1810-\u1819\u1946-\u194f\u19d0-\u19d9\u1a80-\u1a89\u1a90-\u1a99\u1b50-\u1b59\u1bb0-\u1bb9\u1c40-\u1c49\u1c50-\u1c59\ua620-\ua629\ua8d0-\ua8d9\ua900-\ua909\ua9d0-\ua9d9\uaa50-\uaa59\uabf0-\uabf9\uff10-\uff19]",
-		Nl: "[\u16ee-\u16f0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303a\ua6e6-\ua6ef]",
-		No: "[\u00b2\u00b3\u00b9\u00bc-\u00be\u09f4-\u09f9\u0b72-\u0b77\u0bf0-\u0bf2\u0c78-\u0c7e\u0d70-\u0d75\u0f2a-\u0f33\u1369-\u137c\u17f0-\u17f9\u19da\u2070\u2074-\u2079\u2080-\u2089\u2150-\u215f\u2189\u2460-\u249b\u24ea-\u24ff\u2776-\u2793\u2cfd\u3192-\u3195\u3220-\u3229\u3251-\u325f\u3280-\u3289\u32b1-\u32bf\ua830-\ua835]",
-		Zs: "[\u0020\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]",
-		Zl: "[\u2028]",
-		Zp: "[\u2029]",
-		Cc: "[\u0000-\u001f\u007f-\u009f]",
-		Cf: "[\u00ad\u0600-\u0603\u06dd\u070f\u17b4\u17b5\u200b-\u200f\u202a-\u202e\u2060-\u2064\u206a-\u206f\ufeff\ufff9-\ufffb]",
-		Cs: "[\ud800-\udfff]",
-		Co: "[\ue000-\uf8ff]",
-		Ps: "[\u0028\u005b\u007b\u0f3a\u0f3c\u169b\u201a\u201e\u2045\u207d\u208d\u2329\u2768\u276a\u276c\u276e\u2770\u2772\u2774\u27c5\u27e6\u27e8\u27ea\u27ec\u27ee\u2983\u2985\u2987\u2989\u298b\u298d\u298f\u2991\u2993\u2995\u2997\u29d8\u29da\u29fc\u2e22\u2e24\u2e26\u2e28\u3008\u300a\u300c\u300e\u3010\u3014\u3016\u3018\u301a\u301d\ufd3e\ufe17\ufe35\ufe37\ufe39\ufe3b\ufe3d\ufe3f\ufe41\ufe43\ufe47\ufe59\ufe5b\ufe5d\uff08\uff3b\uff5b\uff5f\uff62]",
-		Pd: "[\u002d\u058a\u05be\u1400\u1806\u2010-\u2015\u2e17\u2e1a\u301c\u3030\u30a0\ufe31\ufe32\ufe58\ufe63\uff0d]",
-		Pc: "[\u005f\u203f\u2040\u2054\ufe33\ufe34\ufe4d-\ufe4f\uff3f]",
-		Pe: "[\u0029\\\u005d\u007d\u0f3b\u0f3d\u169c\u2046\u207e\u208e\u232a\u2769\u276b\u276d\u276f\u2771\u2773\u2775\u27c6\u27e7\u27e9\u27eb\u27ed\u27ef\u2984\u2986\u2988\u298a\u298c\u298e\u2990\u2992\u2994\u2996\u2998\u29d9\u29db\u29fd\u2e23\u2e25\u2e27\u2e29\u3009\u300b\u300d\u300f\u3011\u3015\u3017\u3019\u301b\u301e\u301f\ufd3f\ufe18\ufe36\ufe38\ufe3a\ufe3c\ufe3e\ufe40\ufe42\ufe44\ufe48\ufe5a\ufe5c\ufe5e\uff09\uff3d\uff5d\uff60\uff63]",
-		Sm: "[\u002b\u003c-\u003e\u007c\u007e\u00ac\u00b1\u00d7\u00f7\u03f6\u0606-\u0608\u2044\u2052\u207a-\u207c\u208a-\u208c\u2118\u2140-\u2144\u214b\u2190-\u2194\u219a\u219b\u21a0\u21a3\u21a6\u21ae\u21ce\u21cf\u21d2\u21d4\u21f4-\u22ff\u2308-\u230b\u2320\u2321\u237c\u239b-\u23b3\u23dc-\u23e1\u25b7\u25c1\u25f8-\u25ff\u266f\u27c0-\u27c4\u27c7-\u27ca\u27cc\u27ce-\u27e5\u27f0-\u27ff\u2900-\u2982\u2999-\u29d7\u29dc-\u29fb\u29fe-\u2aff\u2b30-\u2b44\u2b47-\u2b4c\ufb29\ufe62\ufe64-\ufe66\uff0b\uff1c-\uff1e\uff5c\uff5e\uffe2\uffe9-\uffec]",
-		Po: "[\u0021-\u0023\u0025-\u0027\u002a\u002c\u002e\u002f\u003a\u003b\u003f\u0040\u005c\u00a1\u00b7\u00bf\u037e\u0387\u055a-\u055f\u0589\u05c0\u05c3\u05c6\u05f3\u05f4\u0609\u060a\u060c\u060d\u061b\u061e\u061f\u066a-\u066d\u06d4\u0700-\u070d\u07f7-\u07f9\u0830-\u083e\u085e\u0964\u0965\u0970\u0df4\u0e4f\u0e5a\u0e5b\u0f04-\u0f12\u0f85\u0fd0-\u0fd4\u0fd9\u0fda\u104a-\u104f\u10fb\u1361-\u1368\u166d\u166e\u16eb-\u16ed\u1735\u1736\u17d4-\u17d6\u17d8-\u17da\u1800-\u1805\u1807-\u180a\u1944\u1945\u1a1e\u1a1f\u1aa0-\u1aa6\u1aa8-\u1aad\u1b5a-\u1b60\u1bfc-\u1bff\u1c3b-\u1c3f\u1c7e\u1c7f\u1cd3\u2016\u2017\u2020-\u2027\u2030-\u2038\u203b-\u203e\u2041-\u2043\u2047-\u2051\u2053\u2055-\u205e\u2cf9-\u2cfc\u2cfe\u2cff\u2d70\u2e00\u2e01\u2e06-\u2e08\u2e0b\u2e0e-\u2e16\u2e18\u2e19\u2e1b\u2e1e\u2e1f\u2e2a-\u2e2e\u2e30\u2e31\u3001-\u3003\u303d\u30fb\ua4fe\ua4ff\ua60d-\ua60f\ua673\ua67e\ua6f2-\ua6f7\ua874-\ua877\ua8ce\ua8cf\ua8f8-\ua8fa\ua92e\ua92f\ua95f\ua9c1-\ua9cd\ua9de\ua9df\uaa5c-\uaa5f\uaade\uaadf\uabeb\ufe10-\ufe16\ufe19\ufe30\ufe45\ufe46\ufe49-\ufe4c\ufe50-\ufe52\ufe54-\ufe57\ufe5f-\ufe61\ufe68\ufe6a\ufe6b\uff01-\uff03\uff05-\uff07\uff0a\uff0c\uff0e\uff0f\uff1a\uff1b\uff1f\uff20\uff3c\uff61\uff64\uff65]",
-		Sk: "[\u005e\u0060\u00a8\u00af\u00b4\u00b8\u02c2-\u02c5\u02d2-\u02df\u02e5-\u02eb\u02ed\u02ef-\u02ff\u0375\u0384\u0385\u1fbd\u1fbf-\u1fc1\u1fcd-\u1fcf\u1fdd-\u1fdf\u1fed-\u1fef\u1ffd\u1ffe\u309b\u309c\ua700-\ua716\ua720\ua721\ua789\ua78a\ufbb2-\ufbc1\uff3e\uff40\uffe3]",
-		Sc: "[\u0024\u00a2-\u00a5\u060b\u09f2\u09f3\u09fb\u0af1\u0bf9\u0e3f\u17db\u20a0-\u20b9\ua838\ufdfc\ufe69\uff04\uffe0\uffe1\uffe5\uffe6]",
-		Pi: "[\u00ab\u2018\u201b\u201c\u201f\u2039\u2e02\u2e04\u2e09\u2e0c\u2e1c\u2e20]",
-		So: "[\u00a6\u00a7\u00a9\u00ae\u00b0\u00b6\u0482\u060e\u060f\u06de\u06e9\u06fd\u06fe\u07f6\u09fa\u0b70\u0bf3-\u0bf8\u0bfa\u0c7f\u0d79\u0f01-\u0f03\u0f13-\u0f17\u0f1a-\u0f1f\u0f34\u0f36\u0f38\u0fbe-\u0fc5\u0fc7-\u0fcc\u0fce\u0fcf\u0fd5-\u0fd8\u109e\u109f\u1360\u1390-\u1399\u1940\u19de-\u19ff\u1b61-\u1b6a\u1b74-\u1b7c\u2100\u2101\u2103-\u2106\u2108\u2109\u2114\u2116\u2117\u211e-\u2123\u2125\u2127\u2129\u212e\u213a\u213b\u214a\u214c\u214d\u214f\u2195-\u2199\u219c-\u219f\u21a1\u21a2\u21a4\u21a5\u21a7-\u21ad\u21af-\u21cd\u21d0\u21d1\u21d3\u21d5-\u21f3\u2300-\u2307\u230c-\u231f\u2322-\u2328\u232b-\u237b\u237d-\u239a\u23b4-\u23db\u23e2-\u23f3\u2400-\u2426\u2440-\u244a\u249c-\u24e9\u2500-\u25b6\u25b8-\u25c0\u25c2-\u25f7\u2600-\u266e\u2670-\u26ff\u2701-\u2767\u2794-\u27bf\u2800-\u28ff\u2b00-\u2b2f\u2b45\u2b46\u2b50-\u2b59\u2ce5-\u2cea\u2e80-\u2e99\u2e9b-\u2ef3\u2f00-\u2fd5\u2ff0-\u2ffb\u3004\u3012\u3013\u3020\u3036\u3037\u303e\u303f\u3190\u3191\u3196-\u319f\u31c0-\u31e3\u3200-\u321e\u322a-\u3250\u3260-\u327f\u328a-\u32b0\u32c0-\u32fe\u3300-\u33ff\u4dc0-\u4dff\ua490-\ua4c6\ua828-\ua82b\ua836\ua837\ua839\uaa77-\uaa79\ufdfd\uffe4\uffe8\uffed\uffee\ufffc\ufffd]",
-		Pf: "[\u00bb\u2019\u201d\u203a\u2e03\u2e05\u2e0a\u2e0d\u2e1d\u2e21]"
-	};
+	
 
 	//jscs:enable
 	$.ig.util.netRegexToJS = function (netPattern) {
@@ -6620,48 +5313,6 @@
 
 		return r;
 	};
-	/* jshint +W016*/
-
-	$.ig.util.invokeCallback = function (callback, args) {
-		if (callback) {
-			if ($.type(callback) === "string" &&
-				window[ callback ] && $.type(window[ callback ]) === "function") {
-				callback = window[ callback ];
-			}
-			if ($.type(callback) === "function") {
-				callback.apply(window, args);
-			}
-		}
-	};
-
-	// M.H. 5 Mar 2013 Fix for bug #134982: When you instantiate dataSource object and there isn't reference to jQueryUI js error is thrown.
-	if ($.Widget) {
-
-		// M.H. 1 Mar 2013 Fix for bug #134534: Updating the jQuery`s version breaks most of the samples in the new samples browser
-		// In jquery-ui 1.9.2+ it is used only full name - we fix this breaking change as adding also widgetName(it is used in older versions)
-		(function (createWidget) {
-			$.Widget.prototype._createWidget = function (options, element) {
-				var el = $(element || this.defaultElement || this)[ 0 ];
-				if (el !== this) {
-					$.data(el, this.widgetName, this);
-				}
-				return createWidget.apply(this, arguments);
-			};
-		})($.Widget.prototype._createWidget);
-
-		// M.H. 21 Oct 2014 Fix for bug #183464: With jQuery UI 1.11.x destroy leaves the { widgetName: widgetInstance } pairs intact on the elements
-		// it should be removed data for this.widgetName as well
-		(function (destroy) {
-			$.Widget.prototype.destroy = function () {
-				// we should call first prototype destroy because _destroy is called before remove data for the element
-				var ret = destroy.apply(this, arguments);
-				if (this.widgetName && this.element) {
-					this.element.removeData(this.widgetName);
-				}
-				return ret;
-			};
-		})($.Widget.prototype.destroy);
-	}
 
 	/*<BeginType Name="System.SystemException" />*/
 	$.ig.util.defType("SystemException", "Error", {
@@ -7116,6 +5767,59 @@
 		};
 	};
 
+	/*! unicode_hack.js
+	Copyright (C) 2010-2012,2014  Marcelo Gibson de Castro GonÃ§alves. All rights reserved.
+
+	Copying and distribution of this file, with or without modification,
+	are permitted in any medium without royalty provided the copyright
+	notice and this notice are preserved.  This file is offered as-is,
+	without any warranty.
+	*/
+
+	// jscs:disable
+	var unicodeCategories = {
+		Cn: "[\u0378\u0379\u037f-\u0383\u038b\u038d\u03a2\u0528-\u0530\u0557\u0558\u0560\u0588\u058b-\u0590\u05c8-\u05cf\u05eb-\u05ef\u05f5-\u05ff\u0604\u0605\u061c\u061d\u070e\u074b\u074c\u07b2-\u07bf\u07fb-\u07ff\u082e\u082f\u083f\u085c\u085d\u085f-\u08ff\u0978\u0980\u0984\u098d\u098e\u0991\u0992\u09a9\u09b1\u09b3-\u09b5\u09ba\u09bb\u09c5\u09c6\u09c9\u09ca\u09cf-\u09d6\u09d8-\u09db\u09de\u09e4\u09e5\u09fc-\u0a00\u0a04\u0a0b-\u0a0e\u0a11\u0a12\u0a29\u0a31\u0a34\u0a37\u0a3a\u0a3b\u0a3d\u0a43-\u0a46\u0a49\u0a4a\u0a4e-\u0a50\u0a52-\u0a58\u0a5d\u0a5f-\u0a65\u0a76-\u0a80\u0a84\u0a8e\u0a92\u0aa9\u0ab1\u0ab4\u0aba\u0abb\u0ac6\u0aca\u0ace\u0acf\u0ad1-\u0adf\u0ae4\u0ae5\u0af0\u0af2-\u0b00\u0b04\u0b0d\u0b0e\u0b11\u0b12\u0b29\u0b31\u0b34\u0b3a\u0b3b\u0b45\u0b46\u0b49\u0b4a\u0b4e-\u0b55\u0b58-\u0b5b\u0b5e\u0b64\u0b65\u0b78-\u0b81\u0b84\u0b8b-\u0b8d\u0b91\u0b96-\u0b98\u0b9b\u0b9d\u0ba0-\u0ba2\u0ba5-\u0ba7\u0bab-\u0bad\u0bba-\u0bbd\u0bc3-\u0bc5\u0bc9\u0bce\u0bcf\u0bd1-\u0bd6\u0bd8-\u0be5\u0bfb-\u0c00\u0c04\u0c0d\u0c11\u0c29\u0c34\u0c3a-\u0c3c\u0c45\u0c49\u0c4e-\u0c54\u0c57\u0c5a-\u0c5f\u0c64\u0c65\u0c70-\u0c77\u0c80\u0c81\u0c84\u0c8d\u0c91\u0ca9\u0cb4\u0cba\u0cbb\u0cc5\u0cc9\u0cce-\u0cd4\u0cd7-\u0cdd\u0cdf\u0ce4\u0ce5\u0cf0\u0cf3-\u0d01\u0d04\u0d0d\u0d11\u0d3b\u0d3c\u0d45\u0d49\u0d4f-\u0d56\u0d58-\u0d5f\u0d64\u0d65\u0d76-\u0d78\u0d80\u0d81\u0d84\u0d97-\u0d99\u0db2\u0dbc\u0dbe\u0dbf\u0dc7-\u0dc9\u0dcb-\u0dce\u0dd5\u0dd7\u0de0-\u0df1\u0df5-\u0e00\u0e3b-\u0e3e\u0e5c-\u0e80\u0e83\u0e85\u0e86\u0e89\u0e8b\u0e8c\u0e8e-\u0e93\u0e98\u0ea0\u0ea4\u0ea6\u0ea8\u0ea9\u0eac\u0eba\u0ebe\u0ebf\u0ec5\u0ec7\u0ece\u0ecf\u0eda\u0edb\u0ede-\u0eff\u0f48\u0f6d-\u0f70\u0f98\u0fbd\u0fcd\u0fdb-\u0fff\u10c6-\u10cf\u10fd-\u10ff\u1249\u124e\u124f\u1257\u1259\u125e\u125f\u1289\u128e\u128f\u12b1\u12b6\u12b7\u12bf\u12c1\u12c6\u12c7\u12d7\u1311\u1316\u1317\u135b\u135c\u137d-\u137f\u139a-\u139f\u13f5-\u13ff\u169d-\u169f\u16f1-\u16ff\u170d\u1715-\u171f\u1737-\u173f\u1754-\u175f\u176d\u1771\u1774-\u177f\u17de\u17df\u17ea-\u17ef\u17fa-\u17ff\u180f\u181a-\u181f\u1878-\u187f\u18ab-\u18af\u18f6-\u18ff\u191d-\u191f\u192c-\u192f\u193c-\u193f\u1941-\u1943\u196e\u196f\u1975-\u197f\u19ac-\u19af\u19ca-\u19cf\u19db-\u19dd\u1a1c\u1a1d\u1a5f\u1a7d\u1a7e\u1a8a-\u1a8f\u1a9a-\u1a9f\u1aae-\u1aff\u1b4c-\u1b4f\u1b7d-\u1b7f\u1bab-\u1bad\u1bba-\u1bbf\u1bf4-\u1bfb\u1c38-\u1c3a\u1c4a-\u1c4c\u1c80-\u1ccf\u1cf3-\u1cff\u1de7-\u1dfb\u1f16\u1f17\u1f1e\u1f1f\u1f46\u1f47\u1f4e\u1f4f\u1f58\u1f5a\u1f5c\u1f5e\u1f7e\u1f7f\u1fb5\u1fc5\u1fd4\u1fd5\u1fdc\u1ff0\u1ff1\u1ff5\u1fff\u2065-\u2069\u2072\u2073\u208f\u209d-\u209f\u20ba-\u20cf\u20f1-\u20ff\u218a-\u218f\u23f4-\u23ff\u2427-\u243f\u244b-\u245f\u2700\u27cb\u27cd\u2b4d-\u2b4f\u2b5a-\u2bff\u2c2f\u2c5f\u2cf2-\u2cf8\u2d26-\u2d2f\u2d66-\u2d6e\u2d71-\u2d7e\u2d97-\u2d9f\u2da7\u2daf\u2db7\u2dbf\u2dc7\u2dcf\u2dd7\u2ddf\u2e32-\u2e7f\u2e9a\u2ef4-\u2eff\u2fd6-\u2fef\u2ffc-\u2fff\u3040\u3097\u3098\u3100-\u3104\u312e-\u3130\u318f\u31bb-\u31bf\u31e4-\u31ef\u321f\u32ff\u4db6-\u4dbf\u9fcc-\u9fff\ua48d-\ua48f\ua4c7-\ua4cf\ua62c-\ua63f\ua674-\ua67b\ua698-\ua69f\ua6f8-\ua6ff\ua78f\ua792-\ua79f\ua7aa-\ua7f9\ua82c-\ua82f\ua83a-\ua83f\ua878-\ua87f\ua8c5-\ua8cd\ua8da-\ua8df\ua8fc-\ua8ff\ua954-\ua95e\ua97d-\ua97f\ua9ce\ua9da-\ua9dd\ua9e0-\ua9ff\uaa37-\uaa3f\uaa4e\uaa4f\uaa5a\uaa5b\uaa7c-\uaa7f\uaac3-\uaada\uaae0-\uab00\uab07\uab08\uab0f\uab10\uab17-\uab1f\uab27\uab2f-\uabbf\uabee\uabef\uabfa-\uabff\ud7a4-\ud7af\ud7c7-\ud7ca\ud7fc-\ud7ff\ufa2e\ufa2f\ufa6e\ufa6f\ufada-\ufaff\ufb07-\ufb12\ufb18-\ufb1c\ufb37\ufb3d\ufb3f\ufb42\ufb45\ufbc2-\ufbd2\ufd40-\ufd4f\ufd90\ufd91\ufdc8-\ufdef\ufdfe\ufdff\ufe1a-\ufe1f\ufe27-\ufe2f\ufe53\ufe67\ufe6c-\ufe6f\ufe75\ufefd\ufefe\uff00\uffbf-\uffc1\uffc8\uffc9\uffd0\uffd1\uffd8\uffd9\uffdd-\uffdf\uffe7\uffef-\ufff8\ufffe\uffff]",
+		Lu: "[\u0041-\u005a\u00c0-\u00d6\u00d8-\u00de\u0100\u0102\u0104\u0106\u0108\u010a\u010c\u010e\u0110\u0112\u0114\u0116\u0118\u011a\u011c\u011e\u0120\u0122\u0124\u0126\u0128\u012a\u012c\u012e\u0130\u0132\u0134\u0136\u0139\u013b\u013d\u013f\u0141\u0143\u0145\u0147\u014a\u014c\u014e\u0150\u0152\u0154\u0156\u0158\u015a\u015c\u015e\u0160\u0162\u0164\u0166\u0168\u016a\u016c\u016e\u0170\u0172\u0174\u0176\u0178\u0179\u017b\u017d\u0181\u0182\u0184\u0186\u0187\u0189-\u018b\u018e-\u0191\u0193\u0194\u0196-\u0198\u019c\u019d\u019f\u01a0\u01a2\u01a4\u01a6\u01a7\u01a9\u01ac\u01ae\u01af\u01b1-\u01b3\u01b5\u01b7\u01b8\u01bc\u01c4\u01c7\u01ca\u01cd\u01cf\u01d1\u01d3\u01d5\u01d7\u01d9\u01db\u01de\u01e0\u01e2\u01e4\u01e6\u01e8\u01ea\u01ec\u01ee\u01f1\u01f4\u01f6-\u01f8\u01fa\u01fc\u01fe\u0200\u0202\u0204\u0206\u0208\u020a\u020c\u020e\u0210\u0212\u0214\u0216\u0218\u021a\u021c\u021e\u0220\u0222\u0224\u0226\u0228\u022a\u022c\u022e\u0230\u0232\u023a\u023b\u023d\u023e\u0241\u0243-\u0246\u0248\u024a\u024c\u024e\u0370\u0372\u0376\u0386\u0388-\u038a\u038c\u038e\u038f\u0391-\u03a1\u03a3-\u03ab\u03cf\u03d2-\u03d4\u03d8\u03da\u03dc\u03de\u03e0\u03e2\u03e4\u03e6\u03e8\u03ea\u03ec\u03ee\u03f4\u03f7\u03f9\u03fa\u03fd-\u042f\u0460\u0462\u0464\u0466\u0468\u046a\u046c\u046e\u0470\u0472\u0474\u0476\u0478\u047a\u047c\u047e\u0480\u048a\u048c\u048e\u0490\u0492\u0494\u0496\u0498\u049a\u049c\u049e\u04a0\u04a2\u04a4\u04a6\u04a8\u04aa\u04ac\u04ae\u04b0\u04b2\u04b4\u04b6\u04b8\u04ba\u04bc\u04be\u04c0\u04c1\u04c3\u04c5\u04c7\u04c9\u04cb\u04cd\u04d0\u04d2\u04d4\u04d6\u04d8\u04da\u04dc\u04de\u04e0\u04e2\u04e4\u04e6\u04e8\u04ea\u04ec\u04ee\u04f0\u04f2\u04f4\u04f6\u04f8\u04fa\u04fc\u04fe\u0500\u0502\u0504\u0506\u0508\u050a\u050c\u050e\u0510\u0512\u0514\u0516\u0518\u051a\u051c\u051e\u0520\u0522\u0524\u0526\u0531-\u0556\u10a0-\u10c5\u1e00\u1e02\u1e04\u1e06\u1e08\u1e0a\u1e0c\u1e0e\u1e10\u1e12\u1e14\u1e16\u1e18\u1e1a\u1e1c\u1e1e\u1e20\u1e22\u1e24\u1e26\u1e28\u1e2a\u1e2c\u1e2e\u1e30\u1e32\u1e34\u1e36\u1e38\u1e3a\u1e3c\u1e3e\u1e40\u1e42\u1e44\u1e46\u1e48\u1e4a\u1e4c\u1e4e\u1e50\u1e52\u1e54\u1e56\u1e58\u1e5a\u1e5c\u1e5e\u1e60\u1e62\u1e64\u1e66\u1e68\u1e6a\u1e6c\u1e6e\u1e70\u1e72\u1e74\u1e76\u1e78\u1e7a\u1e7c\u1e7e\u1e80\u1e82\u1e84\u1e86\u1e88\u1e8a\u1e8c\u1e8e\u1e90\u1e92\u1e94\u1e9e\u1ea0\u1ea2\u1ea4\u1ea6\u1ea8\u1eaa\u1eac\u1eae\u1eb0\u1eb2\u1eb4\u1eb6\u1eb8\u1eba\u1ebc\u1ebe\u1ec0\u1ec2\u1ec4\u1ec6\u1ec8\u1eca\u1ecc\u1ece\u1ed0\u1ed2\u1ed4\u1ed6\u1ed8\u1eda\u1edc\u1ede\u1ee0\u1ee2\u1ee4\u1ee6\u1ee8\u1eea\u1eec\u1eee\u1ef0\u1ef2\u1ef4\u1ef6\u1ef8\u1efa\u1efc\u1efe\u1f08-\u1f0f\u1f18-\u1f1d\u1f28-\u1f2f\u1f38-\u1f3f\u1f48-\u1f4d\u1f59\u1f5b\u1f5d\u1f5f\u1f68-\u1f6f\u1fb8-\u1fbb\u1fc8-\u1fcb\u1fd8-\u1fdb\u1fe8-\u1fec\u1ff8-\u1ffb\u2102\u2107\u210b-\u210d\u2110-\u2112\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u2130-\u2133\u213e\u213f\u2145\u2183\u2c00-\u2c2e\u2c60\u2c62-\u2c64\u2c67\u2c69\u2c6b\u2c6d-\u2c70\u2c72\u2c75\u2c7e-\u2c80\u2c82\u2c84\u2c86\u2c88\u2c8a\u2c8c\u2c8e\u2c90\u2c92\u2c94\u2c96\u2c98\u2c9a\u2c9c\u2c9e\u2ca0\u2ca2\u2ca4\u2ca6\u2ca8\u2caa\u2cac\u2cae\u2cb0\u2cb2\u2cb4\u2cb6\u2cb8\u2cba\u2cbc\u2cbe\u2cc0\u2cc2\u2cc4\u2cc6\u2cc8\u2cca\u2ccc\u2cce\u2cd0\u2cd2\u2cd4\u2cd6\u2cd8\u2cda\u2cdc\u2cde\u2ce0\u2ce2\u2ceb\u2ced\ua640\ua642\ua644\ua646\ua648\ua64a\ua64c\ua64e\ua650\ua652\ua654\ua656\ua658\ua65a\ua65c\ua65e\ua660\ua662\ua664\ua666\ua668\ua66a\ua66c\ua680\ua682\ua684\ua686\ua688\ua68a\ua68c\ua68e\ua690\ua692\ua694\ua696\ua722\ua724\ua726\ua728\ua72a\ua72c\ua72e\ua732\ua734\ua736\ua738\ua73a\ua73c\ua73e\ua740\ua742\ua744\ua746\ua748\ua74a\ua74c\ua74e\ua750\ua752\ua754\ua756\ua758\ua75a\ua75c\ua75e\ua760\ua762\ua764\ua766\ua768\ua76a\ua76c\ua76e\ua779\ua77b\ua77d\ua77e\ua780\ua782\ua784\ua786\ua78b\ua78d\ua790\ua7a0\ua7a2\ua7a4\ua7a6\ua7a8\uff21-\uff3a]",
+		Ll: "[\u0061-\u007a\u00aa\u00b5\u00ba\u00df-\u00f6\u00f8-\u00ff\u0101\u0103\u0105\u0107\u0109\u010b\u010d\u010f\u0111\u0113\u0115\u0117\u0119\u011b\u011d\u011f\u0121\u0123\u0125\u0127\u0129\u012b\u012d\u012f\u0131\u0133\u0135\u0137\u0138\u013a\u013c\u013e\u0140\u0142\u0144\u0146\u0148\u0149\u014b\u014d\u014f\u0151\u0153\u0155\u0157\u0159\u015b\u015d\u015f\u0161\u0163\u0165\u0167\u0169\u016b\u016d\u016f\u0171\u0173\u0175\u0177\u017a\u017c\u017e-\u0180\u0183\u0185\u0188\u018c\u018d\u0192\u0195\u0199-\u019b\u019e\u01a1\u01a3\u01a5\u01a8\u01aa\u01ab\u01ad\u01b0\u01b4\u01b6\u01b9\u01ba\u01bd-\u01bf\u01c6\u01c9\u01cc\u01ce\u01d0\u01d2\u01d4\u01d6\u01d8\u01da\u01dc\u01dd\u01df\u01e1\u01e3\u01e5\u01e7\u01e9\u01eb\u01ed\u01ef\u01f0\u01f3\u01f5\u01f9\u01fb\u01fd\u01ff\u0201\u0203\u0205\u0207\u0209\u020b\u020d\u020f\u0211\u0213\u0215\u0217\u0219\u021b\u021d\u021f\u0221\u0223\u0225\u0227\u0229\u022b\u022d\u022f\u0231\u0233-\u0239\u023c\u023f\u0240\u0242\u0247\u0249\u024b\u024d\u024f-\u0293\u0295-\u02af\u0371\u0373\u0377\u037b-\u037d\u0390\u03ac-\u03ce\u03d0\u03d1\u03d5-\u03d7\u03d9\u03db\u03dd\u03df\u03e1\u03e3\u03e5\u03e7\u03e9\u03eb\u03ed\u03ef-\u03f3\u03f5\u03f8\u03fb\u03fc\u0430-\u045f\u0461\u0463\u0465\u0467\u0469\u046b\u046d\u046f\u0471\u0473\u0475\u0477\u0479\u047b\u047d\u047f\u0481\u048b\u048d\u048f\u0491\u0493\u0495\u0497\u0499\u049b\u049d\u049f\u04a1\u04a3\u04a5\u04a7\u04a9\u04ab\u04ad\u04af\u04b1\u04b3\u04b5\u04b7\u04b9\u04bb\u04bd\u04bf\u04c2\u04c4\u04c6\u04c8\u04ca\u04cc\u04ce\u04cf\u04d1\u04d3\u04d5\u04d7\u04d9\u04db\u04dd\u04df\u04e1\u04e3\u04e5\u04e7\u04e9\u04eb\u04ed\u04ef\u04f1\u04f3\u04f5\u04f7\u04f9\u04fb\u04fd\u04ff\u0501\u0503\u0505\u0507\u0509\u050b\u050d\u050f\u0511\u0513\u0515\u0517\u0519\u051b\u051d\u051f\u0521\u0523\u0525\u0527\u0561-\u0587\u1d00-\u1d2b\u1d62-\u1d77\u1d79-\u1d9a\u1e01\u1e03\u1e05\u1e07\u1e09\u1e0b\u1e0d\u1e0f\u1e11\u1e13\u1e15\u1e17\u1e19\u1e1b\u1e1d\u1e1f\u1e21\u1e23\u1e25\u1e27\u1e29\u1e2b\u1e2d\u1e2f\u1e31\u1e33\u1e35\u1e37\u1e39\u1e3b\u1e3d\u1e3f\u1e41\u1e43\u1e45\u1e47\u1e49\u1e4b\u1e4d\u1e4f\u1e51\u1e53\u1e55\u1e57\u1e59\u1e5b\u1e5d\u1e5f\u1e61\u1e63\u1e65\u1e67\u1e69\u1e6b\u1e6d\u1e6f\u1e71\u1e73\u1e75\u1e77\u1e79\u1e7b\u1e7d\u1e7f\u1e81\u1e83\u1e85\u1e87\u1e89\u1e8b\u1e8d\u1e8f\u1e91\u1e93\u1e95-\u1e9d\u1e9f\u1ea1\u1ea3\u1ea5\u1ea7\u1ea9\u1eab\u1ead\u1eaf\u1eb1\u1eb3\u1eb5\u1eb7\u1eb9\u1ebb\u1ebd\u1ebf\u1ec1\u1ec3\u1ec5\u1ec7\u1ec9\u1ecb\u1ecd\u1ecf\u1ed1\u1ed3\u1ed5\u1ed7\u1ed9\u1edb\u1edd\u1edf\u1ee1\u1ee3\u1ee5\u1ee7\u1ee9\u1eeb\u1eed\u1eef\u1ef1\u1ef3\u1ef5\u1ef7\u1ef9\u1efb\u1efd\u1eff-\u1f07\u1f10-\u1f15\u1f20-\u1f27\u1f30-\u1f37\u1f40-\u1f45\u1f50-\u1f57\u1f60-\u1f67\u1f70-\u1f7d\u1f80-\u1f87\u1f90-\u1f97\u1fa0-\u1fa7\u1fb0-\u1fb4\u1fb6\u1fb7\u1fbe\u1fc2-\u1fc4\u1fc6\u1fc7\u1fd0-\u1fd3\u1fd6\u1fd7\u1fe0-\u1fe7\u1ff2-\u1ff4\u1ff6\u1ff7\u210a\u210e\u210f\u2113\u212f\u2134\u2139\u213c\u213d\u2146-\u2149\u214e\u2184\u2c30-\u2c5e\u2c61\u2c65\u2c66\u2c68\u2c6a\u2c6c\u2c71\u2c73\u2c74\u2c76-\u2c7c\u2c81\u2c83\u2c85\u2c87\u2c89\u2c8b\u2c8d\u2c8f\u2c91\u2c93\u2c95\u2c97\u2c99\u2c9b\u2c9d\u2c9f\u2ca1\u2ca3\u2ca5\u2ca7\u2ca9\u2cab\u2cad\u2caf\u2cb1\u2cb3\u2cb5\u2cb7\u2cb9\u2cbb\u2cbd\u2cbf\u2cc1\u2cc3\u2cc5\u2cc7\u2cc9\u2ccb\u2ccd\u2ccf\u2cd1\u2cd3\u2cd5\u2cd7\u2cd9\u2cdb\u2cdd\u2cdf\u2ce1\u2ce3\u2ce4\u2cec\u2cee\u2d00-\u2d25\ua641\ua643\ua645\ua647\ua649\ua64b\ua64d\ua64f\ua651\ua653\ua655\ua657\ua659\ua65b\ua65d\ua65f\ua661\ua663\ua665\ua667\ua669\ua66b\ua66d\ua681\ua683\ua685\ua687\ua689\ua68b\ua68d\ua68f\ua691\ua693\ua695\ua697\ua723\ua725\ua727\ua729\ua72b\ua72d\ua72f-\ua731\ua733\ua735\ua737\ua739\ua73b\ua73d\ua73f\ua741\ua743\ua745\ua747\ua749\ua74b\ua74d\ua74f\ua751\ua753\ua755\ua757\ua759\ua75b\ua75d\ua75f\ua761\ua763\ua765\ua767\ua769\ua76b\ua76d\ua76f\ua771-\ua778\ua77a\ua77c\ua77f\ua781\ua783\ua785\ua787\ua78c\ua78e\ua791\ua7a1\ua7a3\ua7a5\ua7a7\ua7a9\ua7fa\ufb00-\ufb06\ufb13-\ufb17\uff41-\uff5a]",
+		Lt: "[\u01c5\u01c8\u01cb\u01f2\u1f88-\u1f8f\u1f98-\u1f9f\u1fa8-\u1faf\u1fbc\u1fcc\u1ffc]",
+		Lm: "[\u02b0-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0374\u037a\u0559\u0640\u06e5\u06e6\u07f4\u07f5\u07fa\u081a\u0824\u0828\u0971\u0e46\u0ec6\u10fc\u17d7\u1843\u1aa7\u1c78-\u1c7d\u1d2c-\u1d61\u1d78\u1d9b-\u1dbf\u2071\u207f\u2090-\u209c\u2c7d\u2d6f\u2e2f\u3005\u3031-\u3035\u303b\u309d\u309e\u30fc-\u30fe\ua015\ua4f8-\ua4fd\ua60c\ua67f\ua717-\ua71f\ua770\ua788\ua9cf\uaa70\uaadd\uff70\uff9e\uff9f]",
+		Lo: "[\u01bb\u01c0-\u01c3\u0294\u05d0-\u05ea\u05f0-\u05f2\u0620-\u063f\u0641-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u0800-\u0815\u0840-\u0858\u0904-\u0939\u093d\u0950\u0958-\u0961\u0972-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e45\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0edc\u0edd\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10d0-\u10fa\u1100-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17dc\u1820-\u1842\u1844-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bc0-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c77\u1ce9-\u1cec\u1cee-\u1cf1\u2135-\u2138\u2d30-\u2d65\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u3006\u303c\u3041-\u3096\u309f\u30a1-\u30fa\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcb\ua000-\ua014\ua016-\ua48c\ua4d0-\ua4f7\ua500-\ua60b\ua610-\ua61f\ua62a\ua62b\ua66e\ua6a0-\ua6e5\ua7fb-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa6f\uaa71-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb\uaadc\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa2d\ufa30-\ufa6d\ufa70-\ufad9\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff66-\uff6f\uff71-\uff9d\uffa0-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc]",
+		Mn: "[\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u064b-\u065f\u0670\u06d6-\u06dc\u06df-\u06e4\u06e7\u06e8\u06ea-\u06ed\u0711\u0730-\u074a\u07a6-\u07b0\u07eb-\u07f3\u0816-\u0819\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0859-\u085b\u0900-\u0902\u093a\u093c\u0941-\u0948\u094d\u0951-\u0957\u0962\u0963\u0981\u09bc\u09c1-\u09c4\u09cd\u09e2\u09e3\u0a01\u0a02\u0a3c\u0a41\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a70\u0a71\u0a75\u0a81\u0a82\u0abc\u0ac1-\u0ac5\u0ac7\u0ac8\u0acd\u0ae2\u0ae3\u0b01\u0b3c\u0b3f\u0b41-\u0b44\u0b4d\u0b56\u0b62\u0b63\u0b82\u0bc0\u0bcd\u0c3e-\u0c40\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62\u0c63\u0cbc\u0cbf\u0cc6\u0ccc\u0ccd\u0ce2\u0ce3\u0d41-\u0d44\u0d4d\u0d62\u0d63\u0dca\u0dd2-\u0dd4\u0dd6\u0e31\u0e34-\u0e3a\u0e47-\u0e4e\u0eb1\u0eb4-\u0eb9\u0ebb\u0ebc\u0ec8-\u0ecd\u0f18\u0f19\u0f35\u0f37\u0f39\u0f71-\u0f7e\u0f80-\u0f84\u0f86\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u102d-\u1030\u1032-\u1037\u1039\u103a\u103d\u103e\u1058\u1059\u105e-\u1060\u1071-\u1074\u1082\u1085\u1086\u108d\u109d\u135d-\u135f\u1712-\u1714\u1732-\u1734\u1752\u1753\u1772\u1773\u17b7-\u17bd\u17c6\u17c9-\u17d3\u17dd\u180b-\u180d\u18a9\u1920-\u1922\u1927\u1928\u1932\u1939-\u193b\u1a17\u1a18\u1a56\u1a58-\u1a5e\u1a60\u1a62\u1a65-\u1a6c\u1a73-\u1a7c\u1a7f\u1b00-\u1b03\u1b34\u1b36-\u1b3a\u1b3c\u1b42\u1b6b-\u1b73\u1b80\u1b81\u1ba2-\u1ba5\u1ba8\u1ba9\u1be6\u1be8\u1be9\u1bed\u1bef-\u1bf1\u1c2c-\u1c33\u1c36\u1c37\u1cd0-\u1cd2\u1cd4-\u1ce0\u1ce2-\u1ce8\u1ced\u1dc0-\u1de6\u1dfc-\u1dff\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2cef-\u2cf1\u2d7f\u2de0-\u2dff\u302a-\u302f\u3099\u309a\ua66f\ua67c\ua67d\ua6f0\ua6f1\ua802\ua806\ua80b\ua825\ua826\ua8c4\ua8e0-\ua8f1\ua926-\ua92d\ua947-\ua951\ua980-\ua982\ua9b3\ua9b6-\ua9b9\ua9bc\uaa29-\uaa2e\uaa31\uaa32\uaa35\uaa36\uaa43\uaa4c\uaab0\uaab2-\uaab4\uaab7\uaab8\uaabe\uaabf\uaac1\uabe5\uabe8\uabed\ufb1e\ufe00-\ufe0f\ufe20-\ufe26]",
+		Me: "[\u0488\u0489\u20dd-\u20e0\u20e2-\u20e4\ua670-\ua672]",
+		Mc: "[\u0903\u093b\u093e-\u0940\u0949-\u094c\u094e\u094f\u0982\u0983\u09be-\u09c0\u09c7\u09c8\u09cb\u09cc\u09d7\u0a03\u0a3e-\u0a40\u0a83\u0abe-\u0ac0\u0ac9\u0acb\u0acc\u0b02\u0b03\u0b3e\u0b40\u0b47\u0b48\u0b4b\u0b4c\u0b57\u0bbe\u0bbf\u0bc1\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcc\u0bd7\u0c01-\u0c03\u0c41-\u0c44\u0c82\u0c83\u0cbe\u0cc0-\u0cc4\u0cc7\u0cc8\u0cca\u0ccb\u0cd5\u0cd6\u0d02\u0d03\u0d3e-\u0d40\u0d46-\u0d48\u0d4a-\u0d4c\u0d57\u0d82\u0d83\u0dcf-\u0dd1\u0dd8-\u0ddf\u0df2\u0df3\u0f3e\u0f3f\u0f7f\u102b\u102c\u1031\u1038\u103b\u103c\u1056\u1057\u1062-\u1064\u1067-\u106d\u1083\u1084\u1087-\u108c\u108f\u109a-\u109c\u17b6\u17be-\u17c5\u17c7\u17c8\u1923-\u1926\u1929-\u192b\u1930\u1931\u1933-\u1938\u19b0-\u19c0\u19c8\u19c9\u1a19-\u1a1b\u1a55\u1a57\u1a61\u1a63\u1a64\u1a6d-\u1a72\u1b04\u1b35\u1b3b\u1b3d-\u1b41\u1b43\u1b44\u1b82\u1ba1\u1ba6\u1ba7\u1baa\u1be7\u1bea-\u1bec\u1bee\u1bf2\u1bf3\u1c24-\u1c2b\u1c34\u1c35\u1ce1\u1cf2\ua823\ua824\ua827\ua880\ua881\ua8b4-\ua8c3\ua952\ua953\ua983\ua9b4\ua9b5\ua9ba\ua9bb\ua9bd-\ua9c0\uaa2f\uaa30\uaa33\uaa34\uaa4d\uaa7b\uabe3\uabe4\uabe6\uabe7\uabe9\uabea\uabec]",
+		Nd: "[\u0030-\u0039\u0660-\u0669\u06f0-\u06f9\u07c0-\u07c9\u0966-\u096f\u09e6-\u09ef\u0a66-\u0a6f\u0ae6-\u0aef\u0b66-\u0b6f\u0be6-\u0bef\u0c66-\u0c6f\u0ce6-\u0cef\u0d66-\u0d6f\u0e50-\u0e59\u0ed0-\u0ed9\u0f20-\u0f29\u1040-\u1049\u1090-\u1099\u17e0-\u17e9\u1810-\u1819\u1946-\u194f\u19d0-\u19d9\u1a80-\u1a89\u1a90-\u1a99\u1b50-\u1b59\u1bb0-\u1bb9\u1c40-\u1c49\u1c50-\u1c59\ua620-\ua629\ua8d0-\ua8d9\ua900-\ua909\ua9d0-\ua9d9\uaa50-\uaa59\uabf0-\uabf9\uff10-\uff19]",
+		Nl: "[\u16ee-\u16f0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303a\ua6e6-\ua6ef]",
+		No: "[\u00b2\u00b3\u00b9\u00bc-\u00be\u09f4-\u09f9\u0b72-\u0b77\u0bf0-\u0bf2\u0c78-\u0c7e\u0d70-\u0d75\u0f2a-\u0f33\u1369-\u137c\u17f0-\u17f9\u19da\u2070\u2074-\u2079\u2080-\u2089\u2150-\u215f\u2189\u2460-\u249b\u24ea-\u24ff\u2776-\u2793\u2cfd\u3192-\u3195\u3220-\u3229\u3251-\u325f\u3280-\u3289\u32b1-\u32bf\ua830-\ua835]",
+		Zs: "[\u0020\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000]",
+		Zl: "[\u2028]",
+		Zp: "[\u2029]",
+		Cc: "[\u0000-\u001f\u007f-\u009f]",
+		Cf: "[\u00ad\u0600-\u0603\u06dd\u070f\u17b4\u17b5\u200b-\u200f\u202a-\u202e\u2060-\u2064\u206a-\u206f\ufeff\ufff9-\ufffb]",
+		Cs: "[\ud800-\udfff]",
+		Co: "[\ue000-\uf8ff]",
+		Ps: "[\u0028\u005b\u007b\u0f3a\u0f3c\u169b\u201a\u201e\u2045\u207d\u208d\u2329\u2768\u276a\u276c\u276e\u2770\u2772\u2774\u27c5\u27e6\u27e8\u27ea\u27ec\u27ee\u2983\u2985\u2987\u2989\u298b\u298d\u298f\u2991\u2993\u2995\u2997\u29d8\u29da\u29fc\u2e22\u2e24\u2e26\u2e28\u3008\u300a\u300c\u300e\u3010\u3014\u3016\u3018\u301a\u301d\ufd3e\ufe17\ufe35\ufe37\ufe39\ufe3b\ufe3d\ufe3f\ufe41\ufe43\ufe47\ufe59\ufe5b\ufe5d\uff08\uff3b\uff5b\uff5f\uff62]",
+		Pd: "[\u002d\u058a\u05be\u1400\u1806\u2010-\u2015\u2e17\u2e1a\u301c\u3030\u30a0\ufe31\ufe32\ufe58\ufe63\uff0d]",
+		Pc: "[\u005f\u203f\u2040\u2054\ufe33\ufe34\ufe4d-\ufe4f\uff3f]",
+		Pe: "[\u0029\\\u005d\u007d\u0f3b\u0f3d\u169c\u2046\u207e\u208e\u232a\u2769\u276b\u276d\u276f\u2771\u2773\u2775\u27c6\u27e7\u27e9\u27eb\u27ed\u27ef\u2984\u2986\u2988\u298a\u298c\u298e\u2990\u2992\u2994\u2996\u2998\u29d9\u29db\u29fd\u2e23\u2e25\u2e27\u2e29\u3009\u300b\u300d\u300f\u3011\u3015\u3017\u3019\u301b\u301e\u301f\ufd3f\ufe18\ufe36\ufe38\ufe3a\ufe3c\ufe3e\ufe40\ufe42\ufe44\ufe48\ufe5a\ufe5c\ufe5e\uff09\uff3d\uff5d\uff60\uff63]",
+		Sm: "[\u002b\u003c-\u003e\u007c\u007e\u00ac\u00b1\u00d7\u00f7\u03f6\u0606-\u0608\u2044\u2052\u207a-\u207c\u208a-\u208c\u2118\u2140-\u2144\u214b\u2190-\u2194\u219a\u219b\u21a0\u21a3\u21a6\u21ae\u21ce\u21cf\u21d2\u21d4\u21f4-\u22ff\u2308-\u230b\u2320\u2321\u237c\u239b-\u23b3\u23dc-\u23e1\u25b7\u25c1\u25f8-\u25ff\u266f\u27c0-\u27c4\u27c7-\u27ca\u27cc\u27ce-\u27e5\u27f0-\u27ff\u2900-\u2982\u2999-\u29d7\u29dc-\u29fb\u29fe-\u2aff\u2b30-\u2b44\u2b47-\u2b4c\ufb29\ufe62\ufe64-\ufe66\uff0b\uff1c-\uff1e\uff5c\uff5e\uffe2\uffe9-\uffec]",
+		Po: "[\u0021-\u0023\u0025-\u0027\u002a\u002c\u002e\u002f\u003a\u003b\u003f\u0040\u005c\u00a1\u00b7\u00bf\u037e\u0387\u055a-\u055f\u0589\u05c0\u05c3\u05c6\u05f3\u05f4\u0609\u060a\u060c\u060d\u061b\u061e\u061f\u066a-\u066d\u06d4\u0700-\u070d\u07f7-\u07f9\u0830-\u083e\u085e\u0964\u0965\u0970\u0df4\u0e4f\u0e5a\u0e5b\u0f04-\u0f12\u0f85\u0fd0-\u0fd4\u0fd9\u0fda\u104a-\u104f\u10fb\u1361-\u1368\u166d\u166e\u16eb-\u16ed\u1735\u1736\u17d4-\u17d6\u17d8-\u17da\u1800-\u1805\u1807-\u180a\u1944\u1945\u1a1e\u1a1f\u1aa0-\u1aa6\u1aa8-\u1aad\u1b5a-\u1b60\u1bfc-\u1bff\u1c3b-\u1c3f\u1c7e\u1c7f\u1cd3\u2016\u2017\u2020-\u2027\u2030-\u2038\u203b-\u203e\u2041-\u2043\u2047-\u2051\u2053\u2055-\u205e\u2cf9-\u2cfc\u2cfe\u2cff\u2d70\u2e00\u2e01\u2e06-\u2e08\u2e0b\u2e0e-\u2e16\u2e18\u2e19\u2e1b\u2e1e\u2e1f\u2e2a-\u2e2e\u2e30\u2e31\u3001-\u3003\u303d\u30fb\ua4fe\ua4ff\ua60d-\ua60f\ua673\ua67e\ua6f2-\ua6f7\ua874-\ua877\ua8ce\ua8cf\ua8f8-\ua8fa\ua92e\ua92f\ua95f\ua9c1-\ua9cd\ua9de\ua9df\uaa5c-\uaa5f\uaade\uaadf\uabeb\ufe10-\ufe16\ufe19\ufe30\ufe45\ufe46\ufe49-\ufe4c\ufe50-\ufe52\ufe54-\ufe57\ufe5f-\ufe61\ufe68\ufe6a\ufe6b\uff01-\uff03\uff05-\uff07\uff0a\uff0c\uff0e\uff0f\uff1a\uff1b\uff1f\uff20\uff3c\uff61\uff64\uff65]",
+		Sk: "[\u005e\u0060\u00a8\u00af\u00b4\u00b8\u02c2-\u02c5\u02d2-\u02df\u02e5-\u02eb\u02ed\u02ef-\u02ff\u0375\u0384\u0385\u1fbd\u1fbf-\u1fc1\u1fcd-\u1fcf\u1fdd-\u1fdf\u1fed-\u1fef\u1ffd\u1ffe\u309b\u309c\ua700-\ua716\ua720\ua721\ua789\ua78a\ufbb2-\ufbc1\uff3e\uff40\uffe3]",
+		Sc: "[\u0024\u00a2-\u00a5\u060b\u09f2\u09f3\u09fb\u0af1\u0bf9\u0e3f\u17db\u20a0-\u20b9\ua838\ufdfc\ufe69\uff04\uffe0\uffe1\uffe5\uffe6]",
+		Pi: "[\u00ab\u2018\u201b\u201c\u201f\u2039\u2e02\u2e04\u2e09\u2e0c\u2e1c\u2e20]",
+		So: "[\u00a6\u00a7\u00a9\u00ae\u00b0\u00b6\u0482\u060e\u060f\u06de\u06e9\u06fd\u06fe\u07f6\u09fa\u0b70\u0bf3-\u0bf8\u0bfa\u0c7f\u0d79\u0f01-\u0f03\u0f13-\u0f17\u0f1a-\u0f1f\u0f34\u0f36\u0f38\u0fbe-\u0fc5\u0fc7-\u0fcc\u0fce\u0fcf\u0fd5-\u0fd8\u109e\u109f\u1360\u1390-\u1399\u1940\u19de-\u19ff\u1b61-\u1b6a\u1b74-\u1b7c\u2100\u2101\u2103-\u2106\u2108\u2109\u2114\u2116\u2117\u211e-\u2123\u2125\u2127\u2129\u212e\u213a\u213b\u214a\u214c\u214d\u214f\u2195-\u2199\u219c-\u219f\u21a1\u21a2\u21a4\u21a5\u21a7-\u21ad\u21af-\u21cd\u21d0\u21d1\u21d3\u21d5-\u21f3\u2300-\u2307\u230c-\u231f\u2322-\u2328\u232b-\u237b\u237d-\u239a\u23b4-\u23db\u23e2-\u23f3\u2400-\u2426\u2440-\u244a\u249c-\u24e9\u2500-\u25b6\u25b8-\u25c0\u25c2-\u25f7\u2600-\u266e\u2670-\u26ff\u2701-\u2767\u2794-\u27bf\u2800-\u28ff\u2b00-\u2b2f\u2b45\u2b46\u2b50-\u2b59\u2ce5-\u2cea\u2e80-\u2e99\u2e9b-\u2ef3\u2f00-\u2fd5\u2ff0-\u2ffb\u3004\u3012\u3013\u3020\u3036\u3037\u303e\u303f\u3190\u3191\u3196-\u319f\u31c0-\u31e3\u3200-\u321e\u322a-\u3250\u3260-\u327f\u328a-\u32b0\u32c0-\u32fe\u3300-\u33ff\u4dc0-\u4dff\ua490-\ua4c6\ua828-\ua82b\ua836\ua837\ua839\uaa77-\uaa79\ufdfd\uffe4\uffe8\uffed\uffee\ufffc\ufffd]",
+		Pf: "[\u00bb\u2019\u201d\u203a\u2e03\u2e05\u2e0a\u2e0d\u2e1d\u2e21]"
+	};
+
+	$.ig.util.defType('DomRenderer', 'Object', {
+
+		$type: new $.ig.Type('DomRenderer', null)
+	}, true);
+
+	$.ig.util.defType('DomWrapper', 'Object', {
+
+		$type: new $.ig.Type('DomWrapper', null)
+	}, true);
+
 	$.ig.unicode_hack = (function () { //jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
 		/* Regexps to match characters in the BMP according to their Unicode category.
 		   Extracted from running all characters (code units) against Java's
@@ -7153,4 +5857,5 @@
 		};
 	})();
 
+	return igRoot;
 }));// REMOVE_FROM_COMBINED_FILES

--- a/tests/unit/colorpicker/tests.html
+++ b/tests/unit/colorpicker/tests.html
@@ -12,6 +12,8 @@
 	<script type="text/javascript" src="../../../bower_components/jquery-ui/jquery-ui.js"></script>
 	<script type="text/javascript" src="../../../bower_components/qunit/qunit/qunit.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.colorpicker.js"></script>
 
 	<script type="text/javascript">

--- a/tests/unit/colorpickersplitbutton/tests.html
+++ b/tests/unit/colorpickersplitbutton/tests.html
@@ -18,6 +18,8 @@
 	<script type="text/javascript" src="../../../bower_components/qunit/qunit/qunit.js"></script>
 
     <script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.popover.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.colorpicker.js"></script>

--- a/tests/unit/combo/tests.html
+++ b/tests/unit/combo/tests.html
@@ -14,6 +14,8 @@
     <script type="text/javascript" src="../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>
     <script type="text/javascript" src="../../../tests/unit/common/test-util.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.templating.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.datasource.js"></script>

--- a/tests/unit/dataSource/filtering/tests.html
+++ b/tests/unit/dataSource/filtering/tests.html
@@ -6,6 +6,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery-tmpl/jquery.tmpl.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 

--- a/tests/unit/dataSource/groupby/tests.html
+++ b/tests/unit/dataSource/groupby/tests.html
@@ -6,6 +6,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery-tmpl/jquery.tmpl.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	
 	<link type="text/css" href="../../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" />

--- a/tests/unit/dataSource/hierarchical/tests.html
+++ b/tests/unit/dataSource/hierarchical/tests.html
@@ -10,6 +10,8 @@
 	<script type="text/javascript" src="../../../../bower_components/JSON-js/json2.js"></script>
 	<script type="text/javascript" src="../../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 

--- a/tests/unit/dataSource/mashup/tests.html
+++ b/tests/unit/dataSource/mashup/tests.html
@@ -4,6 +4,8 @@
 	<title>Infragistics Mashup Data Source Tests</title>
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 

--- a/tests/unit/dataSource/paging/tests.html
+++ b/tests/unit/dataSource/paging/tests.html
@@ -5,6 +5,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	
 	<link type="text/css" href="../../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" />

--- a/tests/unit/dataSource/properties/tests.html
+++ b/tests/unit/dataSource/properties/tests.html
@@ -6,6 +6,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	

--- a/tests/unit/dataSource/remote/tests.html
+++ b/tests/unit/dataSource/remote/tests.html
@@ -4,6 +4,8 @@
 	<title> Infragistics jQuery Data Source - tests for Remote operations & mocked AJAX requests to REST services </title> 
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.dataSource-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	<script type="text/javascript" src="../../../../bower_components/JSON-js/json2.js"></script>

--- a/tests/unit/dataSource/rest/tests.html
+++ b/tests/unit/dataSource/rest/tests.html
@@ -9,6 +9,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
 	<script type="text/javascript" src="../../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 
 	<script type="text/javascript" src="../../../../bower_components/qunit/qunit/qunit.js"></script>

--- a/tests/unit/dataSource/schemas/tests.html
+++ b/tests/unit/dataSource/schemas/tests.html
@@ -7,6 +7,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 	
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	
 	<link type="text/css" href="../../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" />

--- a/tests/unit/dataSource/select databinding/tests.html
+++ b/tests/unit/dataSource/select databinding/tests.html
@@ -9,6 +9,8 @@
 	<script type="text/javascript" src="../../../../bower_components/qunit/qunit/qunit.js"></script>
     
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 </head>
 <body>

--- a/tests/unit/dataSource/sorting/tests.html
+++ b/tests/unit/dataSource/sorting/tests.html
@@ -5,6 +5,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 	
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	
 	<script type="text/javascript" src="../../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>

--- a/tests/unit/dataSource/transactions/tests.html
+++ b/tests/unit/dataSource/transactions/tests.html
@@ -5,6 +5,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 

--- a/tests/unit/dataSource/treeHierarchicalDataSource/tests.html
+++ b/tests/unit/dataSource/treeHierarchicalDataSource/tests.html
@@ -5,6 +5,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 
 	<script type="text/javascript" src="../../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>

--- a/tests/unit/dialog/tests.html
+++ b/tests/unit/dialog/tests.html
@@ -11,6 +11,8 @@
     <script type="text/javascript" src="../../../bower_components/jquery-ui/jquery-ui.js"></script>
 
     <script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.dialog.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.ui.dialog-en.js"></script>
     

--- a/tests/unit/editors/AriaRendering/tests.html
+++ b/tests/unit/editors/AriaRendering/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                    
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script> 

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -18,6 +18,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/regional/infragistics.ui.regional-i18n.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                     

--- a/tests/unit/editors/DatePickerBugs/tests.html
+++ b/tests/unit/editors/DatePickerBugs/tests.html
@@ -19,6 +19,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/regional/infragistics.ui.regional-i18n.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                     

--- a/tests/unit/editors/baseEditor/tests.html
+++ b/tests/unit/editors/baseEditor/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script> 

--- a/tests/unit/editors/checkboxEditor/tests.html
+++ b/tests/unit/editors/checkboxEditor/tests.html
@@ -17,6 +17,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 	
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>   
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script> 

--- a/tests/unit/editors/currencyEditor/tests.html
+++ b/tests/unit/editors/currencyEditor/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 	
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                   
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>

--- a/tests/unit/editors/dateEditor/tests.html
+++ b/tests/unit/editors/dateEditor/tests.html
@@ -19,6 +19,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.validator-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                     

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>

--- a/tests/unit/editors/maskEditor/tests.html
+++ b/tests/unit/editors/maskEditor/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>  
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                      
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>

--- a/tests/unit/editors/percentEditor/tests.html
+++ b/tests/unit/editors/percentEditor/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                  
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>

--- a/tests/unit/editors/textEditor/tests.html
+++ b/tests/unit/editors/textEditor/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>                                   
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script> 

--- a/tests/unit/htmleditor/basicfunctionalities/rendering/tests.html
+++ b/tests/unit/htmleditor/basicfunctionalities/rendering/tests.html
@@ -17,6 +17,8 @@
     <script type="text/javascript" src="../../../../../bower_components/jquery-ui/jquery-ui.js"></script>
     <script type="text/javascript" src="../../../../../bower_components/qunit/qunit/qunit.js"></script>
     <script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.shared.js"></script>
     <script type="text/javascript" src="../../../../../src/js/modules/infragistics.templating.js"></script>
     <script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>

--- a/tests/unit/knockout/combo/tests.html
+++ b/tests/unit/knockout/combo/tests.html
@@ -20,6 +20,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.datasource-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.combo-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.templating.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.combo.js"></script>

--- a/tests/unit/knockout/editors/igCurrencyEditor/tests.html
+++ b/tests/unit/knockout/editors/igCurrencyEditor/tests.html
@@ -21,6 +21,8 @@
 	
 	                                    
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>

--- a/tests/unit/knockout/editors/igDateEditor/tests.html
+++ b/tests/unit/knockout/editors/igDateEditor/tests.html
@@ -18,6 +18,8 @@
 	<script type="text/javascript" src="../../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>

--- a/tests/unit/knockout/editors/igDatePicker/tests.html
+++ b/tests/unit/knockout/editors/igDatePicker/tests.html
@@ -18,6 +18,8 @@
 	<script type="text/javascript" src="../../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 	
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>

--- a/tests/unit/knockout/editors/igMaskEditor/tests.html
+++ b/tests/unit/knockout/editors/igMaskEditor/tests.html
@@ -22,6 +22,8 @@
 	<script type="text/javascript" src="../../../../../src/js/modules/i18n/infragistics.ui.tree-en.js"></script>
 	                                   
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>

--- a/tests/unit/knockout/editors/igNumericEditor/tests.html
+++ b/tests/unit/knockout/editors/igNumericEditor/tests.html
@@ -22,6 +22,8 @@
 	<script type="text/javascript" src="../../../../../src/js/modules/i18n/infragistics.ui.tree-en.js"></script>
 	                                   
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>

--- a/tests/unit/knockout/editors/igPercentEditor/tests.html
+++ b/tests/unit/knockout/editors/igPercentEditor/tests.html
@@ -20,6 +20,8 @@
 	<script type="text/javascript" src="../../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
 	                                    
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 

--- a/tests/unit/knockout/editors/igTextEditor/tests.html
+++ b/tests/unit/knockout/editors/igTextEditor/tests.html
@@ -23,6 +23,8 @@
 	<script type="text/javascript" src="../../../../../src/js/modules/i18n/infragistics.ui.tree-en.js"></script>
 	                                    
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<!--<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../../src/js/modules/infragistics.ui.notifier.js"></script>

--- a/tests/unit/knockout/tree/tests.html
+++ b/tests/unit/knockout/tree/tests.html
@@ -12,6 +12,8 @@
 	<script type="text/javascript" src="../../../../bower_components/knockout/dist/knockout.debug.js"></script>
     
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.templating.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>

--- a/tests/unit/loader/tests.html
+++ b/tests/unit/loader/tests.html
@@ -35,6 +35,8 @@
                         "infragistics.loader.js",
                         "infragistics.util-en.js",
                         "infragistics.util.js",
+                        "infragistics.util.jquery.js",
+                        "infragistics.util.jquerydeferred.js",
                         "infragistics.ui.scroll.js",
                         "infragistics.ui.popover-en.js",
                         "infragistics.ui.popover.js",

--- a/tests/unit/popover/common/tests.html
+++ b/tests/unit/popover/common/tests.html
@@ -14,6 +14,8 @@
     <script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.validator-en.js"></script>
 
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.templating.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.shared.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>    

--- a/tests/unit/popover/specific/tests.html
+++ b/tests/unit/popover/specific/tests.html
@@ -10,6 +10,8 @@
     <script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
 
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.templating.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.shared.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>

--- a/tests/unit/rating/common/tests.html
+++ b/tests/unit/rating/common/tests.html
@@ -8,6 +8,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 	<script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.rating.js"></script>
 	
 	<link type="text/css" href="../../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" />

--- a/tests/unit/scroll/events/tests.html
+++ b/tests/unit/scroll/events/tests.html
@@ -12,6 +12,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.scroll.js"></script>
 	<script type="text/javascript" src="../jquery.simulate.js"></script>
 	<script type="text/javascript" src="../simInteractions.js"></script>

--- a/tests/unit/scroll/navigation/tests.html
+++ b/tests/unit/scroll/navigation/tests.html
@@ -12,6 +12,8 @@
 	<script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.scroll.js"></script>
 	<script type="text/javascript" src="../jquery.simulate.js"></script>
 	<script type="text/javascript" src="../simInteractions.js"></script>

--- a/tests/unit/scroll/tests.html
+++ b/tests/unit/scroll/tests.html
@@ -14,6 +14,8 @@
 	<script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.ui.scroll-en.js"></script>
 	
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.scroll.js"></script>
 	<script type="text/javascript" src="jquery.simulate.js"></script>
 	<script type="text/javascript" src="simInteractions.js"></script>

--- a/tests/unit/splitbutton/tests.html
+++ b/tests/unit/splitbutton/tests.html
@@ -12,6 +12,8 @@
 		<script type="text/javascript" src="../../../bower_components/qunit/qunit/qunit.js"></script>
 
 	    <script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+        <script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	    <script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	    <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
         <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.toolbarbutton.js"></script>
         <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.splitbutton.js"></script>

--- a/tests/unit/splitter/tests.html
+++ b/tests/unit/splitter/tests.html
@@ -15,6 +15,8 @@
 
 	<script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.ui.splitter-en.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.splitter.js"></script>
 	<script type="text/javascript" src="jquery.simulate.js"></script>
 	<link type="text/css" href="../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" />

--- a/tests/unit/templating/tests.html
+++ b/tests/unit/templating/tests.html
@@ -8,6 +8,8 @@
 	<script type="text/javascript" src="../../../bower_components/jquery/dist/jquery.js"></script>
 	<script type="text/javascript" src="../../../bower_components/jquery-ui/jquery-ui.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.templating-en.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.templating.js"></script>	
 	<link type="text/css" href="../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" />

--- a/tests/unit/tilemanager/layoutmanager/tests.html
+++ b/tests/unit/tilemanager/layoutmanager/tests.html
@@ -8,6 +8,8 @@
 		<script type="text/javascript" src="../../../../bower_components/jquery/dist/jquery.js"></script>
 		<script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
 		<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+		<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+		<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 		<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.layoutmanager.js"></script>	
 		
 		<script type="text/javascript" src="../../../../bower_components/qunit/qunit/qunit.js"></script>

--- a/tests/unit/tilemanager/tilemanager/tests.html
+++ b/tests/unit/tilemanager/tilemanager/tests.html
@@ -11,6 +11,8 @@
     <script type="text/javascript" src="../../../../bower_components/jquery-ui/jquery-ui.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.splitter-en.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.templating.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.datasource.js"></script>
     <script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.layoutmanager.js"></script>

--- a/tests/unit/toolbar/tests.html
+++ b/tests/unit/toolbar/tests.html
@@ -14,6 +14,8 @@
 
 
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.datasource.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.templating.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.combo.js"></script>

--- a/tests/unit/toolbarbutton/tests.html
+++ b/tests/unit/toolbarbutton/tests.html
@@ -16,6 +16,8 @@
 	<script type="text/javascript" src="../../../bower_components/qunit/qunit/qunit.js"></script>
 
     <script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.toolbarbutton.js"></script>
 

--- a/tests/unit/tree/tests.htm
+++ b/tests/unit/tree/tests.htm
@@ -9,6 +9,8 @@
 	<script type="text/javascript" src="../../../bower_components/jquery/dist/jquery.js"></script>
 	<script type="text/javascript" src="../../../bower_components/jquery-ui/jquery-ui.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.templating.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.datasource.js"></script>

--- a/tests/unit/upload/tests.html
+++ b/tests/unit/upload/tests.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="../../../bower_components/jquery-mockjax/src/jquery.mockjax.js"></script>
     <script type="text/javascript" src="mockServerUpload.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.ui.upload-en.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.upload.js"></script>

--- a/tests/unit/util/formatter/tests.html
+++ b/tests/unit/util/formatter/tests.html
@@ -15,6 +15,8 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/regional/infragistics.ui.regional-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/regional/infragistics.ui.regional-es.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 
 	<script type="text/javascript">
 		function runFormatterTests() {

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -15,6 +15,8 @@
 	<script type="text/javascript" src="../../../src/js/modules/i18n/regional/infragistics.ui.regional-en.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/i18n/regional/infragistics.ui.regional-es.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 <style>
 .container {
     position: relative;

--- a/tests/unit/validator/tests.html
+++ b/tests/unit/validator/tests.html
@@ -19,6 +19,8 @@
     <script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.ui.validator-en.js"></script>
 
     <script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+    <script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.datasource.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.templating.js"></script>
     <script type="text/javascript" src="../../../src/js/modules/infragistics.ui.popover.js"></script>

--- a/tests/unit/videoplayer/tests.html
+++ b/tests/unit/videoplayer/tests.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="../../../bower_components/jquery-ui/jquery-ui.js"></script>
 	<script type="text/javascript" src="mockVideo.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.shared.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/i18n/infragistics.ui.videoplayer-en.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.ui.videoplayer.js"></script>

--- a/tests/unit/zoombar/tests.html
+++ b/tests/unit/zoombar/tests.html
@@ -17,6 +17,8 @@
 	<script type="text/javascript" src="http://cdn-na.infragistics.com/igniteui/latest/js/modules/i18n/infragistics.dvcommonwidget-en.js"></script>
 
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquery.js"></script>
+	<script type="text/javascript" src="../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../src/js/modules/infragistics.datasource.js"></script>
 	<script type="text/javascript" src="http://cdn-na.infragistics.com/igniteui/latest/js/modules/infragistics.dv.core.js"></script>
 	<script type="text/javascript" src="http://cdn-na.infragistics.com/igniteui/latest/js/modules/infragistics.dvcommonwidget.js"></script>


### PR DESCRIPTION
This splits util.js into just the jquery specific section and a jquery independent section. This is a breaking change and means that most pages referencing the individual files will need to reference infragistics.util.jquery.js now in addition to infragistics.util.js, but enables some components to not include the jquery dependency if undesired.