### PR TITLE
Fix for bug 238125 - When headerText contains HTML string the column cell data is broken (contains escaped html)

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -399,7 +399,7 @@
 	//and setting them in a a box can be done by the predefined classes "ui-state-default ui-corner-all ui-igcheckbox-small"
 	$.ig.checkboxMarkupClasses = "";
 
-	$.ig.endcode = function (value) {
+	$.ig.encode = function (value) {
 		/* Encode string.
 			paramType="string" The string to be encoded.
 			returnType="string" Returns the encoded string.
@@ -422,7 +422,7 @@
 			// L.A. 17 October 2012 - Fixing bug #123215 The group rows of a grouped checkbox column are too large
 			display = displayStyle || "inline-block";
 		/* P.Zh. 11 August 2017 - Fixing bug #238125 When headerText contains HTML string the column cell data is broken (contains escaped html) */
-		labelText = $.ig.endcode(labelText);
+		labelText = $.ig.encode(labelText);
 		if (format === "checkbox" && notTemplate) {
 			s = "<span class='ui-igcheckbox-container' style='display:" +
 				display + ";' role='checkbox' aria-disabled='true' aria-checked='" +

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -411,7 +411,7 @@
 			.replace(/>/g, "&gt;")
 			.replace(/'/g, "&#39;")
 			.replace(/"/g, "&#34;") : "";
-	}
+	};
 
 	$.ig.formatter = function (val, type, format, notTemplate, enableUTCDates,
 		displayStyle, labelText, tabIndex) {

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -403,14 +403,14 @@
 		/* Encode string.
 			paramType="string" The string to be encoded.
 			returnType="string" Returns the encoded string.
-		 */
-			return value !== null && value !== undefined ?
-			value.toString()
-			.replace(/&/g, "&amp;")
-			.replace(/</g, "&lt;")
-			.replace(/>/g, "&gt;")
-			.replace(/'/g, "&#39;")
-			.replace(/"/g, "&#34;") : "";
+		*/
+		return value !== null && value !== undefined ?
+		value.toString()
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/'/g, "&#39;")
+		.replace(/"/g, "&#34;") : "";
 	};
 
 	$.ig.formatter = function (val, type, format, notTemplate, enableUTCDates,

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -407,6 +407,13 @@
 
 			// L.A. 17 October 2012 - Fixing bug #123215 The group rows of a grouped checkbox column are too large
 			display = displayStyle || "inline-block";
+		/* P.Zh. 11 August 2017 - Fixing bug #238125 When headerText contains HTML string the column cell data is broken (contains escaped html) */
+		labelText = labelText
+					.replace(/&/g, "&amp;")
+					.replace(/</g, "&lt;")
+					.replace(/>/g, "&gt;")
+					.replace(/"/g, "&quot;")
+					.replace(/'/g, "&#039;");
 		if (format === "checkbox" && notTemplate) {
 			s = "<span class='ui-igcheckbox-container' style='display:" +
 				display + ";' role='checkbox' aria-disabled='true' aria-checked='" +

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -399,6 +399,20 @@
 	//and setting them in a a box can be done by the predefined classes "ui-state-default ui-corner-all ui-igcheckbox-small"
 	$.ig.checkboxMarkupClasses = "";
 
+	$.ig.endcode = function (value) {
+		/* Encode string.
+			paramType="string" The string to be encoded.
+			returnType="string" Returns the encoded string.
+		 */
+			return value !== null && value !== undefined ?
+			value.toString()
+			.replace(/&/g, "&amp;")
+			.replace(/</g, "&lt;")
+			.replace(/>/g, "&gt;")
+			.replace(/'/g, "&#39;")
+			.replace(/"/g, "&#34;") : "";
+	}
+
 	$.ig.formatter = function (val, type, format, notTemplate, enableUTCDates,
 		displayStyle, labelText, tabIndex) {
 		var min, y, h, m, s, ms, am, e, day, pattern, len, n, dot, gr,
@@ -408,12 +422,7 @@
 			// L.A. 17 October 2012 - Fixing bug #123215 The group rows of a grouped checkbox column are too large
 			display = displayStyle || "inline-block";
 		/* P.Zh. 11 August 2017 - Fixing bug #238125 When headerText contains HTML string the column cell data is broken (contains escaped html) */
-		labelText = labelText
-					.replace(/&/g, "&amp;")
-					.replace(/</g, "&lt;")
-					.replace(/>/g, "&gt;")
-					.replace(/"/g, "&quot;")
-					.replace(/'/g, "&#039;");
+		labelText = $.ig.endcode(labelText);
 		if (format === "checkbox" && notTemplate) {
 			s = "<span class='ui-igcheckbox-container' style='display:" +
 				display + ";' role='checkbox' aria-disabled='true' aria-checked='" +

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -70,12 +70,12 @@
 			ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
 		});
 
-        test("Test $.ig.encode", function () {
+		test("Test $.ig.encode", function () {
 			equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
 			equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");
 			equal($.ig.encode("<span id='span1'></span>"), "&lt;span id=&#39;span1&#39;&gt;&lt;/span&gt;", "Should encode span element with attribute and single quote");
 			equal($.ig.encode("<span id=\"span1\"></span>"), "&lt;span id=&#34;span1&#34;&gt;&lt;/span&gt;", "Should encode span element with attribute and double quote")
-        });
+		});
 	</script>
 </head>
 <body>

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -70,6 +70,12 @@
 			ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
 		});
 
+        test("Test $.ig.encode", function () {
+			equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
+			equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");
+			equal($.ig.encode("<span id='span1'></span>"), "&lt;span id=&#39;span1&#39;&gt;&lt;/span&gt;", "Should encode span element with attribute and single quote");
+			equal($.ig.encode("<span id=\"span1\"></span>"), "&lt;span id=&#34;span1&#34;&gt;&lt;/span&gt;", "Should encode span element with attribute and double quote")
+        });
 	</script>
 </head>
 <body>


### PR DESCRIPTION
Fix for bug 238125 - When headerText contains HTML string the column cell data is broken (contains escaped html)

### Additional information related to this pull request:

The issue is caused by the aria-label attribute which accepts the value of the headerText option. When there are html tags in the header text some of the symbols need to be escaped so the generated html is correct.