### PR TITLE
Fixing data source casing in combine list

### DIFF
--- a/build/packages/combined-files.js
+++ b/build/packages/combined-files.js
@@ -92,7 +92,7 @@ module.exports = {
             src: [
                     "./dist/js/i18n/infragistics-en.js",
                     "./dist/js/modules/infragistics.util.js",
-                    "./dist/js/modules/infragistics.dataSource.js",
+                    "./dist/js/modules/infragistics.datasource.js",
                     "./dist/js/modules/infragistics.templating.js",
                     "./dist/js/modules/infragistics.ui.shared.js",
                     "./dist/js/modules/infragistics.ui.scroll.js"


### PR DESCRIPTION
This should properly bundle the data source in core-lite and resolve https://github.com/IgniteUI/igniteui-angular2/issues/124 once a new npm package is released.