### PR TITLE
Date.toStringFormat token replacement

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -1460,7 +1460,6 @@
 	$.ig.Date.prototype.toStringFormat = function (value, format, provider) {
 		var result;
 		provider = provider || $.ig.CultureInfo.prototype.currentCulture(); // TODO: Use the provider below
-		
 		var mmm = function(value, provider) {
 			// On some browsers, the ja-JP month short formatting seems to not match .NET"s "MMM" formatting
 			var cultureName = provider.name();
@@ -1528,11 +1527,10 @@
 			case "%t":
 				return value.getHours() <= 11 ? "A" : "P"; // TODO: Figure out how to get this based on culture
 		}
-		
 		result = format;
 		result = result.replace("yyyy", value.getFullYear().toString());
 		result = result.replace("MMM", mmm(value, provider));
-		result = result.replace("MM", (value.getMonth() + 1).toString().replace( /^(\d)$/, "0$1")); 
+		result = result.replace("MM", (value.getMonth() + 1).toString().replace( /^(\d)$/, "0$1"));
 		result = result.replace("dd", value.getDate().toString().replace(/^(\d)$/, "0$1"));
 		return result;
 	};

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -1460,6 +1460,28 @@
 	$.ig.Date.prototype.toStringFormat = function (value, format, provider) {
 		var result;
 		provider = provider || $.ig.CultureInfo.prototype.currentCulture(); // TODO: Use the provider below
+		
+		var mmm = function(value, provider) {
+			// On some browsers, the ja-JP month short formatting seems to not match .NET"s "MMM" formatting
+			var cultureName = provider.name();
+			if (cultureName == "ja-JP") {
+				result = value.toLocaleString("en-US", { month: "numeric" })
+					.replace(/\u200E/g, "");
+			} else {
+				result = value.toLocaleString(provider.name(), { month: "short" })
+					.replace(/\u200E/g, "");
+			}
+
+			if (result.contains(" ")) {
+
+				// Date.toLocaleString is not supported fully
+				// TODO: Handle other cultures?
+				return [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+					"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ][ value.getMonth() ];
+			}
+
+			return result;
+		};
 		switch (format) {
 			case "s":
 				{
@@ -1474,28 +1496,7 @@
 				}
 
 			case "MMM":
-				{
-
-					// On some browsers, the ja-JP month short formatting seems to not match .NET"s "MMM" formatting
-					var cultureName = provider.name();
-					if (cultureName == "ja-JP") {
-						result = value.toLocaleString("en-US", { month: "numeric" })
-							.replace(/\u200E/g, "");
-					} else {
-						result = value.toLocaleString(provider.name(), { month: "short" })
-							.replace(/\u200E/g, "");
-					}
-
-					if (result.contains(" ")) {
-
-						// Date.toLocaleString is not supported fully
-						// TODO: Handle other cultures?
-						return [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-							"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ][ value.getMonth() ];
-					}
-
-					return result;
-				}
+				return mmm(value, provider);
 
 			case "MMMM":
 				return value.toLocaleString(provider.name(), { month: "long" })
@@ -1527,8 +1528,13 @@
 			case "%t":
 				return value.getHours() <= 11 ? "A" : "P"; // TODO: Figure out how to get this based on culture
 		}
-
-		throw new $.ig.FormatException(1, "Unknown Date format: " + format);
+		
+		result = format;
+		result = result.replace("yyyy", value.getFullYear().toString());
+		result = result.replace("MMM", mmm(value, provider));
+		result = result.replace("MM", (value.getMonth() + 1).toString().replace( /^(\d)$/, "0$1")); 
+		result = result.replace("dd", value.getDate().toString().replace(/^(\d)$/, "0$1"));
+		return result;
 	};
 
 	// implement casting

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -165,6 +165,13 @@
 			var listNullInt = $.ig.IList$1.prototype.$type.specialize($.ig.Nullable$1.prototype.$type.specialize($.ig.Number.prototype.$type));
 			equal($.ig.Number.prototype.$type, listNullInt.typeArguments[0].typeArguments[0], "List<Nullable<int>>");
 		});
+		test("Test Date.toStringFormat", function() {
+			var dt = new Date("1980-10-11T12:00:00");
+			equal($.ig.Date.prototype.toStringFormat(dt, "MM/dd"), "10/11", "Date.toStringFormat formats MM/dd correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "MMM dd"), "Oct 11", "Date.toStringFormat formats MMM dd correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "MMM"), "Oct", "Date.toStringFormat formats MMM correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "yyyy"), "1980", "Date.toStringFormat formats yyyy correctly");
+		});
 	</script>
 </head>
 <body>


### PR DESCRIPTION
working on some time axis stuff for DataChart, task #239473.  the Date.toStringFormat() function is incomplete.  i added a few formats to the bottom of the method.  also, i'm using token replacement instead of trying to replace the entire format string.

note that the function no longer throws an exception, but instead returns the format string with whatever replacements were made.

