### PR TITLE
#1043 Fix composition handling for maxLength on Android 

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2776,6 +2776,14 @@
 					}, 0);
 				},
 				"compositionupdate.editor": function (evt) {
+					if (typeof self._copositionStartIndex === "undefined") {
+						//D.P. Chrome on Adroid will not fire compositionstart if replacing the entire selection
+						//In this case patch start index and value:
+						var startIndex = self._getCursorPosition();
+						startIndex -= evt.originalEvent.data ? evt.originalEvent.data.length : 1;
+						self._copositionStartIndex = startIndex;
+						self._compositionStartValue = self._editorInput.val().substring(0, startIndex);
+					}
 					setTimeout(function () {
 						self._currentCompositionValue =
 							$(evt.target)

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1067,6 +1067,18 @@
 
 				// N.A. 12/1/2015 Bug #207198: Remove notifier when value updated through value method.
 				this._clearEditorNotifier();
+
+				// N.A. July 27th, 2017, #1042: Trim value, when its length is larger then the maxLength one.
+				if (this.options.maxLength) {
+					if (newValue && newValue.toString().length > this.options.maxLength) {
+						newValue = newValue.toString().substring(0, this.options.maxLength);
+						this._sendNotification("warning",
+						{
+							optName: "maxLengthErrMsg",
+							arg: this.options.maxLength
+						});
+					}
+				}
 				if (this._validateValue(newValue)) {
 					if (this.options.toUpper) {
 						if (newValue) { newValue = newValue.toLocaleUpperCase(); }
@@ -1081,17 +1093,9 @@
 					this._updateValue(newValue);
 					this._editorInput.val(this._getDisplayValue());
 				} else {
-
-					// N.A. July 27th, 2017, #1042: Trim value, when its length is larger then the maxLenght one.
-					if (this.options.maxLength) {
-						newValue = newValue.toString().substring(0, this.options.maxLength);
-						this._updateValue(newValue);
-						this._editorInput.val(this._getDisplayValue());
-					} else {
-						this._clearValue();
-						if (this._focused !== true) {
-							this._exitEditMode();
-						}
+					this._clearValue();
+					if (this._focused !== true) {
+						this._exitEditMode();
 					}
 				}
 			} else {
@@ -2255,11 +2259,6 @@
 				 if (val.toString().length <= this.options.maxLength) {
 					result = true;
 				} else {
-					this._sendNotification("warning",
-						{
-							optName: "maxLengthErrMsg",
-							arg: this.options.maxLength
-						});
 					result = false;
 				}
 			} else {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1020,7 +1020,6 @@
 			}
 		},
 		_setBlur: function (event) { //Base Editor
-			//log("blur");
 			var newValue;
 			if (this._cancelBlurOnInput) {
 				this._editorInput.focus();
@@ -2727,7 +2726,6 @@
 				},
 				"compositionend.editor": function () {
 					setTimeout(function () {
-						//log("compositionend.editor:" + self._editorInput.val());
 						var value, pastedValue, widgetName = self.widgetName,
 							cursorPosition = self._getCursorPosition();
 
@@ -2765,22 +2763,10 @@
 							value = $.ig.util.IMEtoNumberString(value, $.ig.util.IMEtoENNumbersMapping());
 							pastedValue = $.ig.util.IMEtoNumberString(pastedValue, $.ig.util.IMEtoENNumbersMapping());
 						}
-						//log("inserting:" + value);
-						// if (self._validateValue(value)) {
-							//D.P. Insert handler should validate
-							self._insert(pastedValue, self._compositionStartValue);
-							self._setCursorPosition(cursorPosition);
-						// } else {
-						// 	if (self.options.revertIfNotValid) {
-						// 		value = self._valueInput.val();
-						// 		self._updateValue(value);
-						// 	} else {
-						// 		self._clearValue();
-						// 	}
-						// 	if (self._focused) {
-						// 		self._enterEditMode();
-						// 	}
-						// }
+						
+						//D.P. 3rd Aug 2017 #1043 Insert handler should handle transformations (trim) and validate
+						self._insert(pastedValue, self._compositionStartValue);
+						self._setCursorPosition(cursorPosition);
 
 						//207318 T.P. 4th Dec 2015, Internal flag needed for specific cases.
 						delete self._inComposition;
@@ -2827,6 +2813,8 @@
 		},
 		_processInternalValueChanging: function (value) { //TextEditor
 			var listIndex;
+
+			//D.P. 3rd Aug 2017 #1043 Make sure maxLength is respected when typing handlers can't prevent entry
 			if (this.options.maxLength) {
 				if (value && value.toString().length > this.options.maxLength) {
 					value = value.toString().substring(0, this.options.maxLength);

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2763,7 +2763,7 @@
 							value = $.ig.util.IMEtoNumberString(value, $.ig.util.IMEtoENNumbersMapping());
 							pastedValue = $.ig.util.IMEtoNumberString(pastedValue, $.ig.util.IMEtoENNumbersMapping());
 						}
-						
+
 						//D.P. 3rd Aug 2017 #1043 Insert handler should handle transformations (trim) and validate
 						self._insert(pastedValue, self._compositionStartValue);
 						self._setCursorPosition(cursorPosition);

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -1020,6 +1020,7 @@
 			}
 		},
 		_setBlur: function (event) { //Base Editor
+			//log("blur");
 			var newValue;
 			if (this._cancelBlurOnInput) {
 				this._editorInput.focus();
@@ -2726,11 +2727,12 @@
 				},
 				"compositionend.editor": function () {
 					setTimeout(function () {
+						//log("compositionend.editor:" + self._editorInput.val());
 						var value, pastedValue, widgetName = self.widgetName,
 							cursorPosition = self._getCursorPosition();
 
 						// In that case blur event is triggered before the composition end and the editor has already processed the change.
-						if (self._inComposition !== true) {
+						if (self._focused !== true) {
 							return;
 						}
 						switch (widgetName) {
@@ -2763,20 +2765,22 @@
 							value = $.ig.util.IMEtoNumberString(value, $.ig.util.IMEtoENNumbersMapping());
 							pastedValue = $.ig.util.IMEtoNumberString(pastedValue, $.ig.util.IMEtoENNumbersMapping());
 						}
-						if (self._validateValue(value)) {
+						//log("inserting:" + value);
+						// if (self._validateValue(value)) {
+							//D.P. Insert handler should validate
 							self._insert(pastedValue, self._compositionStartValue);
 							self._setCursorPosition(cursorPosition);
-						} else {
-							if (self.options.revertIfNotValid) {
-								value = self._valueInput.val();
-								self._updateValue(value);
-							} else {
-								self._clearValue();
-							}
-							if (self._focused) {
-								self._enterEditMode();
-							}
-						}
+						// } else {
+						// 	if (self.options.revertIfNotValid) {
+						// 		value = self._valueInput.val();
+						// 		self._updateValue(value);
+						// 	} else {
+						// 		self._clearValue();
+						// 	}
+						// 	if (self._focused) {
+						// 		self._enterEditMode();
+						// 	}
+						// }
 
 						//207318 T.P. 4th Dec 2015, Internal flag needed for specific cases.
 						delete self._inComposition;
@@ -2823,6 +2827,18 @@
 		},
 		_processInternalValueChanging: function (value) { //TextEditor
 			var listIndex;
+			if (this.options.maxLength) {
+				if (value && value.toString().length > this.options.maxLength) {
+					value = value.toString().substring(0, this.options.maxLength);
+
+					//Raise warning
+					this._sendNotification("warning",
+						{
+							optName: "maxLengthErrMsg",
+							arg: this.options.maxLength
+						});
+				}
+			}
 			if (this._validateValue(value)) {
 				if (this._dropDownList && this.options.isLimitedToListValues &&
 					(listIndex = this._valueIndexInList(value)) !== -1 ) {

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1397,6 +1397,50 @@
 					$("#942Editor").remove();
 					}, 100);
 			});
+			testId = 'Bug 1043 - maxLength not respected on Android';
+			test(testId, 6, function () {
+				var $editor =  $("<input/>").appendTo("#testBedContainer")
+					.igTextEditor({
+						maxLength: 5
+					});
+				$field = $editor.igTextEditor("field");
+
+				$field.focus();
+				var composition = jQuery.Event("compositionstart");
+				$field.trigger(composition);
+				$field.val("12345678");
+				var compositionend = jQuery.Event("compositionend");
+				$field.trigger(compositionend);
+				stop();
+				setTimeout(function () {
+					start();
+					equal($field.val(), "12345", "Text was not trimmed");
+					ok($editor.igTextEditor("editorContainer").hasClass($.ui.igNotifier.prototype.css.warningState), "Warning message not shown");
+					equal($editor.igTextEditor("editorContainer").igNotifier( "container" ).text(),
+						$.ig.Editor.locale.maxLengthErrMsg.replace("{0}", 5), "MaxLength message not correct.");
+					$field.blur();
+					// test case without start (Chrome Android)
+					$field.focus();
+					$field.select();
+					var compositionupdate = jQuery.Event("compositionupdate");
+					compositionupdate.originalEvent = {data: "2"};
+					$field.val("12");
+					$field[0].setSelectionRange(1,1);
+					$field.trigger(compositionupdate);
+					$field.val("12345678");
+					var compositionend = jQuery.Event("compositionend");
+					$field.trigger(compositionend);
+					stop();
+					setTimeout(function () {
+						start();
+						equal($field.val(), "12345", "Text was not trimmed with update only");
+						ok($editor.igTextEditor("editorContainer").hasClass($.ui.igNotifier.prototype.css.warningState), "Warning message not shown");
+						equal($editor.igTextEditor("editorContainer").igNotifier( "container" ).text(),
+							$.ig.Editor.locale.maxLengthErrMsg.replace("{0}", 5), "MaxLength message not correct.");
+						$editor.remove();
+					}, 0);
+				}, 0);
+			});
 		});
 
 		function emulateKeyBoard(key, ctrl, shift, alt, element) {

--- a/tests/unit/editors/textEditor/tests.html
+++ b/tests/unit/editors/textEditor/tests.html
@@ -953,11 +953,11 @@
 			equal(editor.igTextEditor("value"), "newValue", "Value should be changed");
 			editorInput.val("1234567890987654");
 			keyInteraction(13, editorInput);
-			equal(editor.igTextEditor("value"), "newValue", "Value should be limited to 10 symbols");
+			equal(editor.igTextEditor("value"), "1234567890", "Value should be limited to 10 symbols");
 			listEditor.igTextEditor("option", "preventSubmitOnEnter", true);
 			editorInput.val("newNewValue");
 			keyInteraction(13, editorInput);
-			equal(editor.igTextEditor("value"), "newValue", "Value should stay with the previouse value");
+			equal(editor.igTextEditor("value"), "newNewValu", "Value should stay with the previouse value");
 			editor.igTextEditor("value", "newValueto");
 			keyInteraction(56, editorInput);
 			ok(editor.igTextEditor("editorContainer").hasClass($.ui.igNotifier.prototype.css.warningState) &&


### PR DESCRIPTION
Closes #1043 after PR #1117 and #1118 are merged.

### Additional information related to this pull request:
Change to composition handling to allow value to be processed properly rather than rejected.
- Also includes a patch specific composition case where Chrome on Android will go directly into update w/o firing start.
- Also moving the fix for #1042 before validation.
