### PR TITLE
#601 igCheckboxEditor coverage

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11560,10 +11560,6 @@
 			};
 			this._trigger(this.events.blur, event, args);
 		},
-		_updateValue: function (value) {
-			this.options.value = value;
-			this._valueInput.val(value);
-		},
 		_getState: function () {
 			var state;
 			if (this._inputValue !== undefined) {
@@ -11705,7 +11701,7 @@
 			if (delay) {
 				this._timeouts.push(setTimeout(function () {
 					self._cancelFocusTrigger = true;
-					this._editorContainer.focus();
+					self._editorContainer.focus();
 					self._setFocus();
 				}, delay));
 			} else {

--- a/tests/unit/editors/checkboxEditor/tests.html
+++ b/tests/unit/editors/checkboxEditor/tests.html
@@ -281,13 +281,25 @@
 		});
 
 		testId = '[ID10] Check focus using the focus API';
-		test(testId, 3, function () {
+		test(testId, 5, function () {
 		    $chk = $("#chkStyled"), $chk1 = $("#chkInput2"), css = $chk.data("igCheckboxEditor").css;
 		    $chk.igCheckboxEditor("setFocus");
 		    ok($chk.igCheckboxEditor("editorContainer").hasClass(css.focus), "Focus class not applied");
 		    ok($(document.activeElement).html() === $chk.igCheckboxEditor("editorContainer").html(), "Focus class not applied");
 		    $chk1.igCheckboxEditor("setFocus");
 		    ok($chk1.igCheckboxEditor("editorContainer").hasClass(css.focus), "Focus class not removed");
+
+			var $chkEditor = $('<input/>').appendTo("#testBedContainer").igCheckboxEditor({
+				checked: true
+			});
+			$chkEditor.igCheckboxEditor("setFocus", 500);
+			ok(!$chkEditor.igCheckboxEditor("editorContainer").hasClass(css.focus), "Focus class should not be still applied");
+			stop();
+			setTimeout(function() {
+				start();
+				ok($chkEditor.igCheckboxEditor("editorContainer").hasClass(css.focus), "Focus class should be applied");
+			}, 500);
+			$chkEditor.remove();
 		});
 
 		testId = '[ID11] Check exception when setting null';
@@ -349,7 +361,7 @@
         <h2 id="qunit-userAgent"></h2>
         <ol id="qunit-tests"></ol>
     </div>
-    <div style="float:left;overflow:auto;padding:20px;position:absolute;width:300px;">
+    <div id="testBedContainer" style="float:left;overflow:auto;padding:20px;position:absolute;width:300px;">
         <label id="label1" for="chkInput">Label 1</label>
         <input id="chkInput" />
         <label id="label2" for="chkInput2">Label 2</label>

--- a/tests/unit/editors/checkboxEditor/tests.html
+++ b/tests/unit/editors/checkboxEditor/tests.html
@@ -298,8 +298,8 @@
 			setTimeout(function() {
 				start();
 				ok($chkEditor.igCheckboxEditor("editorContainer").hasClass(css.focus), "Focus class should be applied");
+				$chkEditor.remove();
 			}, 500);
-			$chkEditor.remove();
 		});
 
 		testId = '[ID11] Check exception when setting null';


### PR DESCRIPTION
Cover setFocus function when parameter is used and remove unnecessary checkbox code.

closes #601