### PR TITLE
Added translations for default summary labels

### DIFF
--- a/src/js/modules/i18n/infragistics.util-ja.js
+++ b/src/js/modules/i18n/infragistics.util-ja.js
@@ -28,11 +28,11 @@
 			    chromeDownload: "http://www.google.co.jp/chrome/intl/ja/landing_ff.html?hl=ja",
 			    firefoxDownload: "http://www.mozilla.com/",
 			    safariDownload: "http://www.apple.com/jp/safari/download/",
-			    defaultSummaryMethodLabelMin: "Min = ",
-			    defaultSummaryMethodLabelMax: "Max = ",
-			    defaultSummaryMethodLabelSum: "Sum = ",
-			    defaultSummaryMethodLabelAvg: "Avg = ",
-			    defaultSummaryMethodLabelCount: "Count = "
+			    defaultSummaryMethodLabelMin: "最小値 = ",
+			    defaultSummaryMethodLabelMax: "最大値 = ",
+			    defaultSummaryMethodLabelSum: "合計 = ",
+			    defaultSummaryMethodLabelAvg: "平均 = ",
+			    defaultSummaryMethodLabelCount: "数値の個数 = "
 		    }
 	    });
 


### PR DESCRIPTION
I added translations for new entries that were added to the util file.
I don't know if they were added only in master or in 16.2 as well.  Please advise if I should change the pull request.
Also, should these match some text that is defined elsewhere?  @yoshimis suggested the translation for "count" summary that Excel uses, and if we should check that the same summary text is used elsewhere, I'd like to include that change.

