### PR TITLE
Fix for bug #229997

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -11093,7 +11093,11 @@
 			if (this.settings.paging.enabled && this.settings.paging.type !== "remote") {
 				this._generateFlatDataAndCountProperties();
 			}
-			this.generateFlatDataView();
+			if (this.settings.type !== "remoteUrl") {
+				this.dataBind();
+			} else {
+				this.generateFlatDataView();
+			}
 		},
 		_preprocessAddRow: function (row, index, origDs, at, data) {
 			/* This function is called from _addRow - before adding row in data.

--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -11093,7 +11093,7 @@
 			if (this.settings.paging.enabled && this.settings.paging.type !== "remote") {
 				this._generateFlatDataAndCountProperties();
 			}
-			if (this.settings.type !== "remoteUrl") {
+			if (this._runtimeType !== "remoteUrl") {
 				this.dataBind();
 			} else {
 				this.generateFlatDataView();


### PR DESCRIPTION
When paging is enabled after editing a value in TreeGrid the tooltip
shows incorrect text



