### PR TITLE
Fix for bug 230459

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -3280,7 +3280,11 @@
 		},
 		/* END Transactions for igTree */
 		_addTransaction: function (t) {
-			var exists = false, i = 0, prop, globalt, j, dirty = true, k;
+			var exists = false, i = 0, prop, globalt, j, dirty = true, k,
+				shouldAggregateTransactions = this.settings.autoCommit === false &&
+					this.settings.aggregateTransactions === true,
+				isSameAsOrigValue = false,
+				rec = shouldAggregateTransactions ? this.findRecordByKey(t.rowId) : null;
 			if (t.type === "cell") {
 				// check if we don't have an existing transaction and if we do, overwrite it
 				for (i = 0; i < this._transactionLog.length; i++) {
@@ -3288,26 +3292,26 @@
 						exists = true;
 						/* add extra check to see if the "new" value isn't the same as the
 						original one, in that case remove the existing transaction */
-						if (this.settings.autoCommit === false && this.settings.aggregateTransactions === true) {
+						if (shouldAggregateTransactions) {
 							/* we need to find the data source row corresponding to rowId */
-							for (j = 0; j < this.dataView().length; j++) {
-								if (this.dataView()[ j ][ this.settings.primaryKey ] === t.rowId &&
-									this.dataView()[ j ][ t.col ] === t.value) {
-									for (k = 0; k < this._accumulatedTransactionLog.length; k++) {
-										if (this._accumulatedTransactionLog[ k ].rowId === this._transactionLog[ i ].rowId) {
-											$.ig.removeFromArray(this._accumulatedTransactionLog, k);
-										}
+							if (rec && rec[ t.col ] === t.value) {
+								for (k = 0; k < this._accumulatedTransactionLog.length; k++) {
+									if (this._accumulatedTransactionLog[ k ].rowId === this._transactionLog[ i ].rowId) {
+										$.ig.removeFromArray(this._accumulatedTransactionLog, k);
 									}
-									/* remove the transaction because the last entered value is the same as the first one */
-									this._removeTransactionByTransactionId(this._transactionLog[ i ].tid);
-									dirty = false;
 								}
+								/* remove the transaction because the last entered value is the same as the first one */
+								this._removeTransactionByTransactionId(this._transactionLog[ i ].tid);
+								dirty = false;
 							}
 						}
 						if (dirty) {
 							this._transactionLog[ i ].value = t.value;
 							this._syncGlobalTransaction(this._transactionLog[ i ]);
 						}
+					}
+					if (shouldAggregateTransactions && rec && rec[ t.col ] === t.value) {
+						isSameAsOrigValue = true;
 					}
 				}
 				/* ensure we check the newly added rows as well */
@@ -3329,33 +3333,28 @@
 				for (i = 0; i < this._transactionLog.length; i++) {
 					if (this._transactionLog[ i ].rowId === t.rowId && this._transactionLog[ i ].type !== "cell") {
 						exists = true;
-						if (this.settings.autoCommit === false && this.settings.aggregateTransactions === true) {
+						if (shouldAggregateTransactions) {
 							dirty = false;
-							for (j = 0; j < this.dataView().length; j++) {
-								if (this.dataView()[ j ][ this.settings.primaryKey ] === t.rowId) {
-									/* now verify all values in the row correspond to the original ones */
-									for (prop in t.row) {
-										if (t.row.hasOwnProperty(prop) && t.row[ prop ] !== this.dataView()[ j ][ prop ]) {
-											dirty = true;
-											break;
-										}
-									}
+							/* now verify all values in the row correspond to the original ones */
+							for (prop in t.row) {
+								if (rec && t.row.hasOwnProperty(prop) && t.row[ prop ] !== rec[ prop ]) {
+									dirty = true;
 									break;
 								}
 							}
-							/* ensure we check the newly added rows as well */
-							for (j = 0, !dirty; j < this._transactionLog.length; j++) {
-								if (this._transactionLog[ j ].type === "newrow" &&
-									this._transactionLog[ j ].rowId === t.rowId) {
-									/* copy the t.row into newrow's row */
-									this._transactionLog[ j ].row = t.row;
-									/* we need to find and sync the global transaction */
-									this._syncGlobalTransaction(this._transactionLog[ j ]);
-									/* don't add "t" */
-									return;
-								}
+						/* ensure we check the newly added rows as well */
+						for (j = 0, !dirty; j < this._transactionLog.length; j++) {
+							if (this._transactionLog[ j ].type === "newrow" &&
+								this._transactionLog[ j ].rowId === t.rowId) {
+								/* copy the t.row into newrow's row */
+								this._transactionLog[ j ].row = t.row;
+								/* we need to find and sync the global transaction */
+								this._syncGlobalTransaction(this._transactionLog[ j ]);
+								/* don't add "t" */
+								return;
 							}
 						}
+					}
 						if (dirty) {
 							this._transactionLog[ i ].row = t.row;
 							this._syncGlobalTransaction(this._transactionLog[ i ]);
@@ -3370,6 +3369,15 @@
 						}
 					}
 				}
+				if (shouldAggregateTransactions) {
+					for (prop in t.row) {
+						isSameAsOrigValue = true;
+						if (!(t.row.hasOwnProperty(prop) && rec && t.row[ prop ] === rec[ prop ])) {
+							isSameAsOrigValue = false;
+							break;
+						}
+					}
+				}
 			} else if (t.type === "addnode" || t.type === "removenode") {
 				/* K.D. November 11th, 2013 Bug #155067 A deep copy of the object here throws
 				call stack exceeded with recursive objects, so moving the transaction push here and exiting. */
@@ -3378,7 +3386,7 @@
 				this._accumulatedTransactionLog.push(t);
 				return;
 			}
-			if (!exists) {
+			if (!exists && !isSameAsOrigValue) {
 				this._transactionLog.push(t);
 				/* A.T. 27 Sept. we need this change only for the global transaction log,
 				since it's the one that will go to the server for the local transaction log,

--- a/tests/unit/dataSource/transactions/tests.html
+++ b/tests/unit/dataSource/transactions/tests.html
@@ -121,6 +121,57 @@
 				equal(ds.data().length, 4, "The row is added only once.");
 			});
 
+			test("Test if transactions are correct when setting them to original value.", function () {
+				var ds = new $.ig.DataSource({
+					autoCommit: false,
+					aggregateTransactions: true,
+					dataSource: [
+						{ "ProductID": 1, "Name": "Test", "ProductNumber": "AR-5381" },
+						{ "ProductID": 2, "Name": "Test1", "ProductNumber": "BA-8327" },
+						{ "ProductID": 3, "Name": "Test1", "ProductNumber": "BE-2349" }
+					],
+					primaryKey: "ProductID"
+				}).dataBind();
+
+				ds.setCellValue(1, "Name", "Test1", false);
+				ds.setCellValue(2, "Name", "Test1", false);
+				ds.setCellValue(3, "Name", "Test1", false);
+
+				//verify transactions
+				var pending= ds.pendingTransactions();
+				var all = ds.allTransactions();
+
+				ok(pending.length === 1 && all.length === 1, "There should be only 1 transaction.");
+
+				ds.setCellValue(1, "Name", "Test", false);
+
+				pending= ds.pendingTransactions();
+				all = ds.allTransactions();
+
+				ok(pending.length === 0 && all.length === 0, "There should be no transaction.");
+
+				ds.updateRow(2, { "ProductID": 2, "Name": "Test", "ProductNumber": "New" }, false);
+				pending= ds.pendingTransactions();
+				all = ds.allTransactions();
+
+				ok(pending.length === 1 && all.length === 1, "There should be only 1 transaction.");
+				ok(pending[0].row.Name === "Test" && pending[0].row.ProductNumber === "New", "The transaction should contain the updated data.");
+
+				ds.updateRow(2, { "ProductID": 2, "Name": "Test", "ProductNumber": "BA-8327" }, false);
+
+				pending= ds.pendingTransactions();
+				all = ds.allTransactions();
+
+				ok(pending.length === 1 && all.length === 1, "There should be only 1 transaction.");
+				ok(pending[0].row.Name === "Test" && pending[0].row.ProductNumber === "BA-8327", "The transaction should contain the updated data.");
+
+				pending= ds.pendingTransactions();
+				all = ds.allTransactions();
+				ds.updateRow(2, { "ProductID": 2, "Name": "Test1", "ProductNumber": "BA-8327" }, false);
+				ok(pending.length === 0 && all.length === 0, "There should be no transaction.");
+			});
+
+
 			module("igDataSource transactions (autoCommit - ", {
 				setup: function() {
 					ds3 = new $.ig.DataSource({


### PR DESCRIPTION
If aggregateTransactions  is enabled when a value is changed from the original value to the exact same value via the updating API methods (setCellValue, updateRow) a transaction should not be generated.