### PR TITLE
Applying changes for #1043 in 16.2:

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1051,6 +1051,16 @@
 
 				// N.A. 12/1/2015 Bug #207198: Remove notifier when value updated through value method.
 				this._clearEditorNotifier();
+
+				// N.A. July 27th, 2017, #1042: Trim value, when its length is larger then the maxLength one.
+				if (this.options.maxLength) {
+					if (newValue && newValue.toString().length > this.options.maxLength) {
+						newValue = newValue.toString().substring(0, this.options.maxLength);
+						this._sendNotification("warning",
+							$.ig.util.stringFormat($.ig.Editor.locale.maxLengthErrMsg,
+								this.options.maxLength));
+					}
+				}
 				if (this._validateValue(newValue)) {
 					if (this.options.toUpper) {
 						if (newValue) { newValue = newValue.toLocaleUpperCase(); }
@@ -1060,17 +1070,9 @@
 					this._updateValue(newValue);
 					this._editorInput.val(this._getDisplayValue());
 				} else {
-
-					// N.A. July 27th, 2017, #1042: Trim value, when its length is larger then the maxLenght one.
-					if (this.options.maxLength) {
-						newValue = newValue.toString().substring(0, this.options.maxLength);
-						this._updateValue(newValue);
-						this._editorInput.val(this._getDisplayValue());
-					} else {
-						this._clearValue();
-						if (this._focused !== true) {
-							this._exitEditMode();
-						}
+					this._clearValue();
+					if (this._focused !== true) {
+						this._exitEditMode();
 					}
 				}
 			} else {
@@ -2153,9 +2155,6 @@
 				 if (val.toString().length <= this.options.maxLength) {
 					result = true;
 				} else {
-					this._sendNotification("warning",
-						$.ig.util.stringFormat($.ig.Editor.locale.maxLengthErrMsg,
-							this.options.maxLength));
 					result = false;
 				}
 			} else {
@@ -2611,7 +2610,7 @@
 							cursorPosition = self._getCursorPosition();
 
 						// In that case blur event is triggered before the composition end and the editor has already processed the change.
-						if (self._inComposition !== true) {
+						if (self._focused !== true) {
 							return;
 						}
 						switch (widgetName) {
@@ -2644,20 +2643,10 @@
 							value = $.ig.util.IMEtoNumberString(value, $.ig.util.IMEtoENNumbersMapping());
 							pastedValue = $.ig.util.IMEtoNumberString(pastedValue, $.ig.util.IMEtoENNumbersMapping());
 						}
-						if (self._validateValue(value)) {
-							self._insert(pastedValue, self._compositionStartValue);
-							self._setCursorPosition(cursorPosition);
-						} else {
-							if (self.options.revertIfNotValid) {
-								value = self._valueInput.val();
-								self._updateValue(value);
-							} else {
-								self._clearValue();
-							}
-							if (self._focused) {
-								self._enterEditMode();
-							}
-						}
+
+						//D.P. 3rd Aug 2017 #1043 Insert handler should handle transformations (trim) and validate
+						self._insert(pastedValue, self._compositionStartValue);
+						self._setCursorPosition(cursorPosition);
 
 						//207318 T.P. 4th Dec 2015, Internal flag needed for specific cases.
 						delete self._inComposition;
@@ -2667,6 +2656,14 @@
 					}, 0);
 				},
 				"compositionupdate.editor": function (evt) {
+					if (typeof self._copositionStartIndex === "undefined") {
+						//D.P. Chrome on Adroid will not fire compositionstart if replacing the entire selection
+						//In this case patch start index and value:
+						var startIndex = self._getCursorPosition();
+						startIndex -= evt.originalEvent.data ? evt.originalEvent.data.length : 1;
+						self._copositionStartIndex = startIndex;
+						self._compositionStartValue = self._editorInput.val().substring(0, startIndex);
+					}
 					setTimeout(function () {
 						self._currentCompositionValue =
 							$(evt.target)
@@ -2703,19 +2700,32 @@
 			}
 		},
 		_processInternalValueChanging: function (value) { //TextEditor
-				if (this._validateValue(value)) {
+			//D.P. 3rd Aug 2017 #1043 Make sure maxLength is respected when typing handlers can't prevent entry
+			if (this.options.maxLength) {
+				if (value && value.toString().length > this.options.maxLength) {
+					value = value.toString().substring(0, this.options.maxLength);
+
+					//Raise warning
+					this._sendNotification("warning",
+						{
+							optName: "maxLengthErrMsg",
+							arg: this.options.maxLength
+						});
+				}
+			}
+			if (this._validateValue(value)) {
+				this._updateValue(value);
+			} else {
+
+				// If the value is not valid, we clear the editor
+				if (this.options.revertIfNotValid) {
+					value = this._valueInput.val();
 					this._updateValue(value);
 				} else {
-
-					// If the value is not valid, we clear the editor
-					if (this.options.revertIfNotValid) {
-						value = this._valueInput.val();
-						this._updateValue(value);
-					} else {
-						this._clearValue();
-						value = this._valueInput.val();
-					}
+					this._clearValue();
+					value = this._valueInput.val();
 				}
+			}
 		},
 		_triggerKeyDown: function (event) { //TextEditor
 			//cancellable

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1227,6 +1227,51 @@
 					$("#1090Editor").remove();
 				}, 100);
 			});
+
+			testId = 'Bug 1043 - maxLength not respected on Android';
+			test(testId, 6, function () {
+				var $editor =  $("<input/>").appendTo("#testBedContainer")
+					.igTextEditor({
+						maxLength: 5
+					});
+				$field = $editor.igTextEditor("field");
+
+				$field.focus();
+				var composition = jQuery.Event("compositionstart");
+				$field.trigger(composition);
+				$field.val("12345678");
+				var compositionend = jQuery.Event("compositionend");
+				$field.trigger(compositionend);
+				stop();
+				setTimeout(function () {
+					start();
+					equal($field.val(), "12345", "Text was not trimmed");
+					ok($editor.igTextEditor("editorContainer").hasClass($.ui.igNotifier.prototype.css.warningState), "Warning message not shown");
+					equal($editor.igTextEditor("editorContainer").igNotifier( "container" ).text(),
+						$.ig.Editor.locale.maxLengthErrMsg.replace("{0}", 5), "MaxLength message not correct.");
+					$field.blur();
+					// test case without start (Chrome Android)
+					$field.focus();
+					$field.select();
+					var compositionupdate = jQuery.Event("compositionupdate");
+					compositionupdate.originalEvent = {data: "2"};
+					$field.val("12");
+					$field[0].setSelectionRange(1,1);
+					$field.trigger(compositionupdate);
+					$field.val("12345678");
+					var compositionend = jQuery.Event("compositionend");
+					$field.trigger(compositionend);
+					stop();
+					setTimeout(function () {
+						start();
+						equal($field.val(), "12345", "Text was not trimmed with update only");
+						ok($editor.igTextEditor("editorContainer").hasClass($.ui.igNotifier.prototype.css.warningState), "Warning message not shown");
+						equal($editor.igTextEditor("editorContainer").igNotifier( "container" ).text(),
+							$.ig.Editor.locale.maxLengthErrMsg.replace("{0}", 5), "MaxLength message not correct.");
+						$editor.remove();
+					}, 0);
+				}, 0);
+			});
 		});
 
 			

--- a/tests/unit/editors/textEditor/tests.html
+++ b/tests/unit/editors/textEditor/tests.html
@@ -667,11 +667,11 @@
 			equal(editor.igTextEditor("value"), "newValue", "Value should be changed");
 			editorInput.val("1234567890987654");
 			keyInteraction(13, editorInput);
-			equal(editor.igTextEditor("value"), "newValue", "Value should be limited to 10 symbols");
+			equal(editor.igTextEditor("value"), "1234567890", "Value should be limited to 10 symbols");
 			listEditor.igTextEditor("option", "preventSubmitOnEnter", true);
 			editorInput.val("newNewValue");
 			keyInteraction(13, editorInput);
-			equal(editor.igTextEditor("value"), "newValue", "Value should stay with the previouse value");
+			equal(editor.igTextEditor("value"), "newNewValu", "Value should stay with the previouse value");
 			editor.igTextEditor("value", "newValueto");
 			keyInteraction(56, editorInput);
 			equal(editor.igTextEditor("value"), "newValueto", "Value should stay with the previouse value");


### PR DESCRIPTION
- Initial changes to handle maxLength on android properly
- Update tests that exceed maxLength without typing to expect trim. Cleanup code.
- Patch specific composition case where Chrome on Android will go directly into update w/o firing start
- Moving the fix for #1042 before validation.

