### PR TITLE
/* BUG:229991 Marin Popov 1.23.2017; When grid is MRL and width is in…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ bower_components
 
 #Build output
 dist
+.idea/ignite-ui.iml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml
+src/css/themes/prepros.cfg

--- a/src/css/structure/modules/infragistics.ui.grid.css
+++ b/src/css/structure/modules/infragistics.ui.grid.css
@@ -13,6 +13,11 @@
 /* Bug 214589 S.D., 22.02.2016, Missing borders; new classes for a MRL grid; header cell misalignment issue */
 .ui-iggrid-table-mrl,.ui-iggrid-headertable-mrl {border-collapse:collapse;table-layout:fixed;}
 
+/* BUG:229991 Marin Popov 1.23.2017; When grid is MRL and width is in % the header cells and content cells are misaligned.*/
+.ui-iggrid-headertable-mrl {
+	width: 100%;
+}
+
 .ui-iggrid>.ui-widget-header.ui-helper-reset {border-width:0;}
 
 .ui-widget-content.ui-iggrid-filterddlist, .ui-widget-content.ui-iggrid-hiding-dropdown-list, .ui-widget-content.ui-iggrid-columnmoving-dropdown-list, .ui-widget-content.ui-iggrid-featurechooser-list, .ui-iggrid-summaries-dropdown-listcontainer


### PR DESCRIPTION
… % the header cells and content cells are misaligned.*/

Closes # .  

Additional information related to this pull request:

