### PR TITLE
Update the gitignore file and delete an unnecessary variables.css file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,13 @@ bower_components
 #Build output
 dist
 .idea/
+_framework.css
+_infragistics.igniteui.theme.css
+_infragistics.jqueryui.theme.css
+_variables-igniteui.css
+framework.css
+infragistics.igniteui.theme.css
+infragistics.jqueryui.theme.css
+variables-igniteui.css
+variables.css
 src/css/themes/prepros.cfg


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:
Sometimes those files are generated depending on the file watcher setting. We don't want them in GitHub

