### PR TITLE
Fix for bug #227598

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -3397,6 +3397,11 @@
 		},
 		_setSelectionRange: function (input, selectionStart, selectionEnd) {
 			if (input.setSelectionRange) {
+				// IE specific issue when the editor is detached
+				// and setSelectionRange is called as part of a composition mode end
+				if (!jQuery.contains(document.documentElement, input) && $.ig.util.isIE) {
+					return;
+				}
 				input.setSelectionRange(selectionStart, selectionEnd);
 			} else if (input.createTextRange) {
 				var range = input.createTextRange();


### PR DESCRIPTION
Adding an IE specific check for setSelectionRange so that it doesn't crash when the editor is detached and composition mode ends because of that.