### PR TITLE
Add dependency to igExcel.Functions for igSpreadsheet

### DIFF
--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -1767,6 +1767,7 @@ $.ig.dependencies = [
 			{ name: "_ig_dv_jquerydom" },
 			{ name: "_ig_documents_core_openxml" },
 			{ name: "igExcel" },
+			{ name: "Functions", parentWidget: "igExcel" },
 			{ name: "igCombo" },
 			{ name: "_ig_undo" }
 		],


### PR DESCRIPTION
After some discussion we decided that spreadsheet should have a required dependency on the Excel functions so formulas could be evaluated.

