### PR TITLE
Fixing the popover _createWidget, _setOption and destroy

### DIFF
--- a/src/js/modules/infragistics.ui.notifier.js
+++ b/src/js/modules/infragistics.ui.notifier.js
@@ -287,7 +287,7 @@
 		/* States that appear as inline in auto mode */
 		inlineStates: [ "success", "error" ],
 		_create: function () {
-			$.ui.igPopover.prototype._create.apply(this, arguments);
+			this._super();
 
 			// D.P. Override position prio to top > bottom
 			this._setOption("directionPriority", [ "top", "left", "right", "bottom" ]);
@@ -577,7 +577,7 @@
 				```
 			*/
 			this._setTargetState(true);
-			$.ui.igPopover.prototype.destroy.apply(this, arguments);
+			this._super();
 			return this;
 		}
 	});

--- a/src/js/modules/infragistics.ui.popover.js
+++ b/src/js/modules/infragistics.ui.popover.js
@@ -455,7 +455,7 @@
 			if (options && options.directionPriority !== this.options.directionPriority) {
 				options.directionPriority = this._normalizePriority(options.directionPriority);
 			}
-			$.Widget.prototype._createWidget.apply(this, arguments);
+			this._superApply(arguments);
 			this.element = $(element);
 			if (element && element.nodeType !== undefined) {
 				this._renderPopover();
@@ -465,29 +465,10 @@
 			this._super(key, value);
 			switch (key) {
 				case "direction":
-					this.options.direction = value;
 					this._resizeHandler();
 					break;
 				case "directionPriority":
 					this.options.directionPriority = this._normalizePriority(value);
-					break;
-				case "contentTemplate":
-					if (typeof value === "string") {
-						this.options.contentTemplate = value;
-					}
-					break;
-				case "animationDuration":
-					if (typeof value === "number") {
-						this.options.animationDuration = value;
-					}
-					break;
-				case "containment":
-					if (value instanceof $) {
-						this.options.containment = value;
-					}
-					break;
-				case "closeOnBlur":
-					this.options.closeOnBlur = value;
 					break;
 				case "headerTemplate":
 				case "selectors":
@@ -499,7 +480,7 @@
 				case "showOn":
 					throw new Error(this._getLocaleValue("popoverOptionChangeNotSupported") + " " + key);
 				default:
-					$.Widget.prototype._setOption.apply(this, arguments);
+					break;
 			}
 		},
 		destroy: function () {
@@ -511,7 +492,7 @@
 			this._detachEventsFromTarget();
 			$(window).off("resize.popover", this._resizeHandler);
 			this.popover.remove();
-			$.Widget.prototype.destroy.call(this);
+			this._super();
 			return this;
 		},
 		id: function () {

--- a/tests/unit/editors/baseEditor/tests.html
+++ b/tests/unit/editors/baseEditor/tests.html
@@ -20,7 +20,6 @@
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquerydeferred.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.widget.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
-	<!--<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>-->
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script> 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>
 	


### PR DESCRIPTION
### Additional information related to this pull request:

The base calls were bi-passing the base `igWidget`. Also the `_setOption` was performing redundant actions.