### PR TITLE
Fix for bug #229440

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -3087,11 +3087,6 @@
 					this._commitTransaction(this._transactionLog.pop());
 				}
 			}
-			if (this.isGroupByApplied(this.settings.sorting.expressions)) {
-				this._generateGroupByData(this._filter ? this._filteredData :
-															this._data,
-										this.settings.sorting.expressions);
-			}
 		},
 		rollback: function (id) {
 			/* clears the transaction log without updating anything in the data source

--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -3607,6 +3607,11 @@
 				} else {
 					this.removeRecordByKey(t.rowId, origDs);
 				}
+				if (this.isGroupByApplied(this.settings.sorting.expressions)) {
+					this._generateGroupByData(this._filter ? this._filteredData :
+																this._data,
+											this.settings.sorting.expressions);
+				}
 			} else if (t.type === "newrow") {
 				this._addRow(t.row, -1, origDs);
 			} else if (t.type === "insertrow") {

--- a/tests/unit/dataSource/groupby/tests.html
+++ b/tests/unit/dataSource/groupby/tests.html
@@ -400,9 +400,9 @@
 				gbDataView = ds.groupByDataView();
 				dataView = ds.dataView();
 				renderData(gbDataView);
-				ok(gbDataView.length === 10 &&
-					gbDataView[8].__gbRecord === true &&
-					gbDataView[9].Id === i &&
+				ok(gbDataView.length === 9 &&
+					gbDataView[8].__gbRecord === undefined &&
+					gbDataView[8].Id === i &&
 					dataView.length === 5,
 				 	"Test groupByDataView and dataView after new row is added");
 				// test delete row


### PR DESCRIPTION
When new rows are added to the grid while there are grouped columns and
paging is enabled the rendered rows count does not match the total count
displayed in the pager label



