### PR TITLE
Added some css for doughnut chart to allow it to use different colors from the igDataChart

### DIFF
--- a/src/css/themes/infragistics/infragistics.theme.css
+++ b/src/css/themes/infragistics/infragistics.theme.css
@@ -128,6 +128,50 @@
   background-color: #c33d4a!important;
   border: 1px solid #872933!important;
 }
+.doughnutPalette2 {
+  background-color: #9FB328!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette3 {
+  background-color: #F96232!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette4 {
+  background-color: #2E9CA6!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette5 {
+  background-color: #DC3F76!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette6 {
+  background-color: #FF9800!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette7 {
+  background-color: #3F51B5!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette8 {
+  background-color: #439C47!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette9 {
+  background-color: #795548!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette10 {
+  background-color: #9A9A9A!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette11 {
+  background-color: #C62828!important;
+  border: 1px solid #fff!important;
+}
+.doughnutPalette12 {
+  background-color: #9f725f!important;
+  border: 1px solid #fff!important;
+}
 /*  Misc    */
 /************/
 .boxShadow {
@@ -3381,6 +3425,57 @@ input.ui-igbutton {
 }
 .ui-chart-outerlabels {
   color: #666 !important;
+}
+/******************/
+/* Doughnut Chart */
+/******************/
+.ui-doughnut-palette-1 {
+  background-color: #7446B9!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-2 {
+  background-color: #9FB328!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-3 {
+  background-color: #F96232!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-4 {
+  background-color: #2E9CA6!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-5 {
+  background-color: #DC3F76!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-6 {
+  background-color: #FF9800!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-7 {
+  background-color: #3F51B5!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-8 {
+  background-color: #439C47!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-9 {
+  background-color: #795548!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-10 {
+  background-color: #9A9A9A!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-11 {
+  background-color: #C62828!important;
+  border: 1px solid #fff!important;
+}
+.ui-doughnut-palette-12 {
+  background-color: #9f725f!important;
+  border: 1px solid #fff!important;
 }
 /*******************/
 /* Sparkline chart */

--- a/src/css/themes/infragistics/infragistics.theme.less
+++ b/src/css/themes/infragistics/infragistics.theme.less
@@ -160,6 +160,65 @@
     background-color: #c33d4a!important;
     border: 1px solid #872933!important;
 }
+.doughnutPalette1 {
+    background-color: #7446B9!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette2 {
+    background-color: #9FB328!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette3 {
+    background-color: #F96232!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette4 {
+    background-color: #2E9CA6!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette5 {
+    background-color: #DC3F76!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette6 {
+    background-color: #FF9800!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette7 {
+    background-color: #3F51B5!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette8 {
+    background-color: #439C47!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette9 {
+    background-color: #795548!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette10 {
+    background-color: #9A9A9A!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette11 {
+    background-color: #C62828!important;
+    border: 1px solid #fff!important;
+}
+
+.doughnutPalette12 {
+    background-color: #9f725f!important;
+    border: 1px solid #fff!important;
+}
 /*  Misc    */
 /************/
 
@@ -3106,6 +3165,57 @@ input.ui-igbutton {
 }
 .ui-chart-outerlabels {
     color: #666 !important;
+}
+
+/******************/
+/* Doughnut Chart */
+/******************/
+.ui-doughnut-palette-1 {
+    .doughnutPalette1;
+}
+
+.ui-doughnut-palette-2 {
+    .doughnutPalette2;
+}
+
+.ui-doughnut-palette-3 {
+    .doughnutPalette3;
+}
+
+.ui-doughnut-palette-4 {
+    .doughnutPalette4;
+}
+
+.ui-doughnut-palette-5 {
+    .doughnutPalette5;
+}
+
+.ui-doughnut-palette-6 {
+    .doughnutPalette6;
+}
+
+.ui-doughnut-palette-7 {
+    .doughnutPalette7;
+}
+
+.ui-doughnut-palette-8 {
+    .doughnutPalette8;
+}
+
+.ui-doughnut-palette-9 {
+    .doughnutPalette9;
+}
+
+.ui-doughnut-palette-10 {
+    .doughnutPalette10;
+}
+
+.ui-doughnut-palette-11 {
+    .doughnutPalette11;
+}
+
+.ui-doughnut-palette-12 {
+    .doughnutPalette12;
 }
 
 /*******************/


### PR DESCRIPTION
Currently the doughnut chart is using css from the ui-chart-palette class.  This results in the doughnut chart rendering slice outlines that match the slice fill color.  If you have hierarchical ring series present it can be hard to differentiate where one slice begins and another ends if they happen to use the same fill color.

This change allows the doughnut chart to use a different palette which will default to having a white outline.

### Additional information related to this pull request:

