### PR TITLE
#876 Use zero time parts for selected date on initial selection

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -7983,6 +7983,14 @@
 			}
 			return date;
 		},
+		_setNewDateMidnight: function () {
+			var date = new Date();
+			this._setDateField("hours", date, 0);
+			this._setDateField("minutes", date, 0);
+			this._setDateField("seconds", date, 0);
+			this._setDateField("milliseconds", date, 0);
+			return date;
+		},
 		_getInternalMaskedValue: function (newDate) {
 			return this._updateMaskedValue(newDate, true);
 		},
@@ -10664,7 +10672,8 @@
 
 						//T.P. 10th Dec 2015 211062: When there is no value and the datepicker selects value the stored date object needs to be with current time.
 						//In Case there is no dateObject which meand the editor has no value when the date is selected it will be with current time value (hours, minutes, seconds)
-						date = new Date();
+						//D.P. 16th Mar 2017 #876: Warning popup is displayed when maxValue date is selected on the dropdown calendar.
+						date = self._setNewDateMidnight();
 					}
 					date = self._setDateField("year", date, dateFromPicker.getFullYear());
 

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -38,7 +38,7 @@
 						"208264", "210971", "211010", "211062", "210990", "210106", "211575",
 					"208274", "207546", "207321", "212596", "212374", "212642", "215549", "217214", "216789",
 					"218836", "218752", "220479", "220712", "221118", "221494", "221300", "98", "223245", "264", "226", "539",
-					"646"];
+					"646", "876"];
 					
 					for (var i = 0; i < testbedIDs.length; i++) {
 						var testBed = "Bug" + testbedIDs[i] + "Testbed";
@@ -746,27 +746,15 @@
 					} else {
 						month = month.toString();
 					}
-					hours = date.getHours();
-					if (hours < 10) {
-						hours = "0" + hours;
-					} else {
-						hours = hours.toString();
-					}
-					minutes = date.getMinutes();
-					if (minutes < 10) {
-						minutes = "0" + minutes;
-					} else {
-						minutes = minutes.toString();
-					}
 					result += day;
 					result += "/";
 					result += month;
 					result += "/";
 					result += date.getFullYear();
 					result += " ";
-					result += hours;
+					result += "00";
 					result += ":";
-					result += minutes;
+					result += "00";
 
 					return result;
 				}
@@ -782,6 +770,32 @@
 				equal($("#211062Editor1").igDatePicker("field").val(), getDDmmYYYYHHSS(targetDate), "The text should've changed to " + getDDmmYYYYHHSS(targetDate));
 			});
 			
+			
+			testId = 'Bug 876';
+			test(testId, 2, function () {
+				// D.P. Updated for  #876:Warning popup is displayed when maxValue date is selected on the dropdown calendar.
+				var todayDate = new Date(), $editor;
+				
+				todayDate.setHours(0);
+				todayDate.setMinutes(0);
+				todayDate.setSeconds(0);
+				todayDate.setMilliseconds(0);
+				$editor = $("<input />").appendTo("#testBedContainer")
+					.igDatePicker({
+						maxValue: todayDate,
+						dateDisplayFormat: "yy/MM/dd dddd"
+					});
+
+				$editor.igDatePicker("dropDownButton").click();
+				stop();
+				setTimeout(function () {
+					start();
+					$editor.igDatePicker("getCalendar").find(".ui-datepicker-today").find("a").click();
+					equal($editor.igDatePicker("value").getTime(), todayDate.getTime(), "Max value not selected");
+					ok(!$editor.igDatePicker("editorContainer").hasClass($.ui.igNotifier.prototype.css.warningState), "Warning message should not be shown");
+					$editor.remove();
+				}, 400); //This timeout is need because the test requires calendar which needs focus
+			});
 			
 			testId = 'Bug 210990';
 			test(testId, 3, function () {

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -230,7 +230,7 @@
 								start();
 								var newDate = $("#inputEditor2").igDatePicker("value");
 
-								ok(!newDate.toString().contains("00:00:00"), "The time is not correct.")
+								ok(newDate.toString().contains("00:00:00"), "The time is not correct.")
 							},100);
 						},100);
 					},100);


### PR DESCRIPTION
Closes #876  .  

Additional information related to this pull request:
This applies in part changes already made in master for #536
The change is to use 0 time components instead of current time only on the initial date picker selection as it produces unexpected results when comparing with set max value and is also consistent with the value produced if you manually type in the exact same date, so I consider it very minor.
