### PR TITLE
Fixed the description of the tile manager method "splitter".

### DIFF
--- a/src/js/modules/infragistics.ui.tilemanager.js
+++ b/src/js/modules/infragistics.ui.tilemanager.js
@@ -2351,8 +2351,7 @@
             ```
                 $('.selector').igTileManager("splitter")
             ```
-                returnType="object|null" Returns the splitter associated with this tile manager or
-                null if the tile manager was instantiated with maximizedTileIndex.
+                returnType="object|null" Returns the splitter associated with this tile manager or null if the tile manager was instantiated with maximizedTileIndex.
             */
             return this._options.useMaximizedTileIndex ? null : this.element.data("igSplitter");
         },


### PR DESCRIPTION
Closes #675.