### PR TITLE
Implement issue #1060. Make custom/native scrollbars more flexible in general.

### DIFF
--- a/src/css/structure/modules/infragistics.ui.scroll.css
+++ b/src/css/structure/modules/infragistics.ui.scroll.css
@@ -42,10 +42,17 @@
 	position: absolute;
 	right: 0px;
 	top: 0px;
+	height: 100%;
 }
 
 .igscroll-vtrack {
+	top: 15px;
+	bottom: 30px;
+	position: absolute;
+}
 
+.igscroll-vtrack-singlescrollbar {
+	bottom: 15px !important;
 }
 
 /* Vertical arrow - general */
@@ -93,6 +100,20 @@
 }
 
 /* Arrow Down */
+.igscroll-downarrow {
+	bottom: 15px;
+	position: absolute;
+}
+
+.igscroll-downarrow-singlescrollbar {
+	bottom: 0px !important;
+}
+
+.igscroll-downarrow-active {
+	bottom: 15px;
+	position: absolute;
+}
+
 .igscroll-downarrow:before {
 	-webkit-transform: rotate(-180deg);
 	-moz-transform: rotate(-180deg);
@@ -146,11 +167,19 @@
 	height: 15px;
 	position: absolute;
 	bottom: 0px;
+	width: 100%;
 }
 
 .igscroll-htrack {
 	height: 15px;
 	float: left;
+	left: 15px;
+	right: 30px;
+	position: absolute;
+}
+
+.igscroll-htrack-singlescrollbar {
+	right: 15px !important;
 }
 
 /* Horizontal arrow - general */
@@ -199,6 +228,20 @@
 }
 
 /* Arrow Right */
+.igscroll-rightarrow {
+	right: 15px;
+	position: absolute;
+}
+
+.igscroll-rightarrow-singlescrollbar {
+	right: 0px !important;
+}
+
+.igscroll-rightarrow-active {
+	right: 15px;
+	position: absolute;
+}
+
 .igscroll-rightarrow:before {
 	-webkit-transform: rotate(90deg);
 	-moz-transform: rotate(90deg);

--- a/src/css/structure/modules/infragistics.ui.scroll.css
+++ b/src/css/structure/modules/infragistics.ui.scroll.css
@@ -49,10 +49,11 @@
 	top: 15px;
 	bottom: 30px;
 	position: absolute;
+	width: 15px;
 }
 
-.igscroll-vtrack-singlescrollbar {
-	bottom: 15px !important;
+.igscroll-vtrack-single {
+	bottom: 15px;
 }
 
 /* Vertical arrow - general */
@@ -90,7 +91,7 @@
 	transform: rotate(0);
 }		
 
-.igscroll-uparrow-active:before {
+.igscroll-uparrow:active:before {
 	background-image: url('../images/igScroll/up_active.png');
 	-webkit-transform: rotate(0);
 	-moz-transform: rotate(0);
@@ -105,13 +106,8 @@
 	position: absolute;
 }
 
-.igscroll-downarrow-singlescrollbar {
-	bottom: 0px !important;
-}
-
-.igscroll-downarrow-active {
-	bottom: 15px;
-	position: absolute;
+.igscroll-downarrow-single {
+	bottom: 0px;
 }
 
 .igscroll-downarrow:before {
@@ -122,7 +118,7 @@
 	transform: rotate(-180deg);
 }		
 
-.igscroll-downarrow-active:before {
+.igscroll-downarrow:active:before {
 	background-image: url('../images/igScroll/up_active.png');
 	-webkit-transform: rotate(-180deg);
 	-moz-transform: rotate(-180deg);
@@ -178,8 +174,8 @@
 	position: absolute;
 }
 
-.igscroll-htrack-singlescrollbar {
-	right: 15px !important;
+.igscroll-htrack-single {
+	right: 15px;
 }
 
 /* Horizontal arrow - general */
@@ -218,7 +214,7 @@
 	transform: rotate(-90deg);
 }	
 
-.igscroll-leftarrow-active:before {
+.igscroll-leftarrow:active:before {
 	background-image: url('../images/igScroll/up_active.png');
 	-webkit-transform: rotate(-90deg);
 	-moz-transform: rotate(-90deg);
@@ -233,13 +229,8 @@
 	position: absolute;
 }
 
-.igscroll-rightarrow-singlescrollbar {
-	right: 0px !important;
-}
-
-.igscroll-rightarrow-active {
-	right: 15px;
-	position: absolute;
+.igscroll-rightarrow-single {
+	right: 0px;
 }
 
 .igscroll-rightarrow:before {
@@ -250,7 +241,7 @@
 	transform: rotate(90deg);
 }		
 
-.igscroll-rightarrow-active:before {
+.igscroll-rightarrow:active:before {
 	background-image: url('../images/igScroll/up_active.png');
 	-webkit-transform: rotate(90deg);
 	-moz-transform: rotate(90deg);

--- a/src/css/structure/modules/infragistics.ui.scroll.css
+++ b/src/css/structure/modules/infragistics.ui.scroll.css
@@ -283,34 +283,42 @@
 *  Native Scrollbars  *
 ***********************/
 .igscroll-vnative-outer {
-	position: relative;
+	position: absolute;
 	float: right;
 	width: 18px;
 	overflow-x: hidden;
 	overflow-y: auto;
+	top: 0;
 	right: 0px;
 }
 
+.igscroll-vnative-outer-single {
+	bottom: 0px;
+}
+
 .igscroll-vnative-inner {
-	width: 17px;
+	width: 1px;
 }
 
 .igscroll-hnative-outer {
-	position: relative;
+	position: absolute;
 	height: 18px;
-	bottom: 2px;
 	overflow-x: auto;
 	overflow-y: hidden;
+	left: 0px;
+	bottom: 0px;
+}
+
+.igscroll-hnative-outer-single {
+	right: 0px;
 }
 
 .igscroll-hnative-inner {
-	height: 17px;
+	height: 1px;
 }
 
 .igscroll-filler {
 	position: absolute;
-	width: 17px;
-	height: 17px;
 	right: 0px;
 	bottom: 0px;
 	background-color: white;

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -801,8 +801,6 @@
 			this._contentWidth = this._content[ 0 ].scrollWidth;
 			this._percentInViewH = this._elemWidth / this._contentWidth;
 			this._percentInViewV = this._elemHeight / this._contentHeight;
-			this._customBarArrowsSize = 15;
-			this._customBarEmptySpaceSize = 15;
 
 			//1 equals 100%
 			this._isScrollableV = this._percentInViewV < 1;
@@ -1161,24 +1159,61 @@
 		},
 
 		_refreshScrollbars: function () {
-			var containerSizeOffset = this._bMixedEnvironment ? this._customBarEmptySpaceSize : 0;
+			var	css = this.css,
+				nativeScrollSize = $.ig.util.getScrollWidth();
 			this._elemHeight = this.element.height();
 			this._elemWidth = this.element.width();
 
 			if (this.options.scrollbarType === "custom" && this._vBarTrack && this._vBarDrag) {
 				this._vDragHeight = this._percentInViewV * 100;
 				this._vBarDrag.css("height", this._vDragHeight + "%");
+				/* Update classes if only vertical scrollbar will be visible */
+				if (this._percentInViewH >= 1) {
+					this._vBarTrack.addClass(css.verticalScrollTrackSingleScrollbar);
+					this._vBarArrowDown.addClass(css.verticalScrollArrowDownSingleScrollbar);
+				} else {
+					this._vBarTrack.removeClass(css.verticalScrollTrackSingleScrollbar);
+					this._vBarArrowDown.removeClass(css.verticalScrollArrowDownSingleScrollbar);
+				}
 			} else if (this.options.scrollbarType === "native" && this._vBarContainer && this._vBarDrag) {
 				this._vDragHeight = this._content.height();
 				this._vBarDrag.css("height", this._vDragHeight + "px");
+				/* Update classes if only vertical scrollbar will be visible */
+				if (this._percentInViewH >= 1 &&
+					!this._vBarContainer.hasClass(css.nativeVScrollOuterSingle)) {
+					this._vBarContainer.css("bottom", "");
+					this._vBarContainer.addClass(this.css.nativeVScrollOuterSingle);
+				} else if (this._percentInViewH < 1 &&
+					this._vBarContainer.hasClass(css.nativeVScrollOuterSingle)) {
+					this._vBarContainer.removeClass(css.nativeVScrollOuterSingle);
+					this._vBarContainer.css("bottom", nativeScrollSize + "px");
+				}
 			}
 
 			if (this.options.scrollbarType === "custom" && this._hBarTrack && this._hBarDrag) {
 				this._hDragWidth = this._percentInViewH * 100;
 				this._hBarDrag.css("width", this._hDragWidth + "%");
+				/* Update classes if only vertical scrollbar will be visible */
+				if (this._percentInViewV >= 1) {
+					this._hBarTrack.addClass(css.horizontalScrollTrackSingleScrollbar);
+					this._hBarArrowRight.addClass(css.horizontalScrollArrowRightSingleScrollbar);
+				} else {
+					this._hBarTrack.removeClass(css.horizontalScrollTrackSingleScrollbar);
+					this._hBarArrowRight.removeClass(css.horizontalScrollArrowRightSingleScrollbar);
+				}
 			} else if (this.options.scrollbarType === "native" && this._hBarContainer && this._hBarDrag) {
 				this._hDragWidth = this._content.width();
 				this._hBarDrag.css("width", this._hDragWidth + "px");
+				/* Update classes if only horozontal scrollbar will be visible */
+				if (this._percentInViewV >= 1 &&
+					!this._hBarContainer.hasClass(css.nativeHScrollOuterSingle)) {
+					this._hBarContainer.css("right", "");
+					this._hBarContainer.addClass(css.nativeHScrollOuterSingle);
+				} else if (this._percentInViewV < 1 &&
+					this._hBarContainer.hasClass(css.nativeHScrollOuterSingle)) {
+					this._hBarContainer.removeClass(css.nativeHScrollOuterSingle);
+					this._hBarContainer.css("right", nativeScrollSize + "px");
+				}
 			}
 
 			this._updateScrollBarsVisibility();
@@ -2491,8 +2526,7 @@
 
 		_initNativeScrollBarV: function (bRenderScrollbarH) {
 			var css = this.css,
-				nativeScrollSize = $.ig.util.getScrollWidth(),
-				containerSizeOffset = this._bMixedEnvironment ? this._customBarEmptySpaceSize : 0;
+				nativeScrollSize = $.ig.util.getScrollWidth();
 
 			this._vBarContainer = $("<div id='" + this.element.attr("id") + "_vBar'></div>")
 				.addClass(css.nativeVScrollOuter);
@@ -2535,8 +2569,7 @@
 
 		_initNativeScrollBarH: function (bRenderScrollbarV) {
 			var css = this.css,
-				nativeScrollSize = $.ig.util.getScrollWidth(),
-				containerSizeOffset = this._bMixedEnvironment ? this._customBarEmptySpaceSize  : 0;
+				nativeScrollSize = $.ig.util.getScrollWidth();
 
 			this._hBarContainer = $("<div id='" + this.element.attr("id") + "_hBar'></div>")
 				.addClass(css.nativeHScrollOuter);
@@ -2544,7 +2577,7 @@
 			if (!bRenderScrollbarV) {
 				this._hBarContainer.addClass(css.nativeHScrollOuterSingle);
 			} else {
-				this._hBarContainer.css("right", nativeScrollSize + "px")
+				this._hBarContainer.css("right", nativeScrollSize + "px");
 			}
 
 			/* We need the width without the padding, so we have proper scroll position */

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -653,6 +653,8 @@
 			verticalScrollContainer: "igscroll-vcontainer",
 			/* Classes applied to the track of the custom vertical scrollbar */
 			verticalScrollTrack: "igscroll-vtrack",
+			/* Classes applied to the track of the custom vertical scrollbar when no horizontal scrollbar is displayed */
+			verticalScrollTrackSingleScrollbar: "igscroll-vtrack-singlescrollbar",
 			/* Classes applied to the arrows of the custom vertical scrollbar */
 			verticalScrollArrow: "igscroll-varrow",
 			/* Classes applied to the Arrow Up of the custom vertical scrollbar */
@@ -663,6 +665,8 @@
 			verticalScrollArrowDown: "igscroll-downarrow",
 			/* Classes applied to the Arrow Down of the custom vertical scrollbar when it is active */
 			verticalScrollArrowDownActive: "igscroll-downarrow-active",
+			/* Classes applied to the Arrow Down of the custom vertical scrollbar when the horizontal scrollbar is not visible */
+			verticalScrollArrowDownSingleScrollbar: "igscroll-downarrow-singlescrollbar",
 			/* Classes applied to the thumb drag of the custom vertical scrollbar */
 			verticalScrollThumbDrag: "igscroll-vdrag",
 			/* Classes applied to the thumb drag of the custom vertical scrollbar when it is in thin form */
@@ -673,6 +677,8 @@
 			horizontalScrollContainer: "igscroll-hcontainer",
 			/* Classes applied to the track of the custom horizontal scrollbar  */
 			horizontalScrollTrack: "igscroll-htrack",
+			/* Classes applied to the track of the custom horizontal scrollbar when no vertical scrollbar is displayed */
+			horizontalScrollTrackSingleScrollbar: "igscroll-htrack-singlescrollbar",
 			/* Classes applied to the arrows of the custom horizontal scrollbar */
 			horizontalScrollArrow: "igscroll-harrow",
 			/* Classes applied to the Arrow Left of the custom horizontal scrollbar */
@@ -683,6 +689,8 @@
 			horizontalScrollArrowRight: "igscroll-rightarrow",
 			/* Classes applied to the Arrow Right of the custom horizontal scrollbar when it is active */
 			horizontalScrollArrowRightActive: "igscroll-rightarrow-active",
+			/* Classes applied to the Arrow Right of the custom horizontal scrollbar when the vertical scrollbar is not visible */
+			horizontalScrollArrowRightSingleScrollbar: "igscroll-rightarrow-singlescrollbar",
 			/* Classes applied to the thumb drag of the custom horizontal scrollbar */
 			horizontalScrollThumbDrag: "igscroll-hdrag",
 			/* Classes applied to the thumb drag of the custom horizontal scrollbar when it is in thin form */
@@ -1161,12 +1169,9 @@
 
 			if (this.options.scrollbarType === "custom" && this._vBarTrack && this._vBarDrag) {
 				// jscs:disable
-				this._vDragHeight = (this._elemHeight - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize)) * this._percentInViewV;
+				this._vDragHeight = this._percentInViewV * 100;
 				// jscs:enable
-				this._vBarContainer.css("height", (this._elemHeight - this._customBarEmptySpaceSize) + "px");
-				this._vBarDrag.css("height", this._vDragHeight + "px");
-				this._vBarTrack.css("height",
-									this._elemHeight - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize) + "px");
+				this._vBarDrag.css("height", this._vDragHeight + "%");
 			} else if (this.options.scrollbarType === "native" && this._vBarContainer && this._vBarDrag) {
 				this._vBarContainer.css("height", (this._elemHeight - containerSizeOffset) + "px");
 				this._vDragHeight = this._getContentHeight();
@@ -1175,12 +1180,9 @@
 
 			if (this.options.scrollbarType === "custom" && this._hBarTrack && this._hBarDrag) {
 				// jscs:disable
-				this._hDragWidth = (this._elemWidth - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize)) * this._percentInViewH;
+				this._hDragWidth = this._percentInViewH * 100;
 				// jscs:enable
-				this._hBarContainer.css("width", (this._elemWidth - this._customBarEmptySpaceSize) + "px");
-				this._hBarDrag.css("width", this._hDragWidth + "px");
-				this._hBarTrack.css("width",
-									this._elemWidth - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize) + "px");
+				this._hBarDrag.css("width", this._hDragWidth + "%");
 			} else if (this.options.scrollbarType === "native" && this._hBarContainer && this._hBarDrag) {
 				this._hBarContainer.css("width", (this._elemWidth - containerSizeOffset) + "px");
 				this._hDragWidth = this._getContentWidth();
@@ -2448,19 +2450,29 @@
 		},
 
 		_updateScrollBarsVisibility: function () {
+			var bRenderScrollbarV = this._isScrollableV &&
+									!this._vBarContainer &&
+									this._renderVerticalScrollbar,
+				bRenderScrollbarH = this._isScrollableH &&
+									!this._hBarContainer &&
+									this._renderHorizontalScrollbar,
+				bRemoveScrollbarV = (!this._isScrollableV || !this._renderVerticalScrollbar) &&
+									this._vBarContainer,
+				bRemoveScrollbarH = (!this._isScrollableH || !this._renderHorizontalScrollbar) &&
+									this._hBarContainer;
 			if (this.options.scrollbarType === "none") {
 				return;
 			}
 
 			if (this.options.scrollbarType === "native") {
-				if (this._isScrollableV && !this._vBarContainer && this._renderVerticalScrollbar) {
-					this._initNativeScrollBarV();
-				} else if ((!this._isScrollableV || !this._renderVerticalScrollbar) && this._vBarContainer) {
+				if (bRenderScrollbarV) {
+					this._initNativeScrollBarV(bRenderScrollbarH);
+				} else if (bRemoveScrollbarV) {
 					this._removeVerticalScrollbar();
 				}
-				if (this._isScrollableH && !this._hBarContainer && this._renderHorizontalScrollbar) {
-					this._initNativeScrollBarH();
-				} else if ((!this._isScrollableH || !this._renderHorizontalScrollbar) && this._hBarContainer) {
+				if (bRenderScrollbarH) {
+					this._initNativeScrollBarH(bRenderScrollbarV);
+				} else if (bRemoveScrollbarH) {
 					this._removeHorizontalScrollbar();
 				}
 
@@ -2473,14 +2485,14 @@
 						.css("padding-bottom", "0px");
 				}
 			} else if (this.options.scrollbarType === "custom") {
-				if (this._isScrollableV && !this._vBarContainer && this._renderVerticalScrollbar) {
-					this._initCustomScrollBarV();
-				} else if ((!this._isScrollableV || !this._renderVerticalScrollbar) && this._vBarContainer) {
+				if (bRenderScrollbarV) {
+					this._initCustomScrollBarV(bRenderScrollbarH);
+				} else if (bRemoveScrollbarV) {
 					this._removeVerticalScrollbar();
 				}
-				if (this._isScrollableH && !this._hBarContainer && this._renderHorizontalScrollbar) {
-					this._initCustomScrollBarH();
-				} else if ((!this._isScrollableH || !this._renderHorizontalScrollbar) && this._hBarContainer) {
+				if (bRenderScrollbarH) {
+					this._initCustomScrollBarH(bRenderScrollbarV);
+				} else if (bRemoveScrollbarH) {
 					this._removeHorizontalScrollbar();
 				}
 
@@ -2614,32 +2626,37 @@
 			}
 		},
 
-		_initCustomScrollBarV: function () {
+		/** Initialize the custom vertical scrollbar
+			bRenderScrollbarH - gets wheter or not the horizontal scrollbar will be rendered as well
+		*/
+		_initCustomScrollBarV: function (bRenderScrollbarH) {
 			var css = this.css;
 
 			this._vBarContainer = $("<div id='" + this.element.attr("id") + "_vBar'></div>")
-				.addClass(css.verticalScrollContainer)
-				.css("height", this._elemHeight - this._customBarEmptySpaceSize + "px");
+				.addClass(css.verticalScrollContainer);
 
 			this._vBarArrowUp =	$("<div id='" +	this.element.attr("id") + "_vBar_arrowUp'></div>")
 				.addClass(css.verticalScrollArrow)
 				.addClass(css.verticalScrollArrowUp);
 
 			this._vBarTrack = $("<div id='" + this.element.attr("id") + "_vBar_track'></div>")
-				.addClass(css.verticalScrollTrack)
-				.css("height",
-					this._elemHeight - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize) + "px");
+				.addClass(css.verticalScrollTrack);
 
 			this._vBarArrowDown = $("<div id='" + this.element.attr("id") +	"_vBar_arrowDown'></div>")
 				.addClass(css.verticalScrollArrow)
 				.addClass(css.verticalScrollArrowDown);
 
 			// jscs:disable
-			this._vDragHeight = (this._elemHeight - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize)) * this._percentInViewV;
+			this._vDragHeight = this._percentInViewV * 100;
 			// jscs:enable
 			this._vBarDrag = $("<span id='" + this.element.attr("id") + "_vBar_drag'></span>")
 				.addClass(css.verticalScrollThumbDrag + " " + css.verticalScrollThumbDragThin)
-				.css("height", this._vDragHeight + "px");
+				.css("height", this._vDragHeight + "%");
+
+			if (!bRenderScrollbarH) {
+				this._vBarTrack.addClass(css.verticalScrollTrackSingleScrollbar);
+				this._vBarArrowDown.addClass(css.verticalScrollArrowDownSingleScrollbar);
+			}
 
 			if (this.options.scrollbarVParent) {
 				this._vBarContainer
@@ -3094,32 +3111,37 @@
 			this._bUseVDrag = false;
 		},
 
-		_initCustomScrollBarH: function () {
+		/** Initialize the custom horizontal scrollbar
+			bRenderScrollbarV - gets wheter or not the vertical scrollbar will be rendered as well
+		*/
+		_initCustomScrollBarH: function (bRenderScrollbarV) {
 			var css = this.css;
 
 			this._hBarContainer = $("<div id='" + this.element.attr("id") + "_hBar'></div>")
-				.addClass(css.horizontalScrollContainer)
-				.css("width", this._elemWidth + "px");
+				.addClass(css.horizontalScrollContainer);
 
 			this._hBarArrowLeft = $("<div id='" + this.element.attr("id") + "_hBar_arrowLeft'></div>")
 				.addClass(css.horizontalScrollArrow)
 				.addClass(css.horizontalScrollArrowLeft);
 
 			this._hBarTrack = $("<div id='" + this.element.attr("id") + "_hBar_track'></div>")
-				.addClass(css.horizontalScrollTrack)
-				.css("width",
-					this._elemWidth - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize) + "px");
+				.addClass(css.horizontalScrollTrack);
 
 			this._hBarArrowRight = $("<div id='" + this.element.attr("id") + "_hBar_arrowRight'></div>")
 				.addClass(css.horizontalScrollArrow)
 				.addClass(css.horizontalScrollArrowRight);
 
 			// jscs:disable
-			this._hDragWidth = (this._elemWidth - (2 * this._customBarArrowsSize + this._customBarEmptySpaceSize)) * this._percentInViewH;
+			this._hDragWidth = this._percentInViewH * 100;
 			// jscs:enable
 			this._hBarDrag = $("<span id='" + this.element.attr("id") + "_hBar_drag'></span>")
 				.addClass(css.horizontalScrollThumbDrag + " " + css.horizontalScrollThumbDragThin)
-				.css("width", this._hDragWidth + "px");
+				.css("width", this._hDragWidth + "%");
+
+			if (!bRenderScrollbarV) {
+				this._hBarTrack.addClass(css.horizontalScrollTrackSingleScrollbar);
+				this._hBarArrowRight.addClass(css.horizontalScrollArrowRightSingleScrollbar);
+			}
 
 			if (this.options.scrollbarHParent) {
 				this._hBarContainer
@@ -3652,7 +3674,9 @@
 			function updateCSS() {
 				if (self._hBarDrag) {
 					// jscs:disable
-					calculatedDest = destX * (self._elemWidth - 2 * self._customBarArrowsSize - self._customBarEmptySpaceSize) / self._getContentWidth();
+					/**	destX * self._percentInViewH - the translated position of the thumb based on the scroll position
+						(self._hBarTrack.width() / self.element.width() - multiple with it since the track is not 100% the width of the container and the thumb will go out of it otherwise */
+					calculatedDest = destX * self._percentInViewH * (self._hBarTrack.width() / self.element.width());
 					// jscs:enable
 					self._hBarDrag
 						.css("-webkit-transform", "translate3d(" + calculatedDest + "px, 0px, 0px)") /* Safari */
@@ -3661,7 +3685,9 @@
 				}
 				if (self._vBarDrag) {
 					// jscs:disable
-					calculatedDest = destY * (self._elemHeight - 2 * self._customBarArrowsSize - self._customBarEmptySpaceSize) / self._getContentHeight();
+					/**	destY * self._percentInViewV - the translated position of the thumb based on the scroll position
+						(self._vBarTrack.height() / self.element.height()) - multiple with it since the track is not 100% the height of the container and the thumb will go out of it otherwise */
+					calculatedDest = destY * self._percentInViewV * (self._vBarTrack.height() / self.element.height());
 					// jscs:enable
 					self._vBarDrag
 						.css("-webkit-transform", "translate3d(0px, " + calculatedDest + "px, 0px)")

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -654,19 +654,15 @@
 			/* Classes applied to the track of the custom vertical scrollbar */
 			verticalScrollTrack: "igscroll-vtrack",
 			/* Classes applied to the track of the custom vertical scrollbar when no horizontal scrollbar is displayed */
-			verticalScrollTrackSingleScrollbar: "igscroll-vtrack-singlescrollbar",
+			verticalScrollTrackSingleScrollbar: "igscroll-vtrack-single",
 			/* Classes applied to the arrows of the custom vertical scrollbar */
 			verticalScrollArrow: "igscroll-varrow",
 			/* Classes applied to the Arrow Up of the custom vertical scrollbar */
 			verticalScrollArrowUp: "igscroll-uparrow",
-			/* Classes applied to the Arrow Up of the custom vertical scrollbar when it is active */
-			verticalScrollArrowUpActive: "igscroll-uparrow-active",
 			/* Classes applied to the Arrow Down of the custom vertical scrollbar */
 			verticalScrollArrowDown: "igscroll-downarrow",
-			/* Classes applied to the Arrow Down of the custom vertical scrollbar when it is active */
-			verticalScrollArrowDownActive: "igscroll-downarrow-active",
 			/* Classes applied to the Arrow Down of the custom vertical scrollbar when the horizontal scrollbar is not visible */
-			verticalScrollArrowDownSingleScrollbar: "igscroll-downarrow-singlescrollbar",
+			verticalScrollArrowDownSingleScrollbar: "igscroll-downarrow-single",
 			/* Classes applied to the thumb drag of the custom vertical scrollbar */
 			verticalScrollThumbDrag: "igscroll-vdrag",
 			/* Classes applied to the thumb drag of the custom vertical scrollbar when it is in thin form */
@@ -678,19 +674,15 @@
 			/* Classes applied to the track of the custom horizontal scrollbar  */
 			horizontalScrollTrack: "igscroll-htrack",
 			/* Classes applied to the track of the custom horizontal scrollbar when no vertical scrollbar is displayed */
-			horizontalScrollTrackSingleScrollbar: "igscroll-htrack-singlescrollbar",
+			horizontalScrollTrackSingleScrollbar: "igscroll-htrack-single",
 			/* Classes applied to the arrows of the custom horizontal scrollbar */
 			horizontalScrollArrow: "igscroll-harrow",
 			/* Classes applied to the Arrow Left of the custom horizontal scrollbar */
 			horizontalScrollArrowLeft: "igscroll-leftarrow",
-			/* Classes applied to the Arrow Left of the custom horizontal scrollbar when it is active */
-			horizontalScrollArrowLeftActive: "igscroll-leftarrow-active",
 			/* Classes applied  to the Arrow Right of the custom horizontal scrollbar */
 			horizontalScrollArrowRight: "igscroll-rightarrow",
-			/* Classes applied to the Arrow Right of the custom horizontal scrollbar when it is active */
-			horizontalScrollArrowRightActive: "igscroll-rightarrow-active",
 			/* Classes applied to the Arrow Right of the custom horizontal scrollbar when the vertical scrollbar is not visible */
-			horizontalScrollArrowRightSingleScrollbar: "igscroll-rightarrow-singlescrollbar",
+			horizontalScrollArrowRightSingleScrollbar: "igscroll-rightarrow-single",
 			/* Classes applied to the thumb drag of the custom horizontal scrollbar */
 			horizontalScrollThumbDrag: "igscroll-hdrag",
 			/* Classes applied to the thumb drag of the custom horizontal scrollbar when it is in thin form */
@@ -2815,9 +2807,6 @@
 			if (bNoCancel) {
 				this._bMouseDownV = true;
 				this._bUseArrowUp = true;
-				this._vBarArrowUp.switchClass(this.css.verticalScrollArrowUp,
-												this.css.verticalScrollArrowUpActive);
-
 				this._scrollTop(curPosY + scrollStep, false);
 
 				var self = this;
@@ -2830,8 +2819,6 @@
 		_onMouseUpArrowUp: function() {
 			this._bMouseDownV = false;
 			this._bUseArrowUp = true; //We later set it to false with mouseup event of window
-			this._vBarArrowUp.switchClass(this.css.verticalScrollArrowUpActive,
-											this.css.verticalScrollArrowUp);
 			clearTimeout(this._holdTimeoutID);
 		},
 
@@ -2867,8 +2854,6 @@
 			if (bNoCancel) {
 				this._bMouseDownV = true;
 				this._bUseArrowDown = true;
-				this._vBarArrowDown.switchClass(this.css.verticalScrollArrowDown,
-												this.css.verticalScrollArrowDownActive);
 
 				this._scrollTop(curPosY + scrollStep, false);
 
@@ -2882,8 +2867,6 @@
 		_onMouseUpArrowDown: function() {
 			this._bMouseDownV = false;
 			this._bUseArrowDown = true; //We later set it to false with mouseup event of window
-			this._vBarArrowDown.switchClass(this.css.verticalScrollArrowDownActive,
-											this.css.verticalScrollArrowDown);
 			clearTimeout(this._holdTimeoutID);
 		},
 
@@ -3035,8 +3018,6 @@
 			/* Works even if the mouse is out of the browser boundries and we release the left mouse button */
 			if (this._bUseArrowUp) {
 				this._bUseArrowUp = false;
-				this._vBarArrowUp
-					.switchClass(this.css.verticalScrollArrowUpActive, this.css.verticalScrollArrowUp);
 
 				if (!this._cancelScrolling) {
 					this._trigger("scrolled", null, {
@@ -3049,8 +3030,6 @@
 			}
 			if (this._bUseArrowDown) {
 				this._bUseArrowDown = false;
-				this._vBarArrowDown
-					.switchClass(this.css.verticalScrollArrowDownActive, this.css.verticalScrollArrowDown);
 
 				if (!this._cancelScrolling) {
 					this._trigger("scrolled", null, {
@@ -3303,8 +3282,6 @@
 			if (bNoCancel) {
 				this._bMouseDownH = true;
 				this._bUseArrowLeft = true;
-				this._hBarArrowLeft
-					.switchClass(this.css.horizontalScrollArrowLeft, this.css.horizontalScrollArrowLeftActive);
 
 				this._scrollLeft(curPosX + scrollStep, false);
 
@@ -3318,8 +3295,6 @@
 		_onMouseUpArrowLeft: function () {
 			this._bMouseDownH = false;
 			this._bUseArrowLeft = false;
-			this._hBarArrowLeft
-				.switchClass(this.css.horizontalScrollArrowLeftActive, this.css.horizontalScrollArrowLeft);
 
 			clearTimeout(this._holdTimeoutID);
 
@@ -3363,8 +3338,6 @@
 			if (bNoCancel) {
 				this._bMouseDownH = true;
 				this._bUseArrowRight = true;
-				this._hBarArrowRight
-					.switchClass(this.css.horizontalScrollArrowRight, this.css.horizontalScrollArrowRightActive);
 
 				this._scrollLeft(curPosX + scrollStep, false);
 
@@ -3376,8 +3349,6 @@
 		_onMouseUpArrowRight: function () {
 			this._bMouseDownH = false;
 			this._bUseArrowRight = false;
-			this._hBarArrowRight
-				.switchClass(this.css.horizontalScrollArrowRightActive, this.css.horizontalScrollArrowRight);
 
 			clearTimeout(this._holdTimeoutID);
 
@@ -3536,8 +3507,6 @@
 			/* Works even if the mouse is out of the browser boundries and we release the left mouse button */
 			if (this._bUseArrowLeft) {
 				this._bUseArrowLeft = false;
-				this._hBarArrowLeft
-					.switchClass(this.css.horizontalScrollArrowLeftActive, this.css.horizontalScrollArrowLeft);
 
 				if (!this._cancelScrolling) {
 					this._trigger("scrolled", null, {
@@ -3550,8 +3519,6 @@
 			}
 			if (this._bUseArrowRight) {
 				this._bUseArrowRight = false;
-				this._hBarArrowRight
-					.switchClass(this.css.horizontalScrollArrowRightActive, this.css.horizontalScrollArrowRight);
 
 				if (!this._cancelScrolling) {
 					this._trigger("scrolled", null, {

--- a/tests/unit/scroll/events/tests.html
+++ b/tests/unit/scroll/events/tests.html
@@ -447,25 +447,25 @@
 				}
 			});
 			
-			equal($("#elemVH").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH").css("width"), "600px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("width"), "600px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
-			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
+			equal($("#elemVH").css("height"), "400px", "Element initial height is correct");
+			equal($("#elemVH").css("width"), "600px", "Element initial width is correc");
+			equal($("#elemVH_container").css("height"), "400px", "IgScroll's initial contianer height is correct");
+			equal($("#elemVH_container").css("width"), "600px", "IgScroll's initial contianer width is correct");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "IgScroll's initial vertical scrollbar container height is correct");
+			equal($(".igscroll-hcontainer").css("width"), "600px", "IgScroll's initial horizontal scrollbar container width is correct");
 			
 			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
 			$("#elemVH").css("width", "300px")
 			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
 			
-			equal($("#elemVH").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH").css("width"), "300px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("width"), "300px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
-			equal($(".igscroll-hcontainer").css("width"), "285px", "tabindex is the same as the main element");
-			equal(eventsFired[0], "resizing", "");
-			equal(eventsFired[1], "resized", "");
+			equal($("#elemVH").css("height"), "400px", "Element height after resising is correct");
+			equal($("#elemVH").css("width"), "300px", "Element width after resizing is correct");
+			equal($("#elemVH_container").css("height"), "400px", "IgScroll's contaner height after resizing is correct");
+			equal($("#elemVH_container").css("width"), "300px", "IgScroll's contaner width after resizing is correct");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "IgScroll's vertical scrollbar container height after resizing is correct");
+			equal($(".igscroll-hcontainer").css("width"), "300px", "IgScroll's horizontal scrollbar container width after resizing is correct");
+			equal(eventsFired[0], "resizing", "Resizing event fired");
+			equal(eventsFired[1], "resized", "Resized event fired");
 			
 	        $("#elemVH").remove();
 	    });
@@ -478,24 +478,30 @@
 				}
 			});
 			
-			equal($("#elemVH").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH").css("width"), "600px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("width"), "600px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
-			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
+			var hThumbWidthPercentage = $("#elemVH_hBar_drag")[0].style.width;
+			
+			equal($("#elemVH").css("height"), "400px", "Element initial height is correct");
+			equal($("#elemVH").css("width"), "600px", "Element initial width is correc");
+			equal($("#elemVH_container").css("height"), "400px", "IgScroll's initial contianer height is correct");
+			equal($("#elemVH_container").css("width"), "600px", "IgScroll's initial contianer width is correct");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "IgScroll's initial vertical scrollbar container height is correct");
+			equal($(".igscroll-hcontainer").css("width"), "600px", "IgScroll's initial horizontal scrollbar container width is correct");
 			
 			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
 			$("#elemVH").css("width", "300px")
 			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
 			
-			equal($("#elemVH").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH").css("width"), "300px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
-			equal($("#elemVH_container").css("width"), "600px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
-			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
-	        //$("#elemVH").remove();
+			equal($("#elemVH").css("height"), "400px", "Element height after resising is the same");
+			equal($("#elemVH").css("width"), "300px", "Element width after resizing is updated");
+			equal($("#elemVH_container").css("height"), "400px", "IgScroll's contaner height after resizing is the same");
+			equal($("#elemVH_container").css("width"), "600px", "IgScroll's contaner width after resizing is the same");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "IgScroll's vertical scrollbar container height after canceling resizing is the same");
+			
+			//The width of the horizontal scrollbar is changed because it fits the element it is child of to 100%, and since we resized that main element to 300px, the scrollbar container also auto resizes.
+			//The rest remains the same though
+			equal($(".igscroll-hcontainer").css("width"), "300px", "IgScroll's horizontal scrollbar container width after canceling resizing is updated");
+			equal($("#elemVH_hBar_drag")[0].style.width, hThumbWidthPercentage, "IgScroll's horizontal scrollbar thumb width % after canceling resizing is the same");
+	        $("#elemVH").remove();
 	    });
 	</script>
 	<script type="text/javascript" src="../../testswarm/inject.js"></script>

--- a/tests/unit/scroll/tests.html
+++ b/tests/unit/scroll/tests.html
@@ -867,7 +867,8 @@
 			var vBarContainer = $("#elemVH_vBar"),
 				hBarContainer = $("#elemVH_hBar"),
 				elemContainer = $("#elemVH_container"),
-				elemContent = $("#elemVH_content");
+				elemContent = $("#elemVH_content"),
+				nativeScrollSize =  $.ig.util.getScrollWidth();
 
 			//Make it smaller
 			$('#elemVH').css("height", "300px");
@@ -876,8 +877,8 @@
 			
 			equal(elemContainer.css("height"), "300px", "igScroll container did not update it's height");
 			equal(elemContainer.css("width"), "500px", "igScroll container did not update it's width");
-			equal(vBarContainer.height(), 300 - 15, "igScroll did not update vertical scrollbar container height");
-			equal(hBarContainer.width(), 500 - 15, "igScroll did not update horizontal scrollbar container width");			
+			equal(vBarContainer.height(), 300 - nativeScrollSize, "igScroll did not update vertical scrollbar container height");
+			equal(hBarContainer.width(), 500 - nativeScrollSize, "igScroll did not update horizontal scrollbar container width");			
 			
 			//Make it bigger
 			$('#elemVH').css("height", "500px");
@@ -886,8 +887,8 @@
 			
 			equal(elemContainer.css("height"), "500px", "igScroll container did not update it's height");
 			equal(elemContainer.css("width"), "700px", "igScroll container did not update it's width");
-			equal(vBarContainer.height(), 500 - 15, "igScroll did not update vertical scrollbar container height");
-			equal(hBarContainer.width(), 700 - 15, "igScroll did not update horizontal scrollbar container width");			
+			equal(vBarContainer.height(), 500 - nativeScrollSize, "igScroll did not update vertical scrollbar container height");
+			equal(hBarContainer.width(), 700 - nativeScrollSize, "igScroll did not update horizontal scrollbar container width");			
 			$("#elemVH").remove();
 	    });
 				

--- a/tests/unit/scroll/tests.html
+++ b/tests/unit/scroll/tests.html
@@ -832,8 +832,8 @@
 			var hDragWidth = Math.floor(($('#elemVH').width() - 3 * 15) * ($('#elemVH').width() / elemContent.width()));
 			equal(elemContainer.css("height"), "300px", "igScroll container did not update it's height");
 			equal(elemContainer.css("width"), "500px", "igScroll container did not update it's width");
-			equal(vBarContainer.height(), 300 - 15, "igScroll did not update vertical scrollbar container height");
-			equal(hBarContainer.width(), 500 - 15, "igScroll did not update horizontal scrollbar container width");			
+			equal(vBarContainer.height(), 300, "igScroll did not update vertical scrollbar container height");
+			equal(hBarContainer.width(), 500, "igScroll did not update horizontal scrollbar container width");			
 			ok(300 - 3 * 15 - 1 <= parseInt(vTrack.css("height"), 10) && parseInt(vTrack.css("height"), 10) <= 300 - 3 * 15 + 1, "igScroll did not update vertical track height");
 			ok(500 - 3 * 15 - 1 <= parseInt(hTrack.css("width"), 10) && parseInt(hTrack.css("width"), 10) <= 500 - 3 * 15 + 1, "igScroll did not update horizontal track width");
 			ok(vDragHeight - 1 <= parseInt(vDrag.css("height"), 10) && parseInt(vDrag.css("height"), 10) <= vDragHeight + 1, "igScroll did not update vertical thumb drag height");
@@ -848,8 +848,8 @@
 			hDragWidth = Math.floor(($('#elemVH').width() - 3 * 15) * ($('#elemVH').width() / elemContent.width()));
 			equal(elemContainer.css("height"), "500px", "igScroll container did not update it's height");
 			equal(elemContainer.css("width"), "700px", "igScroll container did not update it's width");
-			equal(vBarContainer.height(), 500 - 15, "igScroll did not update vertical scrollbar container height");
-			equal(hBarContainer.width(), 700 - 15, "igScroll did not update horizontal scrollbar container width");		
+			equal(vBarContainer.height(), 500, "igScroll did not update vertical scrollbar container height");
+			equal(hBarContainer.width(), 700, "igScroll did not update horizontal scrollbar container width");		
 			ok(500 - 3 * 15 - 1 <= parseInt(vTrack.css("height"), 10) && parseInt(vTrack.css("height"), 10) <= 500 - 3 * 15 + 1, "igScroll did not update vertical track height");
 			ok(700 - 3 * 15 - 1 <= parseInt(hTrack.css("width"), 10) && parseInt(hTrack.css("width"), 10) <= 700 - 3 * 15 + 1, "igScroll did not update horizontal track width");
 			ok(vDragHeight - 1 <= parseInt(vDrag.css("height"), 10) && parseInt(vDrag.css("height"), 10) <= vDragHeight + 1, "igScroll did not update vertical thumb drag height");
@@ -3736,7 +3736,7 @@
 			equal($("#elemVH").css("width"), "600px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("width"), "600px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "tabindex is the same as the main element");
 			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
 			
 			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
@@ -3747,8 +3747,8 @@
 			equal($("#elemVH").css("width"), "300px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("width"), "300px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
-			equal($(".igscroll-hcontainer").css("width"), "285px", "tabindex is the same as the main element");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "tabindex is the same as the main element");
+			equal($(".igscroll-hcontainer").css("width"), "300px", "tabindex is the same as the main element");
 	        $("#elemVH").remove();
 	    });
 		
@@ -3760,7 +3760,7 @@
 			equal($("#elemVH").css("width"), "600px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("height"), "400px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("width"), "600px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "385px", "tabindex is the same as the main element");
+			equal($(".igscroll-vcontainer").css("height"), "400px", "tabindex is the same as the main element");
 			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
 			
 			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
@@ -3771,8 +3771,8 @@
 			equal($("#elemVH").css("width"), "600px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("height"), "600px", "tabindex is the same as the main element");
 			equal($("#elemVH_container").css("width"), "600px", "tabindex is the same as the main element");
-			equal($(".igscroll-vcontainer").css("height"), "585px", "tabindex is the same as the main element");
-			equal($(".igscroll-hcontainer").css("width"), "585px", "tabindex is the same as the main element");
+			equal($(".igscroll-vcontainer").css("height"), "600px", "tabindex is the same as the main element");
+			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
 	        $("#elemVH").remove();
 	    });
 		

--- a/tests/unit/scroll/tests.html
+++ b/tests/unit/scroll/tests.html
@@ -388,8 +388,8 @@
 		var testId_124 = 'linking two different igScroll to a third one by different orientation scrolls the proper one accordingly.';
 		var testId_125 = 'linking two different igScroll to a third one by different orientation scrolls the proper one accordingly on mobile.';
 		
-		var testId_126 = 'setting scrollWidth updates the horizontal scrollbar width and its visibility.';
-		var testId_127 = 'setting scrollHeight updates the vertical scrollbar width and its visibility.';
+		var testId_126 = 'setting scrollWidth updates the custom horizontal scrollbar width and its visibility.';
+		var testId_127 = 'setting scrollHeight updates the custom vertical scrollbar width and its visibility.';
 		
 		var testId_128 = 'linked element that can be scrolled only vertically updates its position only vertically on touch.';
 		var testId_129 = 'linked element that can be scrolled only horizontally updates its position only horizontally on touch.';
@@ -398,11 +398,16 @@
 		var testId_131 = 'scrolling the container while the scrollbarType is none and setting after that the scrollbarType to native the scrollbars indicate proper scroll position on touch.';
 		var testId_132 = 'scrolling the container while the scrollbarType is none and setting after that the scrollbarType to custom the scrollbars indicate proper scroll position.';
 		
-		var testId_133 = 'changing the width of the main element should update the igScroll container and scrollbar sizes.';
-		var testId_134 = 'changing the height of the main element should update the igScroll container and scrollbar sizes.';
+		var testId_133 = 'changing the width of the main element should auto update the igScroll container and custom scrollbar sizes.';
+		var testId_134 = 'changing the height of the main element should auto update the igScroll container and custom scrollbar sizes.';
+		var testId_135 = 'changing the width of the main element twice should auto hide and then show the custom horizontal scrollbar and the custom vertical scrollbar should update correctly';
+		var testId_136 = 'changing the width of the main element twice should auto hide and then show the custom vertical scrollbar and the custom horizontal scrollbar should update correctly';
+		var testId_137 = 'changing the width of the main element twice should auto hide and then show the native horizontal scrollbar and the native vertical scrollbar should update correctly';
+		var testId_138 = 'changing the width of the main element twice should auto hide and then show the native vertical scrollbar and the native horizontal scrollbar should update correctly';
 		
-		var testId_135 = 'setting scrollTop during vertical inertia stops the inertia and executes the set scrollTop on touch.';
-		var testId_136 = 'setting scrollLeft during horizontal inertia stops the inertia and executes the set scrollLeft on touch.';
+		var testId_140 = 'setting scrollTop during vertical inertia stops the inertia and executes the set scrollTop on touch.';
+		var testId_141 = 'setting scrollLeft during horizontal inertia stops the inertia and executes the set scrollLeft on touch.';
+		
 		
 	    test(testId_1, function () {
 	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 600px; overflow: hidden;"></div>').append(contentScrollVH));
@@ -1963,7 +1968,7 @@
 		 			var scrollbarPixelContentRatio = ($('#elemVH').width() - 3 * 15) / elemContent.width();
 		 			equal(getTransform3dValueX(hDrag), 0, "igScroll did not scroll properly");
 					
-		 			//$("#elemVH").remove();
+		 			$("#elemVH").remove();
 		 			start();
 		 		}, 500);
 		 	}, 500);
@@ -3526,22 +3531,19 @@
 	        $('#elemVH').igScroll();
 		
 			// Claclulating the drag width and height is based on the formula used in the igScroll implementation
-			// vDragHeight = (elemHeight - (2 * ArrowsSize + EmptySpaceSize)) * percentInViewV;
-			// hDragWidth = (elemWidth - (2 * ArrowsSize + EmptySpaceSize)) * percentInViewH;
 			var elemContent = $("#elemVH_content"),
-				hDragWidth = (600 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (600 / elemContent.width()),
-				vDragHeight = (400 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (400 / elemContent.height());
-				
-			ok(Math.round(hDragWidth) - 1 < Math.round($("#elemVH_hBar_drag").width()) < Math.round(hDragWidth) + 1, "Horizontal thumb drag has proper initial width");
-			ok(Math.round(vDragHeight) - 1 < Math.round($("#elemVH_vBar_drag").height()) < Math.round(vDragHeight) + 1, "Vertical thumb drag has proper initial height");
+				hDragWidthPercentage = (600 / elemContent.width()) * 100,
+				vDragHeightPercentage = (400 / elemContent.height()) * 100;
 
-			$('#elemVH').igScroll("option", "scrollWidth", 700);
+			equal(parseFloat($("#elemVH_hBar_drag")[0].style.width).toFixed(4), hDragWidthPercentage.toFixed(4), "Horizontal thumb drag has proper initial width");
+			equal(parseFloat($("#elemVH_vBar_drag")[0].style.height).toFixed(4), vDragHeightPercentage.toFixed(4), "Vertical thumb drag has proper initial height");
 			
-			hDragWidth = (600 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (600 / 700),
-			vDragHeight = (400 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (400 / elemContent.height());
+			$('#elemVH').igScroll("option", "scrollWidth", 700);		
+			hDragWidthPercentage = (600 / elemContent.width()) * 100;
+			vDragHeightPercentage = (400 / elemContent.height()) * 100;
 			
-			ok(Math.round(hDragWidth) - 1 < Math.round($("#elemVH_hBar_drag").width()) < Math.round(hDragWidth) + 1, "Horizontal thumb drag has updated its width after setting scrollWidth");
-			ok(Math.round(vDragHeight) - 1 < Math.round($("#elemVH_vBar_drag").height()) < Math.round(vDragHeight) + 1, "Vertical thumb drag has its height unchanged after setting scrollWidth");
+			equal(parseFloat($("#elemVH_hBar_drag")[0].style.width).toFixed(4), hDragWidthPercentage.toFixed(4), "Horizontal thumb drag has updated its width after setting scrollWidth");
+			equal(parseFloat($("#elemVH_vBar_drag")[0].style.height).toFixed(4), vDragHeightPercentage.toFixed(4), "Vertical thumb drag has its height unchanged after setting scrollWidth");
 			
 			$('#elemVH').igScroll("option", "scrollWidth", 500);
 			
@@ -3556,22 +3558,19 @@
 	        $('#elemVH').igScroll();
 		
 			// Claclulating the drag width and height is based on the formula used in the igScroll implementation
-			// vDragHeight = (elemHeight - (2 * ArrowsSize + EmptySpaceSize)) * percentInViewV;
-			// hDragWidth = (elemWidth - (2 * ArrowsSize + EmptySpaceSize)) * percentInViewH;
 			var elemContent = $("#elemVH_content"),
-				hDragWidth = (600 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (600 / elemContent.width()),
-				vDragHeight = (400 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (400 / elemContent.height());
+				hDragWidthPercentage = (600 / elemContent.width()) * 100,
+				vDragHeightPercentage = (400 / elemContent.height()) * 100;
 				
-			ok(Math.round(hDragWidth) - 1 < Math.round($("#elemVH_hBar_drag").width()) < Math.round(hDragWidth) + 1, "Horizontal thumb drag has proper initial width");
-			ok(Math.round(vDragHeight) - 1 < Math.round($("#elemVH_vBar_drag").height()) < Math.round(vDragHeight) + 1, "Vertical thumb drag has proper initial height");
+			equal(parseFloat($("#elemVH_hBar_drag")[0].style.width).toFixed(4), hDragWidthPercentage.toFixed(4), "Horizontal thumb drag has proper initial width");
+			equal(parseFloat($("#elemVH_vBar_drag")[0].style.height).toFixed(4), vDragHeightPercentage.toFixed(4), "Vertical thumb drag has proper initial height");
 
-			$('#elemVH').igScroll("option", "scrollHeight", 1000);
+			$('#elemVH').igScroll("option", "scrollHeight", 1000);			
+			hDragWidthPercentage = (600 / elemContent.width()) * 100;
+			vDragHeightPercentage = (400 / elemContent.height()) * 100;
 			
-			hDragWidth = (600 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (600 / elemContent.width()),
-			vDragHeight = (400 - (2 * $('#elemVH').data("igScroll")._customBarArrowsSize + $('#elemVH').data("igScroll")._customBarEmptySpaceSize)) * (400 / 1000);
-			
-			ok(Math.round(hDragWidth) - 1 < Math.round($("#elemVH_hBar_drag").width()) < Math.round(hDragWidth) + 1, "Horizontal thumb drag has not changed its width after setting scrollWidth");
-			ok(Math.round(vDragHeight) - 1 < Math.round($("#elemVH_vBar_drag").height()) < Math.round(vDragHeight) + 1, "Vertical thumb drag has updated its height after setting scrollHeight");
+			equal(parseFloat($("#elemVH_hBar_drag")[0].style.width).toFixed(4), hDragWidthPercentage.toFixed(4), "Horizontal thumb drag has updated its width after setting scrollWidth");
+			equal(parseFloat($("#elemVH_vBar_drag")[0].style.height).toFixed(4), vDragHeightPercentage.toFixed(4), "Vertical thumb drag has its height unchanged after setting scrollWidth");
 			
 			$('#elemVH').igScroll("option", "scrollHeight", 300);
 			
@@ -3741,7 +3740,7 @@
 			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
 			
 			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
-			$("#elemVH").css("width", "300px")
+			$("#elemVH").css("width", "300px");
 			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
 			
 			equal($("#elemVH").css("height"), "400px", "tabindex is the same as the main element");
@@ -3765,7 +3764,7 @@
 			equal($(".igscroll-hcontainer").css("width"), "600px", "tabindex is the same as the main element");
 			
 			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
-			$("#elemVH").css("height", "600px")
+			$("#elemVH").css("height", "600px");
 			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
 			
 			equal($("#elemVH").css("height"), "600px", "tabindex is the same as the main element");
@@ -3778,6 +3777,224 @@
 	    });
 		
 		test(testId_135, function () {
+	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 400px; overflow: hidden;" tabindex="1"></div>').append(contentScrollV));
+	        $('#elemVH').igScroll();
+			
+			equal($("#elemVH").css("height"), "400px", "Initial height of the main element is correct");
+			equal($("#elemVH").css("width"), "400px", "Initial width of the main element is correct");
+			equal($("#elemVH_container").css("height"), "400px", "Initial height of the igScroll main container is correct");
+			equal($("#elemVH_container").css("width"), "400px", "Initial height of the igScroll main container is correct");
+			
+			equal($("#elemVH_vBar").css("height"), "400px", "Initial height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_vBar_track").css("bottom"), "30px", "Initial empty space under the custom vertical scrollbar track is correct");
+			equal($("#elemVH_vBar_arrowDown").css("bottom"), "15px", "Initial empty space under the custom vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").css("width"), "400px", "Initial height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_hBar_track").css("right"), "30px", "Initial empty space right of the custom vertical scrollbar track is correct");
+			equal($("#elemVH_hBar_arrowRight").css("right"), "15px", "Initial empty space right of the custom vertical scrollbar track is correct");
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("width", "600px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "400px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "600px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "400px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "600px", "Width of the igScroll main container is correct after changing width");
+			
+			equal($("#elemVH_vBar").length, 1, "Custom vertical scrollbar should be visible");
+			equal($("#elemVH_vBar").css("height"), "400px", "Height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_vBar_track").css("bottom"), "15px", "Empty space under the custom vertical scrollbar track is correct");
+			equal($("#elemVH_vBar_arrowDown").css("bottom"), "0px", "Empty space under the custom down arrow is correct");
+			
+			equal($("#elemVH_hBar").length, 0, "Custom horizontal scrollbar should not be visible");	
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("width", "400px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "400px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "400px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "400px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "400px", "Width of the igScroll main container is correct after changing width");
+			
+			equal($("#elemVH_vBar").length, 1, "Custom vertical scrollbar should be visible");
+			equal($("#elemVH_vBar").css("height"), "400px", "Height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_vBar_track").css("bottom"), "30px", "Empty space under the custom vertical scrollbar track is correct");
+			equal($("#elemVH_vBar_arrowDown").css("bottom"), "15px", "Empty space under the custom vertical scrollbar down arrow is correct");
+			
+			equal($("#elemVH_hBar").length, 1, "Custom horizontal scrollbar should be visible");
+			equal($("#elemVH_hBar").css("width"), "400px", "Width of the custom horizontal scrollbar container is correct");
+			equal($("#elemVH_hBar_track").css("right"), "30px", "Empty space right of the custom horizontal scrollbar track is correct");
+			equal($("#elemVH_hBar_arrowRight").css("right"), "15px", "Empty space right of the custom right arrow is correct");
+	        $("#elemVH").remove();
+	    });
+		
+		test(testId_136, function () {
+	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 400px; overflow: hidden;" tabindex="1"></div>').append(contentScrollV));
+	        $('#elemVH').igScroll();
+			
+			equal($("#elemVH").css("height"), "400px", "Initial height of the main element is correct");
+			equal($("#elemVH").css("width"), "400px", "Initial width of the main element is correct");
+			equal($("#elemVH_container").css("height"), "400px", "Initial height of the igScroll main container is correct");
+			equal($("#elemVH_container").css("width"), "400px", "Initial height of the igScroll main container is correct");
+			
+			equal($("#elemVH_vBar").css("height"), "400px", "Initial height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_vBar_track").css("bottom"), "30px", "Initial empty space under the custom vertical scrollbar track is correct");
+			equal($("#elemVH_vBar_arrowDown").css("bottom"), "15px", "Initial empty space under the custom vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").css("width"), "400px", "Initial height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_hBar_track").css("right"), "30px", "Initial empty space right of the custom vertical scrollbar track is correct");
+			equal($("#elemVH_hBar_arrowRight").css("right"), "15px", "Initial empty space right of the custom vertical scrollbar track is correct");
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("height", "1500px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "1500px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "400px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "1500px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "400px", "Width of the igScroll main container is correct after changing width");
+			
+			equal($("#elemVH_vBar").length, 0, "Custom vertical scrollbar should be visible");
+			
+			equal($("#elemVH_hBar").length, 1, "Custom horizontal scrollbar should not be visible");	
+			equal($("#elemVH_hBar").css("width"), "400px", "Width of the custom horizontal scrollbar container is correct");
+			equal($("#elemVH_hBar_track").css("right"), "15px", "Empty space right of the custom horizontal scrollbar track is correct");
+			equal($("#elemVH_hBar_arrowRight").css("right"), "0px", "Empty space right of the custom right arrow is correct");
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("height", "400px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "400px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "400px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "400px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "400px", "Width of the igScroll main container is correct after changing width");
+			
+			equal($("#elemVH_vBar").length, 1, "Custom vertical scrollbar should be visible");
+			equal($("#elemVH_vBar").css("height"), "400px", "Height of the custom vertical scrollbar container is correct");
+			equal($("#elemVH_vBar_track").css("bottom"), "30px", "Empty space under the custom vertical scrollbar track is correct");
+			equal($("#elemVH_vBar_arrowDown").css("bottom"), "15px", "Empty space under the custom vertical scrollbar down arrow is correct");
+			
+			equal($("#elemVH_hBar").length, 1, "Custom horizontal scrollbar should be visible");
+			equal($("#elemVH_hBar").css("width"), "400px", "Width of the custom horizontal scrollbar container is correct");
+			equal($("#elemVH_hBar_track").css("right"), "30px", "Empty space right of the custom horizontal scrollbar track is correct");
+			equal($("#elemVH_hBar_arrowRight").css("right"), "15px", "Empty space right of the custom right arrow is correct");
+	        $("#elemVH").remove();
+	    });
+		
+		test(testId_137, function () {
+			var nativeScrollSize = $.ig.util.getScrollWidth();
+	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 400px; overflow: hidden;" tabindex="1"></div>').append(contentScrollV));
+	        $('#elemVH').igScroll({
+				scrollbarType: "native"
+			});
+			
+			equal($("#elemVH").css("height"), "400px", "Initial height of the main element is correct");
+			equal($("#elemVH").css("width"), "400px", "Initial width of the main element is correct");
+			equal($("#elemVH_container").css("height"), "400px", "Initial height of the igScroll main container is correct");
+			equal($("#elemVH_container").css("width"), "400px", "Initial height of the igScroll main container is correct");
+			equal($("#elemVH_scrollbarFiller").length, 1, "Native scrollbars filler should be visible");
+			
+			equal($("#elemVH_vBar").css("height"), (400 - nativeScrollSize) + "px", "Initial height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_vBar").css("bottom"), nativeScrollSize + "px", "Initial empty space under the native vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").css("width"), (400 - nativeScrollSize) + "px", "Initial height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_hBar").css("right"), nativeScrollSize + "px", "Initial empty space right of the native vertical scrollbar track is correct");
+					
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("width", "700px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "400px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "700px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "400px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "700px", "Width of the igScroll main container is correct after changing width");
+			equal($("#elemVH_scrollbarFiller").length, 0, "Native scrollbars filler should not be visible");
+			
+			equal($("#elemVH_vBar").length, 1, "native vertical scrollbar should be visible");
+			equal($("#elemVH_vBar").css("height"), "400px", "Initial height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_vBar").css("bottom"), "0px", "Initial empty space under the native vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").length, 0, "native horizontal scrollbar should not be visible");
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("width", "400px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "400px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "400px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "400px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "400px", "Width of the igScroll main container is correct after changing width");
+			equal($("#elemVH_scrollbarFiller").length, 1, "Native scrollbars filler should be visible");
+			
+			equal($("#elemVH_vBar").length, 1, "native vertical scrollbar should be visible");
+			equal($("#elemVH_vBar").css("height"), (400 - nativeScrollSize) +  "px", "Height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_vBar").css("bottom"), nativeScrollSize + "px", "Empty space under the native vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").length, 1, "native horizontal scrollbar should be visible");
+			equal($("#elemVH_hBar").css("width"), (400 - nativeScrollSize) + "px", "Width of the native horizontal scrollbar container is correct");
+			equal($("#elemVH_hBar").css("right"), nativeScrollSize + "px", "Empty space right of the native horizontal scrollbar track is correct");
+	        $("#elemVH").remove();
+	    });
+		
+		test(testId_138, function () {
+			var nativeScrollSize = $.ig.util.getScrollWidth();
+	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 400px; overflow: hidden;" tabindex="1"></div>').append(contentScrollV));
+	        $('#elemVH').igScroll({
+				scrollbarType: "native"
+			});
+			
+			equal($("#elemVH").css("height"), "400px", "Initial height of the main element is correct");
+			equal($("#elemVH").css("width"), "400px", "Initial width of the main element is correct");
+			equal($("#elemVH_container").css("height"), "400px", "Initial height of the igScroll main container is correct");
+			equal($("#elemVH_container").css("width"), "400px", "Initial height of the igScroll main container is correct");
+			equal($("#elemVH_scrollbarFiller").length, 1, "Native scrollbars filler should be visible");
+			
+			equal($("#elemVH_vBar").css("height"), (400 - nativeScrollSize) + "px", "Initial height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_vBar").css("bottom"), nativeScrollSize + "px", "Initial empty space under the native vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").css("width"), (400 - nativeScrollSize) + "px", "Initial height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_hBar").css("right"), nativeScrollSize + "px", "Initial empty space right of the native vertical scrollbar track is correct");
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("height", "1500px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "1500px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "400px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "1500px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "400px", "Width of the igScroll main container is correct after changing width");
+			equal($("#elemVH_scrollbarFiller").length, 0, "Native scrollbars filler should not be visible");
+			
+			equal($("#elemVH_vBar").length, 0, "native vertical scrollbar should be visible");
+			
+			equal($("#elemVH_hBar").length, 1, "native horizontal scrollbar should not be visible");
+			equal($("#elemVH_hBar").css("width"), "400px", "Width of the native horizontal scrollbar container is correct");
+			equal($("#elemVH_hBar").css("right"), "0px", "Empty space right of the native horizontal scrollbar track is correct");
+			
+			//Simulate MutationObserver since it is not supported by PhantomJS prior to 2.0 version
+			$("#elemVH").css("height", "400px");
+			$("#elemVH").data("igScroll")._onElementMutation([{ attributeName: "style" }]);
+			
+			equal($("#elemVH").css("height"), "400px", "Height of the main element is correct after changing width");
+			equal($("#elemVH").css("width"), "400px", "Width of the main element is correct after changing width");
+			equal($("#elemVH_container").css("height"), "400px", "Height of the igScroll main container is correct after changing width");
+			equal($("#elemVH_container").css("width"), "400px", "Width of the igScroll main container is correct after changing width");
+			equal($("#elemVH_scrollbarFiller").length, 1, "Native scrollbars filler should be visible");
+			
+			equal($("#elemVH_vBar").length, 1, "native vertical scrollbar should be visible");
+			equal($("#elemVH_vBar").css("height"), (400 - nativeScrollSize) +  "px", "Height of the native vertical scrollbar container is correct");
+			equal($("#elemVH_vBar").css("bottom"), nativeScrollSize + "px", "Empty space under the native vertical scrollbar track is correct");
+			
+			equal($("#elemVH_hBar").length, 1, "native horizontal scrollbar should be visible");
+			equal($("#elemVH_hBar").css("width"), (400 - nativeScrollSize) + "px", "Width of the native horizontal scrollbar container is correct");
+			equal($("#elemVH_hBar").css("right"), nativeScrollSize + "px", "Empty space right of the native horizontal scrollbar track is correct");
+	        $("#elemVH").remove();
+	    });
+		
+		test(testId_140, function () {
 			$.ig.util.isTouchDevice = function () { return true; };
 	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 600px; overflow: hidden;"></div>').append(contentScrollVH));
 	        $('#elemVH').igScroll({
@@ -3817,7 +4034,7 @@
 			}, 500);		
 	    });
 		
-		test(testId_136, function () {
+		test(testId_141, function () {
 			$.ig.util.isTouchDevice = function () { return true; };
 	        $("#testBed").append($('<div id="elemVH" style="height:400px; width: 600px; overflow: hidden;"></div>').append(contentScrollVH));
 	        $('#elemVH').igScroll({


### PR DESCRIPTION
Not using anymore fixed widths/heights. Add through CSS classes depending on if a single custom/native scrollbar is visible, it shouldn't display empty area.

Resolves #1060
