### PR TITLE
adding css for marker colors

### DIFF
--- a/src/css/themes/infragistics/infragistics.theme.css
+++ b/src/css/themes/infragistics/infragistics.theme.css
@@ -3242,6 +3242,54 @@ input.ui-igbutton {
   background-color: #9f725f!important;
   border: 1px solid #fff!important;
 }
+.ui-chart-marker-palette-1 {
+  background-color: #fff!important;
+  border: 1px solid #7446B9!important;
+}
+.ui-chart-marker-palette-2 {
+  background-color: #fff!important;
+  border: 1px solid #9FB328!important;
+}
+.ui-chart-marker-palette-3 {
+  background-color: #fff!important;
+  border: 1px solid #F96232!important;
+}
+.ui-chart-marker-palette-4 {
+  background-color: #fff!important;
+  border: 1px solid #2E9CA6!important;
+}
+.ui-chart-marker-palette-5 {
+  background-color: #fff!important;
+  border: 1px solid #DC3F76!important;
+}
+.ui-chart-marker-palette-6 {
+  background-color: #fff!important;
+  border: 1px solid #FF9800!important;
+}
+.ui-chart-marker-palette-7 {
+  background-color: #fff!important;
+  border: 1px solid #3F51B5!important;
+}
+.ui-chart-marker-palette-8 {
+  background-color: #fff!important;
+  border: 1px solid #439C47!important;
+}
+.ui-chart-marker-palette-9 {
+  background-color: #fff!important;
+  border: 1px solid #795548!important;
+}
+.ui-chart-marker-palette-10 {
+  background-color: #fff!important;
+  border: 1px solid #9A9A9A!important;
+}
+.ui-chart-marker-palette-11 {
+  background-color: #fff!important;
+  border: 1px solid #C62828!important;
+}
+.ui-chart-marker-palette-12 {
+  background-color: #fff!important;
+  border: 1px solid #9f725f!important;
+}
 .ui-chart-legend,
 .ui-chart-piechart-container {
   border: none;

--- a/src/css/themes/infragistics/infragistics.theme.css
+++ b/src/css/themes/infragistics/infragistics.theme.css
@@ -3196,51 +3196,51 @@ input.ui-igbutton {
 /***********/
 .ui-chart-palette-1 {
   background-color: #7446B9!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #7446B9!important;
 }
 .ui-chart-palette-2 {
   background-color: #9FB328!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #9FB328!important;
 }
 .ui-chart-palette-3 {
   background-color: #F96232!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #F96232!important;
 }
 .ui-chart-palette-4 {
   background-color: #2E9CA6!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #2E9CA6!important;
 }
 .ui-chart-palette-5 {
   background-color: #DC3F76!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #DC3F76!important;
 }
 .ui-chart-palette-6 {
   background-color: #FF9800!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #FF9800!important;
 }
 .ui-chart-palette-7 {
   background-color: #3F51B5!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #3F51B5!important;
 }
 .ui-chart-palette-8 {
   background-color: #439C47!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #439C47!important;
 }
 .ui-chart-palette-9 {
   background-color: #795548!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #795548!important;
 }
 .ui-chart-palette-10 {
   background-color: #9A9A9A!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #9A9A9A!important;
 }
 .ui-chart-palette-11 {
   background-color: #C62828!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #C62828!important;
 }
 .ui-chart-palette-12 {
   background-color: #9f725f!important;
-  border: 1px solid #fff!important;
+  border: 1px solid #9f725f!important;
 }
 .ui-chart-marker-palette-1 {
   background-color: #fff!important;


### PR DESCRIPTION
Added support for the chart markers to pull default marker brushes and outlines from css so add the css to the Infragistics theme.

Closes # .  

Additional information related to this pull request:

