### PR TITLE
#593 Adding minValue/maxValue runtime set support for numerics and date editors.

### DIFF
--- a/src/js/modules/i18n/infragistics.ui.editors-bg.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-bg.js
@@ -66,8 +66,6 @@
 			    datePickerEditorNoSuchMethod: "Редакторът на дати не поддържа този метод.",
 			    datePickerNoSuchMethodDropDownContainer: "Редакторът на дати не поддържа този метод. Вместо него използвайте 'getCalendar'.",
 			    buttonTypeIsDropDownOnly: "Datepicker позволява само dropdown и чисти стойности за опцията buttonType.",
-			    dateEditorMinValue: "Опцията MinValue не може да бъде настроена по време на изпълнение.",
-			    dateEditorMaxValue: "Опцията MaxValue не може да бъде настроена по време на изпълнение.",
 			    cannotSetRuntime: "Тази опцията не може да бъде настроена по време на изпълнение.",
 			    invalidDate: "Невалидна дата",
 			    maskMessage: 'Всички задължителни позиции трябва да бъдат попълнени.',

--- a/src/js/modules/i18n/infragistics.ui.editors-de.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-de.js
@@ -66,8 +66,6 @@
 			    datePickerEditorNoSuchMethod: "Der Daten-Editor unterstützt diese Methode nicht.",
 			    datePickerNoSuchMethodDropDownContainer: "Der Daten-Editor unterstützt diese Methode nicht. Verwenden Sie stattdessen „getCalendar“.",
 			    buttonTypeIsDropDownOnly: "Der Datepicker erlaubt nur Dropdown und Wert löschen für die buttonType-Option.",
-			    dateEditorMinValue: "MinValue-Option kann nicht zur Laufzeit festgelegt werden.",
-			    dateEditorMaxValue: "MaxValue-Option kann nicht zur Laufzeit festgelegt werden.",
 			    cannotSetRuntime: "Diese Option kann nicht zur Laufzeit festgelegt werden",
                 invalidDate: "Ungültiges Datum",
                 maskMessage: 'Alle erforderlichen Positionen sollten ausgefüllt werden',

--- a/src/js/modules/i18n/infragistics.ui.editors-en.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-en.js
@@ -65,8 +65,6 @@
 				datePickerEditorNoSuchMethod: "The date editor does not support this method.",
 				datePickerNoSuchMethodDropDownContainer: "The date editor does not support this method. Use 'getCalendar' one instead.",
 				buttonTypeIsDropDownOnly: "Datepicker allows only dropdown and clear values for the buttonType option.",
-				dateEditorMinValue: "MinValue option can not be set runtime.",
-				dateEditorMaxValue: "MaxValue option can not be set runtime.",
 				setOptionError: 'Runtime changes are not allowed for the following option: ',
 				invalidDate: "Invalid date",
 				maskMessage: 'All required positions should be filled',

--- a/src/js/modules/i18n/infragistics.ui.editors-es.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-es.js
@@ -66,8 +66,6 @@
 			    datePickerEditorNoSuchMethod: "El editor de fechas no admite este método.",
 			    datePickerNoSuchMethodDropDownContainer: "El editor de fechas no admite este método. En su lugar, utilice 'getCalendar' uno.",
 			    buttonTypeIsDropDownOnly: "Datepicker sólo admite valores de desplegar menú y de borrar para la opción buttonType.",
-			    dateEditorMinValue: "La opción MinValue no puede establecer un tiempo de ejecución.",
-			    dateEditorMaxValue: "La opción MaxValue no puede establecer un tiempo de ejecución.",
 			    cannotSetRuntime: "Esta opción no puede establecer un tiempo de ejecución",
 			    invalidDate: "Fecha no válida",
 			    maskMessage: 'Deben rellenarse todas las posiciones requeridas.',

--- a/src/js/modules/i18n/infragistics.ui.editors-fr.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-fr.js
@@ -66,8 +66,6 @@
 			    datePickerEditorNoSuchMethod: "L’éditeur de date ne prend pas cette méthode en charge.",
 			    datePickerNoSuchMethodDropDownContainer: "L’éditeur de date ne prend pas cette méthode en charge. Utilisez 'getCalendar' à la place.",
 			    buttonTypeIsDropDownOnly: "Le sélecteur de dates autorise uniquement les valeurs de la liste déroulante ou d’effacement pour l’option buttonType.",
-			    dateEditorMinValue: "L’option MinValue ne peut pas être définie lors de l’exécution.",
-			    dateEditorMaxValue: "L’option MaxValue ne peut pas être définie lors de l’exécution.",
 			    cannotSetRuntime: "Cette option ne peut pas être définie lors de l’exécution",
 			    invalidDate: "Date non valide",
 			    maskMessage: 'Tous les postes requis doivent être remplis',

--- a/src/js/modules/i18n/infragistics.ui.editors-ja.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-ja.js
@@ -66,8 +66,6 @@
 			    datePickerEditorNoSuchMethod: "日付エディターはこのメソッドをサポートしません。",
 			    datePickerNoSuchMethodDropDownContainer: "日付エディターはこのメソッドをサポートしません。'getCalendar' メソッドを使用してください。",
 			    buttonTypeIsDropDownOnly: "Datepicker の buttonType オプションの有効な値は dropdown および clear 値のみです。",
-			    dateEditorMinValue: "MinValue オプションはランタイムに設定できません。",
-			    dateEditorMaxValue: "MaxValue オプションはランタイムに設定できません。",
 			    cannotSetRuntime: "このオプションはランタイムに設定できません。",
 			    invalidDate: "無効な日付",
 			    maskMessage: 'すべての必須文字を入力してください',

--- a/src/js/modules/i18n/infragistics.ui.editors-ru.js
+++ b/src/js/modules/i18n/infragistics.ui.editors-ru.js
@@ -66,8 +66,6 @@
 			    datePickerEditorNoSuchMethod: "Этот способ не поддерживается редактором дат.",
 			    datePickerNoSuchMethodDropDownContainer: "Этот метод не поддерживается редактором даты. Используйте взамен 'getCalendar'.",
 			    buttonTypeIsDropDownOnly: "Элемент выбора даты позволяет устанавливать значение параметра buttonType только dropdown и clear.",
-			    dateEditorMinValue: "Параметр MinValue не может быть задан во время выполнения программы.",
-			    dateEditorMaxValue: "Параметр MaxValue не может быть задан во время выполнения программы.",
 			    cannotSetRuntime: "Этот параметр не может быть задан во время выполнения программы",
 			    invalidDate: "Неверная дата",
 			    maskMessage: 'Следует заполнить все обязательные поля',

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2733,10 +2733,13 @@
 								this._triggerListItemClick(activeItem);
 							} else {
 								this._processValueChanging(currentInputVal);
+								this._enterEditMode();
 							}
 						} else {
 							// We repeat the logic in case we don't have dropdown list. On enter the value is updated with the current value into editorInput.
 							this._processValueChanging(currentInputVal);
+							// A. M. 20/07/2016 #98 'Value of numeric editor is not set to 'minValue' after pressing ENTER'
+							this._enterEditMode();
 						}
 					}
 				} else if (this._dropDownList) {
@@ -4413,10 +4416,6 @@
 				if (!isNaN(this.options.maxValue) && value > this.options.maxValue) {
 					value = this.options.maxValue;
 
-					// A. M. 18/07/2016 #98 'Value of numeric editor is not set to 'maxValue' after pressing ENTER'
-					this._valueInput.val(value);
-					this._enterEditMode();
-
 					//Raise warning
 					this._sendNotification("warning",
 						$.ig.util.stringFormat($.ig.Editor.locale.maxValExceedSetErrMsg,
@@ -4425,10 +4424,6 @@
 				// I.G. 29/11/2016 #539 'If min/max value is set to 0 and the entered value is invalid, the editor's value is not reverted'
 				} else if (!isNaN(this.options.minValue) && value < this.options.minValue) {
 					value = this.options.minValue;
-
-					// A. M. 20/07/2016 #98 'Value of numeric editor is not set to 'minValue' after pressing ENTER'
-					this._valueInput.val(value);
-					this._enterEditMode();
 
 						// Raise Warning level 2
 						this._sendNotification("warning",
@@ -4495,6 +4490,7 @@
 
 						// We repeat the logic in case we don't have dropdown list. On enter the value is updated with the current value into editorInput
 						this._processValueChanging(currentInputVal);
+						this._enterEditMode();
 					}
 
 				} else if (e.keyCode === 38) {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -10848,15 +10848,13 @@
 						(this._editorInput.data("datepicker").settings.minDate !==
 							this.options.minValue))
 					{
-						this.options.minValue =
-							this._editorInput.data("datepicker").settings.minDate;
+						this._setOption("minValue", this._editorInput.data("datepicker").settings.minDate);
 					}
 					if (value.maxDate &&
 						(this._editorInput.data("datepicker").settings.maxDate !==
 							this.options.maxValue))
 					{
-						this.options.maxValue =
-							this._editorInput.data("datepicker").settings.maxDate;
+						this._setOption("maxValue", this._editorInput.data("datepicker").settings.maxDate);
 					}
 				}
 					break;

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -7419,7 +7419,6 @@
 			value: null,
 			/* type="date" Gets the minimum value which can be entered in editor by user. Date object can be set as value. String value can be passed and the editor will use the javascript Date object constructor to create date object and will use it for the comparison. MVC date format can be used too.
 				Note! This option doesn't use the displayInputFormat to extract the date.
-				Note! This option can not be set runtime.
 				```
 					//Initialize
 					$(".selector").%%WidgetName%%({
@@ -7436,7 +7435,6 @@
 			minValue: null,
 			/* type="date" Gets the maximum value which can be entered in editor by user. Date object can be set as value. String value can be passed and the editor will use the javascript Date object constructor to create date object and will use it for the comparison. MVC date format can be used too.
 				Note! This option doesn't use the displayInputFormat to extract the date.
-				Note! This option can not be set runtime.
 				```
 					//Initialize
 					$(".selector").%%WidgetName%%({

--- a/tests/unit/editors/dateEditor/tests.html
+++ b/tests/unit/editors/dateEditor/tests.html
@@ -319,23 +319,31 @@
 			});
 
 			var testId = 'Set options, Apply options test';
-			test(testId, 6, function () {			 
+			test(testId, 8, function () {
+				var $editor = $('#inputEditor3');
+
 				// if prevValue is same as the newVal
-				$('#inputEditor3').igDateEditor("value", "10/10/2010");			   
+				$editor.igDateEditor("value", "10/10/2010");			   
 
 				// set minValue / maxValue:
-				$('#inputEditor3').igDateEditor("option", "minValue", new Date(2010, 0, 10).toLocaleString());
-				equal($('#inputEditor3').igDateEditor("option", "minValue").getTime(), new Date(2010, 0, 10).getTime(), "minValue not set correctly");
-				$('#inputEditor3').igDateEditor("option", "minValue", new Date(2011, 0, 10));
-				equal($('#inputEditor3').igDateEditor("value").getTime(), new Date(2011, 0, 10).getTime(), "Value not updated when setting minValue after that time.");
-				equal($('#inputEditor3').igDateEditor("field").val(), "1/10/2011 12:00 AM", "Text not updated when setting minValue after that time.");
+				$editor.igDateEditor("option", "minValue", new Date(2010, 0, 10).toLocaleString());
+				equal($editor.igDateEditor("option", "minValue").getTime(), new Date(2010, 0, 10).getTime(), "minValue not set correctly");
+				$editor.igDateEditor("option", "minValue", new Date(2011, 0, 10));
+				equal($editor.igDateEditor("value").getTime(), new Date(2011, 0, 10).getTime(), "Value not updated when setting minValue after that time.");
+				equal($editor.igDateEditor("field").val(), "1/10/2011 12:00 AM", "Text not updated when setting minValue after that time.");
 
-				$('#inputEditor3').igDateEditor("value", new Date(2014, 9, 10));	
-				$('#inputEditor3').igDateEditor("option", "maxValue", new Date(2015, 0, 12).toLocaleString());
-				equal($('#inputEditor3').igDateEditor("option", "maxValue").getTime(), new Date(2015, 0, 12).getTime(), "maxValue not set correctly");
-				$('#inputEditor3').igDateEditor("option", "maxValue", new Date(2014, 0, 12));
-				equal($('#inputEditor3').igDateEditor("value").getTime(), new Date(2014, 0, 12).getTime(), "Value not updated when setting maxValue before that time.");
-				equal($('#inputEditor3').igDateEditor("field").val(), "1/12/2014 12:00 AM", "Text not updated when setting maxValue before that time.");
+				$editor.igDateEditor("value", new Date(2014, 9, 10));	
+				$editor.igDateEditor("option", "maxValue", new Date(2015, 0, 12).toLocaleString());
+				equal($editor.igDateEditor("option", "maxValue").getTime(), new Date(2015, 0, 12).getTime(), "maxValue not set correctly");
+				$editor.igDateEditor("option", "maxValue", new Date(2014, 0, 12));
+				equal($editor.igDateEditor("value").getTime(), new Date(2014, 0, 12).getTime(), "Value not updated when setting maxValue before that time.");
+				equal($editor.igDateEditor("field").val(), "1/12/2014 12:00 AM", "Text not updated when setting maxValue before that time.");
+
+				//restore initial state:
+				$editor.igDateEditor("option", "minValue", null);
+				$editor.igDateEditor("option", "maxValue", null);
+				equal($editor.igDateEditor("option", "minValue"), null, "minValue not set to null");
+				equal($editor.igDateEditor("option", "maxValue"), null, "maxValue not set to null");
 			});
 
 			var testId = 'Initialize minVal and maxVal with wrong values';
@@ -417,7 +425,7 @@
 				$dtEditor.igDateEditor("value", "2021/12/31");
 				$dtEditor.trigger("blur");
 				equal($dtEditor.igDateEditor("value"), new Date("2020/12/31").toString(), 'The max value is not correctly applied');
-				equal($(".ui-ignotify-warn .ui-ignotify-content").text(), "Entry exceeded the maximum value of 2020/12/31 and was set to the maximum value", 'The maximum value warning not correct');
+				equal($dtEditor.igDateEditor("editorContainer").igNotifier("container").text(), "Entry exceeded the maximum value of 2020/12/31 and was set to the maximum value", 'The maximum value warning not correct');
 				//$(".ui-ignotify-warn .ui-igpopover-close-button").click();
 
 				// Set value different from ""			  
@@ -432,7 +440,7 @@
 				$dtEditor.igDateEditor("value", "2015/05/01");
 				$dtEditor.trigger("blur");
 				equal($dtEditor.igDateEditor("value"), new Date(2015, 6, 1).toString(), 'The value is not set to min');
-				equal($(".ui-ignotify-warn .ui-ignotify-content").text(), "Entry exceeded the minimum value of 2015/07/01 and was set to the minimum value", 'The initial value is not as expexted');
+				equal($dtEditor.igDateEditor("editorContainer").igNotifier("container").text(), "Entry exceeded the minimum value of 2015/07/01 and was set to the minimum value", 'The initial value is not as expexted');
 
 			});
 			

--- a/tests/unit/editors/dateEditor/tests.html
+++ b/tests/unit/editors/dateEditor/tests.html
@@ -318,20 +318,24 @@
 				$dtEditor2.igDateEditor("validator")._setOption("custom", null);
 			});
 
-			var testId = 'Set options, Apply options test';			
-			test(testId, 2, function () {			 
+			var testId = 'Set options, Apply options test';
+			test(testId, 6, function () {			 
 				// if prevValue is same as the newVal
 				$('#inputEditor3').igDateEditor("value", "10/10/2010");			   
 
-				// set MinVal
-				throws(function () {
-					$('#inputEditor3').igDateEditor("option", "minValue", "01/10/2010");
-				}, "Uncaught Error: MinValue option can not be set runtime.");
+				// set minValue / maxValue:
+				$('#inputEditor3').igDateEditor("option", "minValue", new Date(2010, 0, 10).toLocaleString());
+				equal($('#inputEditor3').igDateEditor("option", "minValue").getTime(), new Date(2010, 0, 10).getTime(), "minValue not set correctly");
+				$('#inputEditor3').igDateEditor("option", "minValue", new Date(2011, 0, 10));
+				equal($('#inputEditor3').igDateEditor("value").getTime(), new Date(2011, 0, 10).getTime(), "Value not updated when setting minValue after that time.");
+				equal($('#inputEditor3').igDateEditor("field").val(), "1/10/2011 12:00 AM", "Text not updated when setting minValue after that time.");
 
-				// set MinVal
-				throws(function () {
-					$('#inputEditor3').igDateEditor("option", "maxValue", "01/12/2015");
-				}, "Uncaught Error: MaxValue option can not be set runtime.");
+				$('#inputEditor3').igDateEditor("value", new Date(2014, 9, 10));	
+				$('#inputEditor3').igDateEditor("option", "maxValue", new Date(2015, 0, 12).toLocaleString());
+				equal($('#inputEditor3').igDateEditor("option", "maxValue").getTime(), new Date(2015, 0, 12).getTime(), "maxValue not set correctly");
+				$('#inputEditor3').igDateEditor("option", "maxValue", new Date(2014, 0, 12));
+				equal($('#inputEditor3').igDateEditor("value").getTime(), new Date(2014, 0, 12).getTime(), "Value not updated when setting maxValue before that time.");
+				equal($('#inputEditor3').igDateEditor("field").val(), "1/12/2014 12:00 AM", "Text not updated when setting maxValue before that time.");
 			});
 
 			var testId = 'Initialize minVal and maxVal with wrong values';

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -149,7 +149,7 @@
 			});
 
 			var testId = 'Date Picker min/max values.';
-			test(testId, 11, function () {
+			test(testId, 16, function () {
 				var $editor = $("<input />").appendTo("#testBedContainer")
 					.igDatePicker({
 						dateInputFormat: "dateTime"
@@ -164,7 +164,19 @@
 				$editor.igDatePicker("option", "maxValue", new Date(2017, 0, 31).toLocaleString());
 				equal($editor.igDatePicker("option", "maxValue").getTime(), new Date(2017, 0, 31).getTime(), "maxValue not set correctly");
 				equal($editor.datepicker("option", "maxDate").getTime(), new Date(2017, 0, 31).getTime(), "maxValue not set to picker");
+
+				// set through datepickerOptions (support for #84)
+				$editor.igDatePicker("value", new Date(2017, 0, 10));
+				$editor.igDatePicker({ datepickerOptions: { minDate : new Date(2017, 0, 11) } });
+				equal($editor.igDatePicker("option", "minValue").getTime(), new Date(2017, 0, 11).getTime(), "minValue not set correctly through datepickerOptions");
+				equal($editor.datepicker("option", "minDate").getTime(), new Date(2017, 0, 11).getTime(), "minDate not set through datepickerOptions");
+				equal($editor.igDatePicker("value").getTime(), new Date(2017, 0, 11).getTime(), "Value not updated when below min set through datepickerOptions");
+
+				$editor.igDatePicker({ datepickerOptions: { maxDate : new Date(2017, 1, 1) } });
+				equal($editor.igDatePicker("option", "maxValue").getTime(), new Date(2017, 1, 1).getTime(), "maxValue not set correctly through datepickerOptions");
+				equal($editor.datepicker("option", "maxDate").getTime(), new Date(2017, 1, 1).getTime(), "maxDate not set through datepickerOptions");
 				
+
 				$editor.igDatePicker("value", new Date(2017, 0, 11));
 				$editor.igDatePicker("option", "minValue", new Date(2017, 0, 12));
 				equal($editor.igDatePicker("value").getTime(), new Date(2017, 0, 12).getTime(), "Value not updated when setting minValue after that time.");

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -148,6 +148,39 @@
 				editor.igDatePicker("option", "isLimitedToListValues", false);
 			});
 
+			var testId = 'Date Picker min/max values.';
+			test(testId, 9, function () {
+				var $editor = $("<input />").appendTo("#testBedContainer")
+					.igDatePicker(),
+					$ddButton = $editor.igDatePicker("dropDownButton"),
+					$calendar = $editor.igDatePicker("getCalendar");
+				
+				$editor.igDatePicker("option", "minValue", new Date(2017, 0, 10).toLocaleString());
+				equal($editor.igDatePicker("option", "minValue").getTime(), new Date(2017, 0, 10).getTime(), "minValue not set correctly");
+				equal($editor.datepicker("option", "minDate").getTime(), new Date(2017, 0, 10).getTime(), "minValue not set to picker");
+
+				$editor.igDatePicker("option", "maxValue", new Date(2017, 0, 31).toLocaleString());
+				equal($editor.igDatePicker("option", "maxValue").getTime(), new Date(2017, 0, 31).getTime(), "maxValue not set correctly");
+				equal($editor.datepicker("option", "maxDate").getTime(), new Date(2017, 0, 31).getTime(), "maxValue not set to picker");
+				
+				$editor.igDatePicker("value", new Date(2017, 0, 11));
+				$editor.igDatePicker("option", "minValue", new Date(2017, 0, 12));
+				equal($editor.igDatePicker("value").getTime(), new Date(2017, 0, 12).getTime(), "Value not updated when setting minValue after that time.");
+
+				$ddButton.click();
+				stop();
+				$calendar.promise().done(function () {
+					start();
+					equal($calendar.find("td.ui-datepicker-current-day").text(), "12", "Picker selection not correct");
+					$editor.igDatePicker("option", "minValue", new Date(2017, 0, 13));
+					equal($calendar.find("td.ui-datepicker-current-day").text(), "13", "Picker selection not correct");
+					ok($calendar.find("td:contains(12)").hasClass("ui-state-disabled"), "MinValue did not update currently visible calendar");
+					$editor.igDatePicker("option", "maxValue", new Date(2017, 0, 30).toLocaleString());
+					ok($calendar.find("td:contains(31)").hasClass("ui-state-disabled"), "MaxValue did not update currently visible calendar");
+					//$editor.remove();
+				});
+			});
+
 			var testId = 'Date Picker onSelect event.';
 			test(testId,2,function(){
 				var editor = $('#inputEditor2').igDatePicker("field"),

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -149,9 +149,11 @@
 			});
 
 			var testId = 'Date Picker min/max values.';
-			test(testId, 9, function () {
+			test(testId, 11, function () {
 				var $editor = $("<input />").appendTo("#testBedContainer")
-					.igDatePicker(),
+					.igDatePicker({
+						dateInputFormat: "dateTime"
+					}),
 					$ddButton = $editor.igDatePicker("dropDownButton"),
 					$calendar = $editor.igDatePicker("getCalendar");
 				
@@ -166,18 +168,22 @@
 				$editor.igDatePicker("value", new Date(2017, 0, 11));
 				$editor.igDatePicker("option", "minValue", new Date(2017, 0, 12));
 				equal($editor.igDatePicker("value").getTime(), new Date(2017, 0, 12).getTime(), "Value not updated when setting minValue after that time.");
+				equal($editor.igDatePicker("field").val(), "1/12/2017 12:00 AM", "Text not updated when setting minValue after that time.");
 
 				$ddButton.click();
 				stop();
 				$calendar.promise().done(function () {
 					start();
 					equal($calendar.find("td.ui-datepicker-current-day").text(), "12", "Picker selection not correct");
+					
 					$editor.igDatePicker("option", "minValue", new Date(2017, 0, 13));
+					equal($editor.igDatePicker("field").val(), "01/12/2017 12:00 AM", "Text should not update.");
 					equal($calendar.find("td.ui-datepicker-current-day").text(), "13", "Picker selection not correct");
 					ok($calendar.find("td:contains(12)").hasClass("ui-state-disabled"), "MinValue did not update currently visible calendar");
+					
 					$editor.igDatePicker("option", "maxValue", new Date(2017, 0, 30).toLocaleString());
 					ok($calendar.find("td:contains(31)").hasClass("ui-state-disabled"), "MaxValue did not update currently visible calendar");
-					//$editor.remove();
+					$editor.remove();
 				});
 			});
 

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -607,7 +607,7 @@
 		});
 		
 		testId = "Min/Max value";
-		test(testId, 4, function () {
+		test(testId, 8, function () {
 			var container = $('#minMaxValue'), containerInput = $('#minMaxValue').igNumericEditor("field");
 
 			container.igNumericEditor("value", 9);
@@ -620,7 +620,23 @@
 			container.igNumericEditor("value", null);
 			equal($('#minMaxValue').igNumericEditor("value"), 99, "The maxValue is not respected");
 
-		});		
+			// runtime changes:
+			var $editor = $('<input id="privateFuncEditor" />')
+				.appendTo("#testBedContainer")
+				.igNumericEditor({
+					value: 5
+				});
+			
+			$editor.igNumericEditor("option", "minValue", -150);
+			strictEqual($editor.igNumericEditor("value"), 5, "Value should remain the same");
+			$editor.igNumericEditor("option", "maxValue", 5);
+			strictEqual($editor.igNumericEditor("value"), 5, "Value should remain the same");
+			$editor.igNumericEditor("option", "maxValue", 4);
+			strictEqual($editor.igNumericEditor("value"), 4, "Value should be set to max");
+			$editor.igNumericEditor("value", 0);
+			$editor.igNumericEditor("option", "minValue", 1);
+			strictEqual($editor.igNumericEditor("value"), 1, "Value should be set to min");
+		});
 
 		testId = "Scientific spin buttons";
 		test(testId, 2, function () {
@@ -1045,17 +1061,23 @@
 		});
 		
 		testId = 'Issue 226939'
-		test(testId, 3, function () {
+		test(testId, 6, function () {
 			var $editor = $("#issue226939"),
 				editorInput = $editor.igNumericEditor("field"), btnSpinDown = $editor.igNumericEditor("spinDownButton"),
 				btnSpinUp = $editor.igNumericEditor("spinUpButton");
 				
 				$editor.igNumericEditor("option", "minValue", 5);
-				$("#issue226939").igNumericEditor("spinUp");
-				equal($("#issue226939").igNumericEditor("value"), 5, 'Spin up method not working.');
 				ok(btnSpinDown.hasClass("ui-state-disabled"), "The spinDown button is not disabled.");
+				$editor.igNumericEditor("spinUp");
+				equal($editor.igNumericEditor("value"), 6, 'Spin up method not working.');
+				ok(!btnSpinDown.hasClass("ui-state-disabled"), "The spinDown button is not enabled.");
 				$editor.igNumericEditor("option", "minValue", 1);
-				ok(!(btnSpinDown.hasClass("ui-state-disabled")), "The spinDown button is disabled.");
+				ok(!(btnSpinDown.hasClass("ui-state-disabled")), "The spinDown button is enabled.");
+				$editor.igNumericEditor("option", "maxValue", 6);
+				ok(btnSpinUp.hasClass("ui-state-disabled"), "The spinUp button is not disabled.");
+				$editor.igNumericEditor("option", "minValue", 5);
+				$editor.igNumericEditor("value", 5);
+				ok(btnSpinDown.hasClass("ui-state-disabled"), "The spinDown button is not disabled.");
 		});
 
 		testing = "Clear button dynamic show/hide";

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -607,7 +607,7 @@
 		});
 		
 		testId = "Min/Max value";
-		test(testId, 8, function () {
+		test(testId, 15, function () {
 			var container = $('#minMaxValue'), containerInput = $('#minMaxValue').igNumericEditor("field");
 
 			container.igNumericEditor("value", 9);
@@ -621,8 +621,7 @@
 			equal($('#minMaxValue').igNumericEditor("value"), 99, "The maxValue is not respected");
 
 			// runtime changes:
-			var $editor = $('<input id="privateFuncEditor" />')
-				.appendTo("#testBedContainer")
+			var $editor = $('<input />').appendTo("#testBedContainer")
 				.igNumericEditor({
 					value: 5
 				});
@@ -633,9 +632,26 @@
 			strictEqual($editor.igNumericEditor("value"), 5, "Value should remain the same");
 			$editor.igNumericEditor("option", "maxValue", 4);
 			strictEqual($editor.igNumericEditor("value"), 4, "Value should be set to max");
+			equal($editor.igNumericEditor("field").val(), "4", "Text not updated with max value");
 			$editor.igNumericEditor("value", 0);
 			$editor.igNumericEditor("option", "minValue", 1);
 			strictEqual($editor.igNumericEditor("value"), 1, "Value should be set to min");
+			equal($editor.igNumericEditor("field").val(), "1", "Text not updated with min value");
+			$editor.focus();
+			$editor.igNumericEditor("field").val("3");
+			$editor.igNumericEditor("option", "minValue", 2);
+			strictEqual($editor.igNumericEditor("value"), 2, "Value not set to min while editng");
+			equal($editor.igNumericEditor("field").val(), "3", "Editing text should remain unchanged");
+			$editor.igNumericEditor("field").blur();			
+			strictEqual($editor.igNumericEditor("value"), 3, "Value not updated after chaning min");
+
+			// ensure base dataMode min/max, double:
+			$editor.igNumericEditor("option", "minValue", null);
+			$editor.igNumericEditor("option", "maxValue", null);
+			equal($editor.igNumericEditor("option", "minValue"), -(Number.MAX_VALUE), "minValue not set to null");
+			equal($editor.igNumericEditor("option", "maxValue"), Number.MAX_VALUE, "maxValue not set to null");
+
+			//$editor.remove();
 		});
 
 		testId = "Scientific spin buttons";

--- a/tests/unit/editors/percentEditor/tests.html
+++ b/tests/unit/editors/percentEditor/tests.html
@@ -137,6 +137,28 @@
 				strictEqual($('#pEditor4').data("igPercentEditor")._valueFromText("22%"), 0.22, "The parsed value is not correct");
 			});
 
+			testId = "Runtime Min/Max value";
+			test(testId, 6, function () {
+				var $editor = $('<input />').appendTo("#testBedContainer")
+					.igPercentEditor({
+						value: 0.5
+					});
+				
+				$editor.igPercentEditor("option", "minValue", -1.5);
+				strictEqual($editor.igPercentEditor("value"), 0.5, "Value should remain the same");
+				$editor.igPercentEditor("option", "maxValue", 0.5);
+				strictEqual($editor.igPercentEditor("value"), 0.5, "Value should remain the same");
+				$editor.igPercentEditor("option", "maxValue", 0.4);
+				strictEqual($editor.igPercentEditor("value"), 0.4, "Value should be set to max");
+				equal($editor.igPercentEditor("field").val(), "40.00%", "Text not updated with max value");
+				$editor.igPercentEditor("value", 0);
+				$editor.igPercentEditor("option", "minValue", 0.1);
+				strictEqual($editor.igPercentEditor("value"), 0.1, "Value should be set to min");
+				equal($editor.igPercentEditor("field").val(), "10.00%", "Text not updated with min value");
+
+				$editor.remove();
+			});
+
 			var testId = 'Editors initialization with display factor different from 1 and 100';
 			test(testId, 3, function () {			   
 				throws(function () {


### PR DESCRIPTION
#593
Numerics - min/max are still handled by `dataMode` if set back to null.
Date - Had to reuse the set handler to ensure the editor can update it's value if min/max are set through `datepickerOptions`.

There's a slight change from moving the fix for #98 - Hitting enter to set the value now (by default) selects the input text due to re-entering edit mode, as opposed to no feedback on success.