### PR TITLE
[igCombo] Extra apostrophe is in the type attribute (type="text’") PR 16.2

### DIFF
--- a/src/js/modules/infragistics.ui.combo.js
+++ b/src/js/modules/infragistics.ui.combo.js
@@ -1851,7 +1851,7 @@
                     $("<div>")).addClass(css.comboWrapper),
 				$combo = $("<div>").addClass(css.combo).attr("unselectable", "on"),
 				$input = (_options.$input ||
-                    $("<input type=text'>")).addClass(css.field)
+                    $("<input type='text'>")).addClass(css.field)
                     .attr({ tabIndex: options.tabIndex, autocomplete: "off" }),
 				$hiddenInput = $("<input type='hidden'>").addClass(css.hiddenField),
 				$fieldCont = $("<div>").addClass(css.fieldHolder),


### PR DESCRIPTION
Fix apostrophe in the type attribute
closes #715