### PR TITLE
Remove references to jQuery in Ignite UI code so that only $ is used from what is provided through the AMD wrapper.

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -4416,8 +4416,8 @@
 				/*A.T. workaround for jQuery's 1.5 and above bug related to dataFilter and success callback.
 				We need to explicitly set the dataType to "text" when manually parsing it */
 				/* get jquery version */
-				if (jQuery.fn.jquery) {
-					ver = jQuery.fn.jquery.split(".");
+				if ($.fn.jquery) {
+					ver = $.fn.jquery.split(".");
 				}
 				if (ver && ver.length >= 2) {
 					/* if jQuery is 1.5 and greater or if the first major version is greater than 1 (when jQuery 2 comes out)

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -3500,7 +3500,7 @@
 			if (input.setSelectionRange) {
 				// IE specific issue when the editor is detached
 				// and setSelectionRange is called as part of a composition mode end
-				if (!jQuery.contains(document.documentElement, input) && $.ig.util.isIE) {
+				if (!$.contains(document.documentElement, input) && $.ig.util.isIE) {
 					return;
 				}
 				input.setSelectionRange(selectionStart, selectionEnd);

--- a/src/js/modules/infragistics.ui.notifier.js
+++ b/src/js/modules/infragistics.ui.notifier.js
@@ -653,7 +653,7 @@
 		},
 		_setNewContent: function (nc) {
 			var newContent = nc;
-			if (nc instanceof jQuery) {
+			if (nc instanceof $) {
 				newContent = nc.html();
 			} else if (typeof nc === "object") {
 				newContent = nc.innerHTML;

--- a/src/js/modules/infragistics.ui.popover.js
+++ b/src/js/modules/infragistics.ui.popover.js
@@ -208,7 +208,7 @@
 					}
 					break;
 				case "containment":
-					if (value instanceof jQuery) {
+					if (value instanceof $) {
 						this.options.containment = value;
 					}
 					break;
@@ -566,7 +566,7 @@
 			/* D.K. checking the node type of the element as an alternative of "instanceof HTMLElement" for IE8
 			nodeType === 1 represents an elements */
 			if ( t && ( ( window.HTMLElement !== undefined &&
-				( t instanceof HTMLElement || t instanceof jQuery ) && showEvt ) ||
+				( t instanceof HTMLElement || t instanceof $ ) && showEvt ) ||
 				(typeof t[ 0 ] === "object") && (t[ 0 ].nodeType === 1) &&
 				( typeof t[ 0 ].style === "object" ) &&
 				( typeof t[ 0 ].ownerDocument === "object" ) ) ) {
@@ -593,7 +593,7 @@
 			/* D.K. checking the node type of the element as an alternative of "instanceof HTMLElement" for IE8
 			nodeType === 1 represents an elements */
 			if ( t && ( ( window.HTMLElement !== undefined &&
-				( t instanceof HTMLElement || t instanceof jQuery ) ) ||
+				( t instanceof HTMLElement || t instanceof $ ) ) ||
 				(typeof t[ 0 ] === "object") && (t[ 0 ].nodeType === 1) &&
 				( typeof t[ 0 ].style === "object" ) &&
 				( typeof t[ 0 ].ownerDocument === "object" ) ) ) {
@@ -1021,7 +1021,7 @@
 		},
 		_setNewContent: function (nc) {
 			var newContent = nc;
-			if (nc instanceof jQuery) {
+			if (nc instanceof $) {
 				newContent = nc.html();
 			} else if (typeof nc === "object") {
 				newContent = nc.innerHTML;

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -4407,7 +4407,7 @@
 					control._showVolumeSlider();
 				},
 				mouseout: function (event) {
-					if (!jQuery.contains(event.currentTarget, event.relatedTarget) &&
+					if (!$.contains(event.currentTarget, event.relatedTarget) &&
 						event.currentTarget !== event.relatedTarget) {
 						control._volumeSliderTimeoutId =
 							setTimeout($.proxy(control._hideVolumeSlider, control),

--- a/src/js/modules/infragistics.ui.zoombar.js
+++ b/src/js/modules/infragistics.ui.zoombar.js
@@ -1098,7 +1098,7 @@
 				// target is specified we"ll get the element from there
 				if (typeof opts.target === "string") {
 					this._target = $(opts.target);
-				} else if (opts.target instanceof jQuery) {
+				} else if (opts.target instanceof $) {
 					this._target = $(opts.target[ 0 ]);
 				}
 			} else {
@@ -1247,7 +1247,7 @@
 		},
 		_dragCont: function (left, evt) {
 			var ol = this._cw.left, ow = this._cw.width, nl = ol, nw = ow, args, dragging = false, noCancel;
-			if (!this._draggedElement || !(this._draggedElement instanceof jQuery)) {
+			if (!this._draggedElement || !(this._draggedElement instanceof $)) {
 				return;
 			}
 			if (this._draggedElement.hasClass("ui-igzoombar-window-handle-left")) {

--- a/src/js/modules/infragistics.util.jquerydeferred.js
+++ b/src/js/modules/infragistics.util.jquerydeferred.js
@@ -117,7 +117,7 @@
 					type;
 				for (i = 0, length = args.length; i < length; i++) {
 					elem = args[ i ];
-					type = jQuery.type(elem);
+					type = $.type(elem);
 					if (type === "array") {
 
 						// Inspect recursively
@@ -329,7 +329,7 @@
 				},
 				pipe: function (fnDone, fnFail, fnProgress) {
 					return $.ig.util.jqueryDeferred(function (newDefer) {
-						jQuery.each({
+						$.each({
 							done: [ fnDone, "resolve" ],
 							fail: [ fnFail, "reject" ],
 							progress: [ fnProgress, "notify" ]
@@ -337,10 +337,10 @@
 							var fn = data[ 0 ],
 								action = data[ 1 ],
 								returned;
-							if (jQuery.isFunction(fn)) {
+							if ($.isFunction(fn)) {
 								deferred[ handler ](function () {
 									returned = fn.apply(this, arguments);
-									if (returned && jQuery.isFunction(returned.promise)) {
+									if (returned && $.isFunction(returned.promise)) {
 										returned.promise().then(newDefer.resolve, newDefer.reject, newDefer.notify);
 									} else {
 										newDefer[ action + "With" ](this === deferred ? newDefer : this, [ returned ]);


### PR DESCRIPTION
Regarding task 235134.