### PR TITLE
Dpetev/mask initial error

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1804,14 +1804,6 @@
 			switch (option) {
 			case "value":
 				this.value(value);
-
-				//if (this._validateValue(value)) {
-				//	this._updateValue(value);
-				//	this._exitEditMode();
-				//} else {
-				//	this._clearValue();
-				//	this._exitEditMode();
-				//}
 				break;
 			case "placeHolder":
 				this._applyPlaceHolder();
@@ -6940,7 +6932,6 @@
 			return dataModeValue;
 		},
 		_updateValue: function (value) { //igMaskEditor
-			var nullValue;
 			if (value === "") {
 
 				// Convert empty value by dataMode
@@ -7481,9 +7472,8 @@
 				if (newValue === this._maskWithPrompts) {
 					newValue = "";
 				}
-				//if (this._validateValue(newValue)) {
-					this._updateValue(newValue);
-				//}
+
+				this._updateValue(newValue);
 
 				//In the applyOption there is initial value false to _editMode variable, so the editor input is changed based on the state of the editor.
 				//if (this._focused === false || this._focused === undefined) {
@@ -9124,9 +9114,12 @@
 		_clearValue: function (textOnly) { //DateEditor
 			var newValue = "", maskedValue = this._maskWithPrompts;
 			if (this.options.allowNullValue) {
-				newValue = this.options.nullValue;
-				if (newValue instanceof Date) {
-					maskedValue = this._updateMaskedValue(this.options.nullValue, true);
+				if (this._validateValue(this.options.nullValue)) {
+					newValue = this.options.nullValue;
+					if (newValue !== null && newValue !== "") {
+						newValue = this._getDateObjectFromValue(this.options.nullValue);
+						maskedValue = this._updateMaskedValue(this.options.nullValue, true);
+					}
 				}
 			}
 			this._editorInput.val(maskedValue);
@@ -10589,7 +10582,7 @@
 
 				//If the value is valid proceed with min/max value
 				parsedVal = this._getDateObjectFromValue(newValue);
-				if (this._isValidDate(parsedVal)) {
+				if (newValue !== null && this._isValidDate(parsedVal)) {
 					if (this.options.maxValue && parsedVal > this.options.maxValue) {
 						newValue = this._getDateObjectFromValue(this.options.maxValue);
 						this._sendNotification("warning",
@@ -10606,11 +10599,20 @@
 							});
 					}
 				}
+
 				if (this._validateValue(newValue)) {
 					this._updateValue(newValue);
 
 					//TODO Update maskedValue according to the new value.
 					this._updateMaskedValue();
+				} else {
+					if (this.options.revertIfNotValid &&
+					!(newValue === null && this.options.allowNullValue)) {
+						newValue = this._valueInput.val();
+						this._updateValue(newValue);
+					} else {
+						this._clearValue();
+					}
 				}
 				this._editorInput.val(this._editMode ?
 					this._maskedValue :

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1915,18 +1915,10 @@
 				this._setInitialValue(initialValue);
 				this._editorInput.val(this._getDisplayValue());
 			} else if (initialValue === null && !this.options.allowNullValue) {
-				//D.P.
 				this._setInitialValue("");
 			} else {
 				//D.P. Fallback if initial is not valid and can be null
 				this._setInitialValue();
-			}
-
-			//M.S. 4/19/2017. Issue 779 and issue 892 Initially when allowNullValue is true and the value is not set, the value should be equal to nullValue
-			// D.P.
-			if (!this.options.value && this.options.allowNullValue &&
-				this.options.nullValue !== null && this._validateValue(this.options.nullValue)) {
-				//this._setOption("value", this.options.nullValue);
 			}
 
 			this._applyPlaceHolder();
@@ -6499,12 +6491,6 @@
 				this._maskFlagsArray = [ "C", "&", "a", "A", "?", "L", "9", "0", "<", ">", "#" ];
 			}
 			this._promptCharsIndices = [];
-
-			//M.S. 4/19/2017. Issue 892 Initially when allowNullValue is true and the value is not set, the value should be equal to nullValue
-			// D.P. nullValue/value can be 0 or empty string
-			if (this.options.allowNullValue && !this.options.value && this.options.nullValue) {
-				//this.options.value = this.options.nullValue;
-			}
 		},
 		_applyOptions: function () { //igMaskEditor
 			this._getMaskLiteralsAndRequiredPositions();
@@ -6725,7 +6711,8 @@
 				ch, maskFlagsArray = this._maskFlagsArray,
 			length = mask.length, i, j, tempChar;
 
-			value = value ? value.toString() : "";
+			// D.P. Since other numbers are converted, so should be 0
+			value = value === 0 || value ? value.toString() : "";
 			if (length && length > 0) {
 				if (value.indexOf(this.options.unfilledCharsPrompt !== -1)) {
 					i = 225;
@@ -6985,7 +6972,7 @@
 						this._valueInput.val("");
 						this.options.value = this.options.nullValue;
 					} else {
-						nullValue = this._parseValueByMask(value);
+						nullValue = this._parseValueByMask(this.options.nullValue);
 						this._maskedValue = nullValue;
 						this._valueInput.val(nullValue);
 						this.options.value = nullValue;
@@ -7119,7 +7106,7 @@
 				this._updateValue("");
 				this._maskedValue = "";
 			} else {
-				this._maskedValue = this._parseValueByMask(value.toString());
+				this._maskedValue = this._parseValueByMask(value);
 				this._updateValue(this._maskedValue);
 			}
 			this._checkClearButtonState();
@@ -7512,16 +7499,9 @@
 				}
 				this._updateValue(newValue);
 
-				//M.S. 4/19/2017. Issue 892 Initially when allowNullValue is true and the value is not set, the value should be equal to nullValue
-				if (this.options.allowNullValue && newValue === null && this.options.nullValue) {
-					//D.P. NO!
-					//this.value(this.options.nullValue);
-				}
-
-				// this._setInitialValue(newValue);
 				//In the applyOption there is initial value false to _editMode variable, so the editor input is changed based on the state of the editor.
 				//if (this._focused === false || this._focused === undefined) {
-					this._editorInput.val(this._editMode ?
+				this._editorInput.val(this._editMode ?
 						this._maskedValue :
 						this._getDisplayValue());
 			} else {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1914,11 +1914,9 @@
 			if (this._validateValue(initialValue)) {
 				this._setInitialValue(initialValue);
 				this._editorInput.val(this._getDisplayValue());
-			} else if (initialValue === null && !this.options.allowNullValue) {
-				this._setInitialValue("");
 			} else {
-				//D.P. Fallback if initial is not valid
-				this._setInitialValue();
+				//D.P. 2017-07-27 #1027 Fallback if initial value is not valid
+				this._setInitialValue("");
 				this._editorInput.val(this._getDisplayValue());
 			}
 
@@ -2110,9 +2108,6 @@
 
 		//We use this extra function so we can branch the logic into mask editor.
 		_setInitialValue: function (value) { //igTextEditor
-			if (typeof value === "undefined") {
-				value = "";
-			}
 			this._updateValue(value);
 		},
 		_disableEditor: function (applyDisabledClass) { //TextEditor
@@ -4522,16 +4517,11 @@
 				this.options.minDecimals;
 		},
 		_setInitialValue: function (value) { // NumericEditor
-			if (typeof value === "undefined") {
-				// D.P. Fallback zero in case both the value/nullValue are not valid
-				value = 0;
-			}
-
 			// D.P. 6th Mar 2017 #777 'minValue/maxValue options are not respected at initialization'
-			if (!isNaN(this.options.maxValue) && value > this.options.maxValue) {
-				value = this.options.maxValue;
-			} else if (!isNaN(this.options.minValue) && value < this.options.minValue) {
+			if (!isNaN(this.options.minValue) && this.options.minValue > value) {
 				value = this.options.minValue;
+			} else if (!isNaN(this.options.maxValue) && this.options.maxValue < value) {
+				value = this.options.maxValue;
 			}
 			this._super(value);
 		},
@@ -7091,9 +7081,6 @@
 			if (value === null || value === "") {
 				this._updateValue(value);
 				this._maskedValue = "";
-			} else if (typeof value === "undefined") {
-				this._updateValue("");
-				this._maskedValue = "";
 			} else {
 				this._maskedValue = this._parseValueByMask(value);
 				this._updateValue(this._maskedValue);
@@ -7999,9 +7986,6 @@
 			this._maskWithPrompts = this._parseValueByMask("");
 			if (value === null || value === "") {
 				this._updateValue(value);
-				this._maskedValue = "";
-			} else if (typeof value === "undefined") {
-				this._updateValue("");
 				this._maskedValue = "";
 			} else {
 				//check value

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1892,6 +1892,13 @@
 			}
 
 			initialValue = this.options.value;
+
+			// D.P. Set nullValue if needed. NB! Both value and nullValue *can* be 0 or ""
+			if (this.options.allowNullValue && initialValue === null) {
+				//doesn't really matter what nullValue is, at worst it will be null as well
+				initialValue = this.options.nullValue;
+			}
+
 			if (this.options.maxLength) {
 				if (initialValue && initialValue.toString().length > this.options.maxLength) {
 					initialValue = initialValue.toString().substring(0, this.options.maxLength);
@@ -1908,13 +1915,18 @@
 				this._setInitialValue(initialValue);
 				this._editorInput.val(this._getDisplayValue());
 			} else if (initialValue === null && !this.options.allowNullValue) {
+				//D.P.
 				this._setInitialValue("");
+			} else {
+				//D.P. Fallback if initial is not valid and can be null
+				this._setInitialValue();
 			}
 
 			//M.S. 4/19/2017. Issue 779 and issue 892 Initially when allowNullValue is true and the value is not set, the value should be equal to nullValue
+			// D.P.
 			if (!this.options.value && this.options.allowNullValue &&
 				this.options.nullValue !== null && this._validateValue(this.options.nullValue)) {
-				this._setOption("value", this.options.nullValue);
+				//this._setOption("value", this.options.nullValue);
 			}
 
 			this._applyPlaceHolder();
@@ -6489,8 +6501,9 @@
 			this._promptCharsIndices = [];
 
 			//M.S. 4/19/2017. Issue 892 Initially when allowNullValue is true and the value is not set, the value should be equal to nullValue
+			// D.P. nullValue/value can be 0 or empty string
 			if (this.options.allowNullValue && !this.options.value && this.options.nullValue) {
-				this.options.value = this.options.nullValue;
+				//this.options.value = this.options.nullValue;
 			}
 		},
 		_applyOptions: function () { //igMaskEditor
@@ -7106,7 +7119,7 @@
 				this._updateValue("");
 				this._maskedValue = "";
 			} else {
-				this._maskedValue = this._parseValueByMask(value);
+				this._maskedValue = this._parseValueByMask(value.toString());
 				this._updateValue(this._maskedValue);
 			}
 			this._checkClearButtonState();
@@ -7501,7 +7514,8 @@
 
 				//M.S. 4/19/2017. Issue 892 Initially when allowNullValue is true and the value is not set, the value should be equal to nullValue
 				if (this.options.allowNullValue && newValue === null && this.options.nullValue) {
-					this.value(this.options.nullValue);
+					//D.P. NO!
+					//this.value(this.options.nullValue);
 				}
 
 				// this._setInitialValue(newValue);
@@ -8074,6 +8088,7 @@
 			this._super();
 
 			if (this._maskWithPrompts === undefined) {
+				//D.P.
 				this._setInitialValue();
 			}
 		},

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -6955,10 +6955,9 @@
 						this._valueInput.val("");
 						this.options.value = this.options.nullValue;
 					} else {
-						nullValue = this._parseValueByMask(this.options.nullValue);
-						this._maskedValue = nullValue;
-						this._valueInput.val(nullValue);
-						this.options.value = nullValue;
+						this._maskedValue = this._parseValueByMask(this.options.nullValue);
+						this.options.value = this._getValueByDataMode();
+						this._valueInput.val(this.options.value);
 
 					}
 				} else {
@@ -6978,10 +6977,15 @@
 			var newValue = "";
 			if (this.options.allowNullValue) {
 				newValue = this.options.nullValue;
+			}
+
+			if (this._validateValue(newValue)) {
 				this._editorInput.val(this._parseValueByMask(newValue));
 			} else {
+				newValue = "";
 				this._editorInput.val(this._maskWithPrompts);
 			}
+
 			if (!textOnly) {
 				this._updateValue(newValue);
 			}
@@ -7477,7 +7481,9 @@
 				if (newValue === this._maskWithPrompts) {
 					newValue = "";
 				}
-				this._updateValue(newValue);
+				//if (this._validateValue(newValue)) {
+					this._updateValue(newValue);
+				//}
 
 				//In the applyOption there is initial value false to _editMode variable, so the editor input is changed based on the state of the editor.
 				//if (this._focused === false || this._focused === undefined) {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -780,6 +780,10 @@
 				newValue = this.options.nullValue;
 			}
 
+			if (!this._validateValue(newValue)) {
+				newValue = "";
+			}
+
 			if (textOnly) {
 				this._editorInput.val(newValue);
 			} else {

--- a/tests/unit/common/test-util.js
+++ b/tests/unit/common/test-util.js
@@ -113,7 +113,7 @@
 		 */
 		keyInteraction: function (key, target, special) {
 			// could use an update in the future - https://www.w3.org/TR/DOM-Level-3-Events/#keypress-event-order
-			var char, endPos;
+			var char, startPos, endPos, newPos;
 			char = (key > 31) ? String.fromCharCode(key) : "";
 			if (special && char) {
 				char = special === "shiftKey" ? char.toUpperCase() : "";
@@ -127,11 +127,19 @@
 			}
 			if (char && target[0].selectionEnd !== undefined) {
 				endPos = target[0].selectionEnd;
+				startPos = target[0].selectionStart;
 				target[0].value =
-					target[0].value.substring(0, target[0].selectionStart) +
+					target[0].value.substring(0, startPos) +
 					char +
 					target[0].value.substring(endPos);
-				target[0].selectionStart = target[0].selectionEnd = endPos + 1;
+				if (startPos !== endPos) {
+					// replaced selection, cursor goes to start + char
+					newPos = startPos + 1;
+				} else {
+					//typing move the cursor +1
+					newPos = endPos + 1;
+				}
+				target[0].selectionStart = target[0].selectionEnd = newPos;
 			}
 			this.keyUpChar(key, target, special);
 		},

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -30,6 +30,7 @@
 	
 	<link type="text/css" href="../../../../bower_components/qunit/qunit/qunit.css" rel="stylesheet" media="screen" /> 
 	<script type="text/javascript" src="../../../../bower_components/qunit/qunit/qunit.js"></script>
+	<script type="text/javascript" src="../../common/test-util.js"></script>
 
 	<script type="text/javascript">
 	/*global window, setTimeout, $, startTesting, QUnit, module, test, ok, equals*/
@@ -1342,7 +1343,7 @@
 					$("#695Editor").remove();
 			});
 
-        		testId = 'Bug 809 - Wrong value is set when we have isLimitedToListValues: true and revertIfNotValid: false';
+			testId = 'Bug 809 - Wrong value is set when we have isLimitedToListValues: true and revertIfNotValid: false';
 			test(testId, 5, function () {
 				var editor =  $("#809Editor");
 				input = editor.igNumericEditor("field"),
@@ -1395,7 +1396,68 @@
 					clearButton.click();
 					equal(field.val(), "", 'input value is not set to ""' );
 					$("#942Editor").remove();
-					}, 100);
+				}, 100);
+			});
+
+			testId = 'Bug 1027 Exception is thrown when typing due to incorrect value/nullValue on init';
+			test(testId, 7, function () {
+				var $editor;
+
+				// value not matching mask (fails validation)
+				$editor = $('<input/>').appendTo("#testBedContainer")
+					.igMaskEditor({ 
+						 inputMask : "9900",
+						 value: "abc" //should be numerics
+					 });
+				$editor.trigger("focus").select();
+				try {
+					$.ig.TestUtil.keyInteraction(49, $editor);
+					$.ig.TestUtil.keyInteraction(50, $editor);
+					$.ig.TestUtil.keyInteraction(51, $editor);
+					ok(true);
+				} catch (error) {
+					ok(false, "(wrong value) Typing caused an exception: " + error.message );
+				}
+				equal($editor.val(), "123_", "(wrong value) Typing did not update Edit text.");
+				$editor.remove();
+				
+				// nullValue not matching mask (fails validation)
+				$editor = $('<input/>').appendTo("#testBedContainer")
+					.igMaskEditor({ 
+						 inputMask : "AA??",
+						 allowNullValue: true,
+						 nullValue: "#5a" //wrong first char
+					 });
+				$editor.trigger("focus").select();
+				try {
+					$.ig.TestUtil.keyInteraction(97, $editor);
+					$.ig.TestUtil.keyInteraction(98, $editor);
+					$.ig.TestUtil.keyInteraction(99, $editor);
+					ok(true);
+				} catch (error) {
+					ok(false, "(wrong nullValue) Typing caused an exception: " + error.message );
+				}
+				equal($editor.val(), "abc_", "(wrong nullValue) Typing did not update Edit text.");
+				$editor.remove();
+
+				// nullValue not a string
+				$editor = $('<input/>').appendTo("#testBedContainer")
+					.igMaskEditor({
+						 allowNullValue: true,
+						 nullValue: 0
+					 });
+				equal($editor.val(), "0", "Null value not applied on Display text.")
+				$editor.trigger("focus").select();
+				try {
+					$.ig.TestUtil.keyInteraction(49, $editor);
+					$.ig.TestUtil.keyInteraction(50, $editor);
+					$.ig.TestUtil.keyInteraction(51, $editor);
+					ok(true);
+				} catch (error) {
+					ok(false, "(numeric nullValue) Typing caused an exception: " + error.message );
+				}
+				equal($editor.val(), "123_______", "(numeric nullValue) Typing did not update Edit text.");
+				$editor.remove();
 			});
 		});
 

--- a/tests/unit/editors/dateEditor/tests.html
+++ b/tests/unit/editors/dateEditor/tests.html
@@ -1892,7 +1892,7 @@
 				$dtEditor.remove();
 			});
 			testId = "Test nullValue on initialization";
-			test(testId, 4, function(){
+			test(testId, 9, function(){
 				var $editor = $("<input id='editor'/>").
 				appendTo("#testBedContainer").igDateEditor({ allowNullValue: false});
 				//Get null Value
@@ -1908,6 +1908,28 @@
 				$editor.igDateEditor("value", null);
 				//Get null value
 				equal($editor.igDateEditor("value"), null, "The value is not an empty string");
+				$editor.remove();
+
+				// test invalid nullValue
+				$editor = $("<input />").appendTo("#testBedContainer")
+					.igDateEditor({ 
+						buttonType: "clear", 
+						nullValue: new Date("abc"),
+						allowNullValue: true
+					});
+
+				equal($editor.val(), "", "Display did not initialize correctly");
+				strictEqual($editor.igDateEditor("value"), "", "Null value should be ignored on init");
+				//check clear also ignores the wrong nullValue:
+				$editor.igDateEditor("value", new Date());
+				$editor.igDateEditor("clearButton").trigger("click");
+				strictEqual($editor.igDateEditor("value"), "", "Null value should be ignored on clear");
+				$editor.igDateEditor("value", new Date(2017,5,4));
+				$editor.igDateEditor("value", null);
+				strictEqual($editor.igDateEditor("value"), "", "Null value should be ignored on set");
+				//verify empty string is still accepted
+				$editor.igDateEditor("value", "");
+				strictEqual($editor.igDateEditor("value"), "", "Empty value should be accepted");
 				$editor.remove();
 			});
 

--- a/tests/unit/editors/maskEditor/tests.html
+++ b/tests/unit/editors/maskEditor/tests.html
@@ -1040,7 +1040,7 @@
 				});
 			});
 			testId = "Test nullValue on initialization";
-			test(testId, 4, function(){
+			test(testId, 9, function(){
 				var $editor = $("<input id='editor'/>").
 				appendTo("#testBedContainer").igMaskEditor({ allowNullValue: false});
 				//Get null Value
@@ -1056,6 +1056,30 @@
 				$editor.igMaskEditor("value", null);
 				//Get null value
 				equal($editor.igMaskEditor("value"), null, "The value is not an empty string");
+				$editor.remove();
+
+				// test invalid nullValue
+				$editor = $("<input />").appendTo("#testBedContainer")
+					.igMaskEditor({ 
+						inputMask: "9990",
+						dataMode: "rawText",
+						nullValue: "abc",
+						allowNullValue: true,
+						buttonType: "clear"
+					});
+
+				equal($editor.val(), "", "Display did not initialize correctly");
+				strictEqual($editor.igMaskEditor("value"), "", "Null value should be ignored on init");
+				//check clear also ignores the wrong nullValue:
+				$editor.igMaskEditor("value", "555");
+				$editor.igMaskEditor("clearButton").trigger("click");
+				strictEqual($editor.igMaskEditor("value"), "", "Null value should be ignored on clear");
+				$editor.igMaskEditor("value", "123");
+				$editor.igMaskEditor("value", null);
+				strictEqual($editor.igMaskEditor("value"), "", "Null value should be ignored on set");
+				//verify empty string is still accepted
+				$editor.igMaskEditor("value", "");
+				strictEqual($editor.igMaskEditor("value"), "", "Empty value should be accepted");
 				$editor.remove();
 			});
 

--- a/tests/unit/editors/maskEditor/tests.html
+++ b/tests/unit/editors/maskEditor/tests.html
@@ -1059,7 +1059,7 @@
 				$editor.remove();
 			});
 
-			var testId = 'Clear button state';
+			testId = 'Clear button state';
 			test(testId, 2, function () {
 				var $editor;
 

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -2293,7 +2293,7 @@
 		});
 		
 	testId = "Test allowNullValue and NullValue at initialization #779";
-	test(testId, 8, function(){
+	test(testId, 9, function(){
 		var $editor = $("<input id='editor'/>").
 				appendTo("#testBedContainer").igNumericEditor({ allowNullValue: true, nullValue: 0});
 			
@@ -2315,6 +2315,9 @@
 			$editor.igNumericEditor("value", 5);
 			$editor.igNumericEditor("clearButton").trigger("click");
 			strictEqual($editor.igNumericEditor("value"), "", "Null value should be ignored on clear");
+			$editor.igNumericEditor("value", 5);
+			$editor.igNumericEditor("value", null);
+			strictEqual($editor.igNumericEditor("value"), "", "Null value should be ignored on set");
 			//verify empty string is still accepted
 			$editor.igNumericEditor("value", "");
 			strictEqual($editor.igNumericEditor("value"), "", "Empty value should be accepted");

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -2305,9 +2305,8 @@
 			$editor = $("<input id='editor'/>").appendTo("#testBedContainer")
 				.igNumericEditor({ 
 					buttonType: "clear", 
-					nullValue: "abc", 
-					allowNullValue: true,
-					value: "" 
+					nullValue: "abc",
+					allowNullValue: true
 				});
 
 			equal($editor.val(), "", "Display did not initialize correctly");

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -2293,12 +2293,49 @@
 		});
 		
 	testId = "Test allowNullValue and NullValue at initialization #779";
-	test(testId, 1, function(){
+	test(testId, 8, function(){
 		var $editor = $("<input id='editor'/>").
 				appendTo("#testBedContainer").igNumericEditor({ allowNullValue: true, nullValue: 0});
 			
 			var currentValue = $editor.igNumericEditor("value");
 			equal(currentValue, 0, "The value is not 0, although the nullValue is set to 0.")
+			$editor.remove();
+
+			// test invalid nullValue
+			$editor = $("<input id='editor'/>").appendTo("#testBedContainer")
+				.igNumericEditor({ 
+					buttonType: "clear", 
+					nullValue: "abc", 
+					allowNullValue: true,
+					value: "" 
+				});
+
+			equal($editor.val(), "", "Display did not initialize correctly");
+			strictEqual($editor.igNumericEditor("value"), "", "Null value should be ignored on init");
+			//check clear also ignores the wrong nullValue:
+			$editor.igNumericEditor("value", 5);
+			$editor.igNumericEditor("clearButton").trigger("click");
+			strictEqual($editor.igNumericEditor("value"), "", "Null value should be ignored on clear");
+			//verify empty string is still accepted
+			$editor.igNumericEditor("value", "");
+			strictEqual($editor.igNumericEditor("value"), "", "Empty value should be accepted");
+			$editor.remove();
+
+			//nullValue outside min/max:
+			$editor = $("<input id='editor'/>").appendTo("#testBedContainer")
+				.igNumericEditor({ 
+					buttonType: "clear", 
+					nullValue: 5,
+					maxValue: -3,
+					allowNullValue: true 
+				});
+			equal($editor.igNumericEditor("value"), -3, "Null value should be ignored on init and default to max.");
+			$editor.igNumericEditor("value", -5);
+			$editor.igNumericEditor("clearButton").trigger("click");
+			equal($editor.igNumericEditor("value"), -3, "Null value should be ignored on clear and default to max.");
+			//verify empty string is still accepted
+			$editor.igNumericEditor("value", "");
+			strictEqual($editor.igNumericEditor("value"), "", "Empty value should be accepted");
 			$editor.remove();
 		});
 

--- a/tests/unit/editors/textEditor/tests.html
+++ b/tests/unit/editors/textEditor/tests.html
@@ -1432,7 +1432,7 @@
 			$classSelector.remove();
 		});
 		var testId = "NullValue set on init.";
-		test(testId, 2, function(){
+		test(testId, 5, function(){
 			var $editor=$("<input id='textEditorNull' />").appendTo("#testBedContainer").igTextEditor({
 					allowNullValue: true,
 					nullValue: 0
@@ -1444,6 +1444,25 @@
 			$editor.igTextEditor("value", null);
 			currentValue = $editor.igTextEditor("value");
 			equal(currentValue, "0" , "The value is not set to the nullValue");
+			$editor.remove();
+
+			//invalid null value:
+			var $editor=$("<input />").appendTo("#testBedContainer").igTextEditor({
+					nullValue: "312",
+					allowNullValue: true,
+					isLimitedToListValues: true,
+					listItems: ["a", "b", "c"],
+					buttonType: "clear"
+				});
+			
+			var currentValue = $editor.igTextEditor("value");
+			strictEqual($editor.igTextEditor("value"), "" , "Initial value should ignore wrong nullValue");
+			$editor.igTextEditor("value", "a");
+			$editor.igTextEditor("value", null);
+			strictEqual($editor.igTextEditor("value"), "" , "Value set should ignore wrong nullValue");
+			$editor.igTextEditor("value", "a");
+			$editor.igTextEditor("clearButton").trigger("click");
+			strictEqual($editor.igTextEditor("value"), "" , "Clear should ignore wrong nullValue");
 			$editor.remove();
 		});
 		var testId = "Test creating on wrong field or wrong options combinations."


### PR DESCRIPTION
Closes #1027 

### Additional information related to this pull request:
Since the original issue was in incorrect initialization, I've made sure _setInitialvalue is always called.
This also obsoletes and reverts most changes made for #892.
The change actually led to some additional changes for text and numeric editors that did not rely on that being called and for some other edge cases.
