### PR TITLE
#812 Fixed typo in deselectAll code snippet in the documentation.

### DIFF
--- a/src/js/modules/infragistics.ui.combo.js
+++ b/src/js/modules/infragistics.ui.combo.js
@@ -7262,7 +7262,7 @@
                 $(".selector").igCombo("deselectAll");
 
                 //deselect all, focus combo, keep input text and trigger events
-                $(".selector").igCombo("deselectAll", { focusCombo: ture, keepInputText: true }, true);
+                $(".selector").igCombo("deselectAll", { focusCombo: true, keepInputText: true }, true);
             ```
                 paramType="object" optional="true" Object with set of options controlling the behavior of this api method.
                     focusCombo (boolean): Set to true to focus combo after the deselection.


### PR DESCRIPTION
Closes #812 .

