### PR TITLE
Fix bower jquery version to 3.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "package.json"
   ],
   "dependencies": {
-    "jquery": "^3.1.0",
+    "jquery": "3.1.1",
     "jquery-ui": "^1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to changes in jQuery 3.2.0 temporary restricting the version of the bower package.
