### PR TITLE
#1076 Editors knockout extension should allow setting null values

### DIFF
--- a/src/js/extensions/infragistics.ui.editors.knockout-extensions.js
+++ b/src/js/extensions/infragistics.ui.editors.knockout-extensions.js
@@ -289,7 +289,8 @@
 			value = ko.utils.unwrapObservable(valueAccessor().value);
 
 			// Related to #695. Editors should allow empty string.
-			if (value !== "") {
+			// N.A. August 14th, 2017 #1078: Allow setting null values.
+			if (value !== "" && value !== null) {
 				// K.D. Good!
 				if (isNaN(value)) {
 					value = undefined;
@@ -352,7 +353,8 @@
 			value = ko.utils.unwrapObservable(valueAccessor().value);
 
 			// Related to #695. Editors should allow empty string.
-			if (value !== "") {
+			// N.A. August 14th, 2017 #1078: Allow setting null values.
+			if (value !== "" && value !== null) {
 				if (isNaN(value)) {
 					value = undefined;
 				}
@@ -413,7 +415,8 @@
 			value = ko.utils.unwrapObservable(valueAccessor().value);
 
 			// Related to #695. Editors should allow empty string.
-			if (value !== "") {
+			// N.A. August 14th, 2017 #1078: Allow setting null values.
+			if (value !== "" && value !== null) {
 				if (isNaN(value)) {
 					value = undefined;
 				}

--- a/tests/unit/knockout/editors/igCurrencyEditor/tests.html
+++ b/tests/unit/knockout/editors/igCurrencyEditor/tests.html
@@ -423,6 +423,7 @@
 			equal($editor.igCurrencyEditor("value"), 23, "Editor should have 23 as a value");
 			model.nullValue(null);
 			equal($editor.igCurrencyEditor("value"), null, "Editor should have null as a value");
+			$editor.remove();
 		});
 	});//document ready
 

--- a/tests/unit/knockout/editors/igCurrencyEditor/tests.html
+++ b/tests/unit/knockout/editors/igCurrencyEditor/tests.html
@@ -63,6 +63,7 @@
 				eventTriggered = true;
 			};
 			this.isDisabled =  ko.observable(false);
+			this.nullValue = ko.observable(null);
 		};
 		
 		model = new viewModel();
@@ -412,6 +413,17 @@
 			$editor.remove();
 			$chk.remove();
 		});
+
+		var testId = 'Test null binding';
+		test(testId, 3, function () {
+			var $editor = $("#nullBoundEditor");
+
+			equal($editor.igCurrencyEditor("value"), null, "Editor should have null as a value");
+			model.nullValue(23);
+			equal($editor.igCurrencyEditor("value"), 23, "Editor should have 23 as a value");
+			model.nullValue(null);
+			equal($editor.igCurrencyEditor("value"), null, "Editor should have null as a value");
+		});
 	});//document ready
 
 	function mouseInteraction(type, element) {
@@ -610,6 +622,8 @@
           }, igEditorDisable: isDisabled" />
 
 		<input id="chkDisabled" type="checkbox" data-bind="checked: isDisabled"/>
+
+		<input id="nullBoundEditor" data-bind="igCurrencyEditor: { value: nullValue, allowNullValue: true }" />
 </div>
 </body>
 </html>

--- a/tests/unit/knockout/editors/igNumericEditor/tests.html
+++ b/tests/unit/knockout/editors/igNumericEditor/tests.html
@@ -390,6 +390,7 @@
 			equal($editor.igNumericEditor("value"), 23, "Editor should have 23 as a value");
 			model.nullValue(null);
 			equal($editor.igNumericEditor("value"), null, "Editor should have null as a value");
+			$editor.remove();
 		});
 	});
 

--- a/tests/unit/knockout/editors/igNumericEditor/tests.html
+++ b/tests/unit/knockout/editors/igNumericEditor/tests.html
@@ -63,6 +63,7 @@
 				eventTriggered = true;
 			};
 			this.isDisabled =  ko.observable(false);
+			this.nullValue = ko.observable(null);
 		};
 		
 		model = new viewModel();
@@ -379,6 +380,17 @@
 			$editor.remove();
 			$chk.remove();
 		});
+
+		var testId = 'Test null binding';
+		test(testId, 3, function () {
+			var $editor = $("#nullBoundEditor");
+
+			equal($editor.igNumericEditor("value"), null, "Editor should have null as a value");
+			model.nullValue(23);
+			equal($editor.igNumericEditor("value"), 23, "Editor should have 23 as a value");
+			model.nullValue(null);
+			equal($editor.igNumericEditor("value"), null, "Editor should have null as a value");
+		});
 	});
 
 	function testImmediate(element) {
@@ -591,6 +603,8 @@
 		}, igEditorDisable: isDisabled" />
 
 	<input id="chkDisabled" type="checkbox" data-bind="checked: isDisabled"/>
+
+	<input id="nullBoundEditor" data-bind="igNumericEditor: { value: nullValue, allowNullValue: true }" />
 </div>
 </body>
 </html>

--- a/tests/unit/knockout/editors/igPercentEditor/tests.html
+++ b/tests/unit/knockout/editors/igPercentEditor/tests.html
@@ -403,6 +403,7 @@
 			equal($editor.igPercentEditor("value"), 23, "Editor should have 23 as a value");
 			model.nullValue(null);
 			equal($editor.igPercentEditor("value"), null, "Editor should have null as a value");
+			$editor.remove();
 		});
 	});//document ready
 

--- a/tests/unit/knockout/editors/igPercentEditor/tests.html
+++ b/tests/unit/knockout/editors/igPercentEditor/tests.html
@@ -58,6 +58,7 @@
 				eventTriggered = true;
 			};
 			this.isDisabled =  ko.observable(false);
+			this.nullValue = ko.observable(null);
 		};
 		
 		model = new viewModel();
@@ -392,6 +393,17 @@
 			$editor.remove();
 			$chk.remove();
 		});
+
+		var testId = 'Test null binding';
+		test(testId, 3, function () {
+			var $editor = $("#nullBoundEditor");
+
+			equal($editor.igPercentEditor("value"), null, "Editor should have null as a value");
+			model.nullValue(23);
+			equal($editor.igPercentEditor("value"), 23, "Editor should have 23 as a value");
+			model.nullValue(null);
+			equal($editor.igPercentEditor("value"), null, "Editor should have null as a value");
+		});
 	});//document ready
 
 	function mouseInteraction(type, element) {
@@ -596,6 +608,8 @@
 		}, igEditorDisable: isDisabled" />
 
 	<input id="chkDisabled" type="checkbox" data-bind="checked: isDisabled"/>
+
+	<input id="nullBoundEditor" data-bind="igPercentEditor: { value: nullValue, allowNullValue: true }" />
 </div>
 </body>
 </html>


### PR DESCRIPTION
Closes #1076

### Additional information related to this pull request:
If editor allows null values, then the knockout extension should allow setting them to the editor.

