### PR TITLE
Adding scheduler description into master

### DIFF
--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -130,7 +130,8 @@ $.ig.loaderClass.locale.descriptions = {
 	dateTimeAxisDescription: "Allows for configuring DateTimeAxis.",
 	overviewPlusDetailPaneDescription: "Component that display an OverviewPlusDetailPane over the igDataChart plot area.",
 	zoombarDescription: "The igZoombar control provides zooming functionality to range-based controls.",
-	mapDescription: "The igMap visualize various kinds of maps based on the HTML5 canvas element and performs all rendering on the client-side."
+	mapDescription: "The igMap visualize various kinds of maps based on the HTML5 canvas element and performs all rendering on the client-side.",
+	schedulerDescription: "Component that provides scheduling solution for presenting and managing time periods and associated activities."
 };
 
 // jscs:enable


### PR DESCRIPTION
Adding scheduler description to the `$.ig.loaderClass.locale.descriptions` class required by the script combiner parser for the view generation.