### PR TITLE
Making sure that local groups are regenerated after remote requests initiated by other features.

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -4449,7 +4449,8 @@
 			}
 			if (s.type === "local" && s.defaultFields.length > 0) {
 				this.sort(s.defaultFields, s.defaultDirection);
-			} else if (this.isGroupByApplied(s.expressions)) {
+			}
+			if (this.isGroupByApplied(s.expressions)) {
 				this._generateGroupByData(this._filter ? this._filteredData : this._data,
 										s.expressions);
 			}


### PR DESCRIPTION
This is related to bug 229075.