### PR TITLE
Fixing data source casing in combine list

### DIFF
--- a/build/packages/combined-files.js
+++ b/build/packages/combined-files.js
@@ -94,7 +94,7 @@ module.exports = {
                     "./dist/js/modules/infragistics.util.js",
                     "./dist/js/modules/infragistics.util.jquery.js",
                     "./dist/js/modules/infragistics.util.jquerydeferred.js",
-                    "./dist/js/modules/infragistics.dataSource.js",
+                    "./dist/js/modules/infragistics.datasource.js",
                     "./dist/js/modules/infragistics.templating.js",
                     "./dist/js/modules/infragistics.ui.shared.js",
                     "./dist/js/modules/infragistics.ui.scroll.js"


### PR DESCRIPTION
 \# Conflicts:
 \#	build/packages/combined-files.js
This should properly bundle the data source in core-lite.
Related #705 (16.2 PR) and IgniteUI/igniteui-angular2#124.