### PR TITLE
[igDateEditor] Restore partial revert behavior on invalid composition

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2625,7 +2625,8 @@
 				"compositionend.editor": function () {
 					setTimeout(function () {
 						var value, pastedValue, widgetName = self.widgetName,
-							cursorPosition = self._getCursorPosition();
+							cursorPosition = self._getCursorPosition(),
+							selection = { start: cursorPosition, end: cursorPosition };
 
 						// In that case blur event is triggered before the composition end and the editor has already processed the change.
 						if (self._focused !== true) {
@@ -2647,6 +2648,11 @@
 									pastedValue = value = self._parseValueByMask(value);
 									if (value !== self._maskWithPrompts) {
 										value = self._parseDateFromMaskedValue(value);
+									} else if (self.options.revertIfNotValid) {
+										//D.P. Assume empty mask means everything entered was not accepted, attempt to revert
+										pastedValue = value = self._maskedValue;
+										selection.start = 0;
+										selection.end = value.length;
 									}
 								}
 								break;
@@ -2663,8 +2669,7 @@
 						}
 
 						//D.P. 3rd Aug 2017 #1043 Insert handler should handle transformations (trim) and validate
-						self._insert(pastedValue, self._compositionStartValue);
-						self._setCursorPosition(cursorPosition);
+						self._insert(pastedValue, self._compositionStartValue, selection);
 
 						//207318 T.P. 4th Dec 2015, Internal flag needed for specific cases.
 						delete self._inComposition;

--- a/tests/unit/editors/dateEditor/tests.html
+++ b/tests/unit/editors/dateEditor/tests.html
@@ -1259,6 +1259,35 @@
 				ok($editor.igDateEditor("clearButton").is(":visible"), "Clear button is not visible");
 				$editor.remove();
 			});
+
+			var testId = 'Test invalid composition value';
+			test(testId, 3, function () {
+				var $editor =  $("<input/>").appendTo("#testBedContainer")
+					.igDateEditor({
+						value: new Date(2015, 04, 01)
+					});
+				$field = $editor.igDateEditor("field");
+
+				$field.focus();
+				$field[0].setSelectionRange(0,5);
+				var composition = jQuery.Event("compositionstart");
+				$field.trigger(composition);
+				var compositionupdate = jQuery.Event("compositionupdate");
+				$field.val("あいうえお");
+				$field[0].setSelectionRange(5,5);
+				$field.trigger(compositionupdate);
+				var compositionend = jQuery.Event("compositionend");
+				$field.trigger(compositionend);
+				stop();
+				setTimeout(function () {
+					start();
+					equal($field.val(), "05/01/2015", "Text should remain on invalid composition value.");
+					ok($field[0].selectionStart === 0 && $field[0].selectionEnd === 10, "Entire value should be selected.");
+					$field.blur();
+					equal($editor.igDateEditor("value") && $editor.igDateEditor("value").getTime(), new Date(2015, 04, 01).getTime(), "value did not stay the same");
+					$editor.remove();
+				}, 0);
+			});
 		});
 
 		// function emulateKeyBoard(key, ctrl, shift, alt, element) {


### PR DESCRIPTION
Restoring partial revert behavior when composing produces a completely invalid result
Caused by changes for #1043 in 16.2

### Additional information related to this pull request:

