### PR TITLE
Menu structure overrides for jquery ui pre 1.11 use of anchors

### DIFF
--- a/src/css/structure/modules/infragistics.ui.spreadsheet.css
+++ b/src/css/structure/modules/infragistics.ui.spreadsheet.css
@@ -14,6 +14,11 @@
 	white-space: nowrap;
 }
 
+.ui-igspreadsheet .ui-menu-item > a {
+	text-decoration: none;
+	white-space: nowrap;
+}
+
 .ui-igspreadsheet .ui-menu-divider {
 	margin: 0;
 	border-top: none;


### PR DESCRIPTION
Prior to 1.11 jquery ui would use anchors within the menu items. Our current spreadsheet styling for menu items turns off wrapping for the 1.11 and later menus but didn't handle the older structure where we don't want the underlines of anchors nor the text wrapping of the (sub)menu items.

