### PR TITLE
#1151 Remove $.ig.setRegionalDefault method

### DIFF
--- a/src/js/modules/i18n/regional/infragistics.ui.regional-af.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-af.js
@@ -53,7 +53,7 @@
 	    currencySymbol: 'R'
 	};
 	
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('af');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-af.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-af.js
@@ -51,8 +51,9 @@
 	    currencyPositivePattern: '$ n',
 	    currencyNegativePattern: '$-n',
 	    currencySymbol: 'R'
-    };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('af');
+	};
+	
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('af');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ar.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ar.js
@@ -37,7 +37,7 @@ $.ig.regional.ar = {
 	percentPositivePattern: 'n $',
 	percentNegativePattern: '-n $'
 };
-if ($.ig.setRegionalDefault) {
-	$.ig.setRegionalDefault('ar');
+if ($.ig.util.changeGlobalRegional) {
+	$.ig.util.changeGlobalRegional('ar');
 }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ar.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ar.js
@@ -37,7 +37,7 @@ $.ig.regional.ar = {
 	percentPositivePattern: 'n $',
 	percentNegativePattern: '-n $'
 };
-if ($.ig.util.changeGlobalRegional) {
+if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	$.ig.util.changeGlobalRegional('ar');
 }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-az.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-az.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('az');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('az');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-az.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-az.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('az');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-bg.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-bg.js
@@ -62,7 +62,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('bg');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-bg.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-bg.js
@@ -62,7 +62,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('bg');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('bg');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-bs.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-bs.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('bs');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('bs');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-bs.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-bs.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('bs');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ca.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ca.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('ca');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ca.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ca.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('ca');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('ca');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-cs.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-cs.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('cs');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('cs');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-cs.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-cs.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('cs');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-da.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-da.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('da');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('da');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-da.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-da.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('da');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-de.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-de.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('de');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-de.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-de.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('de');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('de');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-el.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-el.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('el');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-el.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-el.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('el');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('el');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-en-GB.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-en-GB.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: '.',
 	    percentGroupSeparator: ','
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('en-GB');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-en-GB.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-en-GB.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: '.',
 	    percentGroupSeparator: ','
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('en-GB');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('en-GB');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-en.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-en.js
@@ -51,7 +51,7 @@
 	    percentMaxDecimals: 2,
 	    percentMinDecimals: 2
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('en-US');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('en-US');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-en.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-en.js
@@ -51,7 +51,7 @@
 	    percentMaxDecimals: 2,
 	    percentMinDecimals: 2
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('en-US');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es-419.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es-419.js
@@ -59,7 +59,7 @@
 		percentDecimalSeparator: '.',
 		percentGroupSeparator: ','
 	};
-	if ($.ig.setRegionalDefault) {
-		$.ig.setRegionalDefault('es-419');
+	if ($.ig.util.changeGlobalRegional) {
+		$.ig.util.changeGlobalRegional('es-419');
 	}
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es-419.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es-419.js
@@ -59,7 +59,7 @@
 		percentDecimalSeparator: '.',
 		percentGroupSeparator: ','
 	};
-	if ($.ig.util.changeGlobalRegional) {
+	if ($.ig.util && $.ig.util.changeGlobalRegional) {
 		$.ig.util.changeGlobalRegional('es-419');
 	}
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es-MX.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es-MX.js
@@ -59,7 +59,7 @@
 		percentDecimalSeparator: '.',
 		percentGroupSeparator: ','
 	};
-	if ($.ig.util.changeGlobalRegional) {
+	if ($.ig.util && $.ig.util.changeGlobalRegional) {
 		$.ig.util.changeGlobalRegional('es-MX');
 	}
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es-MX.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es-MX.js
@@ -59,7 +59,7 @@
 		percentDecimalSeparator: '.',
 		percentGroupSeparator: ','
 	};
-	if ($.ig.setRegionalDefault) {
-		$.ig.setRegionalDefault('es-MX');
+	if ($.ig.util.changeGlobalRegional) {
+		$.ig.util.changeGlobalRegional('es-MX');
 	}
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('es');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-es.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-es.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('es');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('es');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-et.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-et.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('et');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-et.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-et.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('et');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('et');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fa.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fa.js
@@ -92,7 +92,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('fa');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fa.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fa.js
@@ -92,7 +92,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('fa');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('fa');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fi.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fi.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('fi');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('fi');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fi.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fi.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('fi');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fo.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fo.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('fo');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fo.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fo.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('fo');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('fo');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fr-CH.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fr-CH.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: "'"
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('fr-CH');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fr-CH.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fr-CH.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: "'"
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('fr-CH');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('fr-CH');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fr.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('fr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-fr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-fr.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('fr');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('fr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-he.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-he.js
@@ -51,7 +51,7 @@
 	    currencyNegativePattern: '$-n',
 	    currencySymbol: 'KM'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('he');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('he');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-he.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-he.js
@@ -51,7 +51,7 @@
 	    currencyNegativePattern: '$-n',
 	    currencySymbol: 'KM'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('he');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hr.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('hr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hr.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('hr');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('hr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hu.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hu.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('hu');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hu.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hu.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('hu');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('hu');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hy.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hy.js
@@ -52,7 +52,7 @@
 	    currencyNegativePattern: '-n $',
 	    currencySymbol: 'դր.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('hy');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-hy.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-hy.js
@@ -52,7 +52,7 @@
 	    currencyNegativePattern: '-n $',
 	    currencySymbol: 'դր.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('hy');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('hy');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-id.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-id.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('id');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('id');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-id.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-id.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('id');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-is.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-is.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('is');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('is');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-is.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-is.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('is');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-it.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-it.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('it');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('it');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-it.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-it.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('it');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ja.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ja.js
@@ -54,7 +54,7 @@ $.ig.regional.ja = {
 	currencyMaxDecimals: 0,
 	currencyMinDecimals: 0
 };
-if ($.ig.util.changeGlobalRegional) {
+if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	$.ig.util.changeGlobalRegional('ja');
 }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ja.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ja.js
@@ -54,7 +54,7 @@ $.ig.regional.ja = {
 	currencyMaxDecimals: 0,
 	currencyMinDecimals: 0
 };
-if ($.ig.setRegionalDefault) {
-	$.ig.setRegionalDefault('ja');
+if ($.ig.util.changeGlobalRegional) {
+	$.ig.util.changeGlobalRegional('ja');
 }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ko.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ko.js
@@ -56,7 +56,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('ko');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('ko');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ko.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ko.js
@@ -56,7 +56,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('ko');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-lt.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-lt.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('lt');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('lt');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-lt.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-lt.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('lt');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-lv.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-lv.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('lv');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('lv');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-lv.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-lv.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('lv');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ms.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ms.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
     	$.ig.util.changeGlobalRegional('ms');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ms.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ms.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-    	$.ig.setRegionalDefault('ms');
+    if ($.ig.util.changeGlobalRegional) {
+    	$.ig.util.changeGlobalRegional('ms');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-nl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-nl.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-    	$.ig.setRegionalDefault('nl');
+    if ($.ig.util.changeGlobalRegional) {
+    	$.ig.util.changeGlobalRegional('nl');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-nl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-nl.js
@@ -59,7 +59,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
     	$.ig.util.changeGlobalRegional('nl');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-no.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-no.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-    	$.ig.setRegionalDefault('no');
+    if ($.ig.util.changeGlobalRegional) {
+    	$.ig.util.changeGlobalRegional('no');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-no.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-no.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
     	$.ig.util.changeGlobalRegional('no');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-pl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-pl.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
     	$.ig.util.changeGlobalRegional('pl');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-pl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-pl.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-    	$.ig.setRegionalDefault('pl');
+    if ($.ig.util.changeGlobalRegional) {
+    	$.ig.util.changeGlobalRegional('pl');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-pt-BR.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-pt-BR.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
     	$.ig.util.changeGlobalRegional('pt-BR');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-pt-BR.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-pt-BR.js
@@ -57,7 +57,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-    	$.ig.setRegionalDefault('pt-BR');
+    if ($.ig.util.changeGlobalRegional) {
+    	$.ig.util.changeGlobalRegional('pt-BR');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ro.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ro.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-    	$.ig.setRegionalDefault('ro');
+    if ($.ig.util.changeGlobalRegional) {
+    	$.ig.util.changeGlobalRegional('ro');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ro.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ro.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
     	$.ig.util.changeGlobalRegional('ro');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ru.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ru.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('ru');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('ru');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ru.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ru.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('ru');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sk.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sk.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('sk');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sk.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sk.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('sk');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('sk');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sl.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('sl');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('sl');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sl.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sl.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('sl');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sq.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sq.js
@@ -62,7 +62,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('sq');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sq.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sq.js
@@ -62,7 +62,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('sq');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('sq');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sr-SR.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sr-SR.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('sr-SR');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sr-SR.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sr-SR.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('sr-SR');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('sr-SR');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sr.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('sr');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('sr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sr.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('sr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sv.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sv.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('sv');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-sv.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-sv.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('sv');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('sv');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ta.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ta.js
@@ -55,7 +55,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('ta');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('ta');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-ta.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-ta.js
@@ -55,7 +55,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('ta');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-th.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-th.js
@@ -52,7 +52,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('th');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('th');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-th.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-th.js
@@ -52,7 +52,7 @@
 	    percentPositivePattern: 'n $',
 	    percentNegativePattern: '-n $'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('th');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-tr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-tr.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('tr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-tr.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-tr.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('tr');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('tr');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-uk.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-uk.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('uk');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-uk.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-uk.js
@@ -58,7 +58,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: ' '
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('uk');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('uk');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-vi.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-vi.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('vi');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-vi.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-vi.js
@@ -60,7 +60,7 @@
 	    percentDecimalSeparator: ',',
 	    percentGroupSeparator: '.'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('vi');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('vi');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-CN.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-CN.js
@@ -52,7 +52,7 @@
 	    currencyNegativePattern: '$-n',
 	    currencySymbol: '￥'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('zh-CN');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-CN.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-CN.js
@@ -52,7 +52,7 @@
 	    currencyNegativePattern: '$-n',
 	    currencySymbol: '￥'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('zh-CN');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('zh-CN');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-HK.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-HK.js
@@ -45,7 +45,7 @@
 	    numericMaxDecimals: 2,
 	    currencySymbol: 'HK$'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('zh-HK');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-HK.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-HK.js
@@ -45,7 +45,7 @@
 	    numericMaxDecimals: 2,
 	    currencySymbol: 'HK$'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('zh-HK');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('zh-HK');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-TW.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-TW.js
@@ -52,7 +52,7 @@
 	    currencyNegativePattern: '-$n',
 	    currencySymbol: 'NT$'
     };
-    if ($.ig.util.changeGlobalRegional) {
+    if ($.ig.util && $.ig.util.changeGlobalRegional) {
 	    $.ig.util.changeGlobalRegional('zh-TW');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/i18n/regional/infragistics.ui.regional-zh-TW.js
+++ b/src/js/modules/i18n/regional/infragistics.ui.regional-zh-TW.js
@@ -52,7 +52,7 @@
 	    currencyNegativePattern: '-$n',
 	    currencySymbol: 'NT$'
     };
-    if ($.ig.setRegionalDefault) {
-	    $.ig.setRegionalDefault('zh-TW');
+    if ($.ig.util.changeGlobalRegional) {
+	    $.ig.util.changeGlobalRegional('zh-TW');
     }
 }));// REMOVE_FROM_COMBINED_FILES

--- a/src/js/modules/infragistics.util.jquery.js
+++ b/src/js/modules/infragistics.util.jquery.js
@@ -663,61 +663,6 @@
 		}
 		return (val || val === 0) ? val : "&nbsp;";
 	};
-	$.ig._regional = {
-		monthNames: [ "January", "February", "March", "April", "May", "June",
-			"July", "August", "September", "October", "November", "December" ],
-		monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
-		dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday",
-			"Thursday", "Friday", "Saturday" ],
-		dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
-		am: "AM",
-		pm: "PM",
-		datePattern: "M/d/yyyy",
-		dateLongPattern: "dddd, MMMM dd, yyyy",
-		dateTimePattern: "M/d/yyyy h:mm tt",
-		timePattern: "h:mm tt",
-		timeLongPattern: "h:mm:ss tt",
-		dateTitleFullPattern: "dd MM yy",
-		dateTitleMonthPattern: "MM yy",
-		negativeSign: "-",
-		numericNegativePattern: "-$n",
-		numericDecimalSeparator: ".",
-		numericGroupSeparator: ",",
-		numericGroups: [ 3 ],
-		numericMaxDecimals: 2,
-		numericMinDecimals: 0,
-		currencyPositivePattern: "$n",
-		currencyNegativePattern: "-$n",
-		currencySymbol: "$",
-		currencyDecimalSeparator: ".",
-		currencyGroupSeparator: ",",
-		currencyGroups: [ 3 ],
-		currencyMaxDecimals: 2,
-		currencyMinDecimals: 2,
-		percentPositivePattern: "n$",
-		percentNegativePattern: "-n$",
-		percentSymbol: "%",
-		percentDecimalSeparator: ".",
-		percentGroupSeparator: ",",
-		percentGroups: [ 3 ],
-		percentDisplayFactor: 100,
-		percentMaxDecimals: 2,
-		percentMinDecimals: 2
-	};
-	$.ig.regional = $.ig.regional || {};
-	$.ig.regional.defaults = $.ig._regional;
-	$.ig.setRegionalDefault = function (regional) {
-		if ($.ui && $.ui.igEditor) {
-			$.ui.igEditor.setDefaultCulture(regional);
-		} else {
-			$.ig.regional.defaults = $.extend($.ig._regional,
-				(typeof regional === "string") ? $.ig.regional[ regional ] : regional);
-		}
-		if ($.ig && $.ig.util) {
-			$.ig.util.regional = regional;
-		}
-	};
 
 	// get max zIndex of ui-dialogs - method is usually called by feautures for configuring zIndex of modal dialogs(like filtering, feature chooser, hiding, etc.)
 	$.ig.getMaxZIndex = function (id) {

--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -206,6 +206,51 @@
 	$.ig.util.regional = "en-US";
 	$.ig.util.widgetStack = [];
 
+	$.ig._regional = {
+		monthNames: [ "January", "February", "March", "April", "May", "June",
+			"July", "August", "September", "October", "November", "December" ],
+		monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+		dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday",
+			"Thursday", "Friday", "Saturday" ],
+		dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
+		am: "AM",
+		pm: "PM",
+		datePattern: "M/d/yyyy",
+		dateLongPattern: "dddd, MMMM dd, yyyy",
+		dateTimePattern: "M/d/yyyy h:mm tt",
+		timePattern: "h:mm tt",
+		timeLongPattern: "h:mm:ss tt",
+		dateTitleFullPattern: "dd MM yy",
+		dateTitleMonthPattern: "MM yy",
+		negativeSign: "-",
+		numericNegativePattern: "-$n",
+		numericDecimalSeparator: ".",
+		numericGroupSeparator: ",",
+		numericGroups: [ 3 ],
+		numericMaxDecimals: 2,
+		numericMinDecimals: 0,
+		currencyPositivePattern: "$n",
+		currencyNegativePattern: "-$n",
+		currencySymbol: "$",
+		currencyDecimalSeparator: ".",
+		currencyGroupSeparator: ",",
+		currencyGroups: [ 3 ],
+		currencyMaxDecimals: 2,
+		currencyMinDecimals: 2,
+		percentPositivePattern: "n$",
+		percentNegativePattern: "-n$",
+		percentSymbol: "%",
+		percentDecimalSeparator: ".",
+		percentGroupSeparator: ",",
+		percentGroups: [ 3 ],
+		percentDisplayFactor: 100,
+		percentMaxDecimals: 2,
+		percentMinDecimals: 2
+	};
+	$.ig.regional = $.ig.regional || {};
+	$.ig.regional.defaults = $.ig._regional;
+
 	$.ig.util.changeGlobalLanguage = function (language) {
 		$.ig.util.language = language;
 		for (var i = 0; i < $.ig.util.widgetStack.length; i++) {
@@ -215,6 +260,8 @@
 
 	$.ig.util.changeGlobalRegional = function (regional) {
 		$.ig.util.regional = regional;
+		$.ig.regional.defaults = $.extend($.ig._regional,
+			(typeof regional === "string") ? $.ig.regional[ regional ] : regional);
 		for (var i = 0; i < $.ig.util.widgetStack.length; i++) {
 			$.ig.util.widgetStack[ i ].changeGlobalRegional();
 		}

--- a/tests/unit/util/formatter/tests.html
+++ b/tests/unit/util/formatter/tests.html
@@ -23,7 +23,7 @@
 		function runFormatterTests() {
 			test("testnumbertype", function() {
 				// change the regional default
-				$.ig.setRegionalDefault("en-US");
+				$.ig.util.changeGlobalRegional("en-US");
 				var stringValue = $.ig.formatter(55, "number");
 				equal("55", stringValue);
 				stringValue = $.ig.formatter(55, "number", "number");
@@ -61,7 +61,7 @@
 				equal("55.79%", stringValue);
 
 				// change the regional default
-				$.ig.setRegionalDefault("bg");
+				$.ig.util.changeGlobalRegional("bg");
 
 				stringValue = $.ig.formatter(55, "number", "currency");
 				equal("55,00 лв", stringValue);
@@ -86,7 +86,7 @@
 				// HH - hour 2 digits 24 hour format
 				// tt - AM/PM
 				// change the regional default
-				$.ig.setRegionalDefault("en-US");
+				$.ig.util.changeGlobalRegional("en-US");
 				var stringValue = $.ig.formatter(new Date(2013, 0, 1), "date");
 				equal("1/1/2013", stringValue);
 				stringValue = $.ig.formatter(new Date(2013, 0, 1), "date", "date");
@@ -142,7 +142,7 @@
 				equal("Tue", stringValue);
 
 				// change the regional default
-				$.ig.setRegionalDefault("bg");
+				$.ig.util.changeGlobalRegional("bg");
 				stringValue = $.ig.formatter(new Date(2013, 0, 1), "date");
 				equal("01.01.2013 г.", stringValue);
 				stringValue = $.ig.formatter(new Date(2013, 0, 1), "date", "date");
@@ -163,7 +163,7 @@
 				stringValue = $.ig.formatter(new Date(2013, 0, 1), "date", "ddd, d MMM, yyyy");
 				equal("Вто, 1 Яну, 2013", stringValue);
 
-				$.ig.setRegionalDefault("es");
+				$.ig.util.changeGlobalRegional("es");
 				stringValue = $.ig.formatter(new Date(2013, 0, 1), "date", "dddd, dd \\de MMMM \\de yyyy");
 				equal("Martes, 01 de Enero de 2013", stringValue);
 
@@ -192,7 +192,7 @@
 		function runEscapeTests() {
 			test("testescape", function() {
 				// change the regional default
-				$.ig.setRegionalDefault("en-US");
+				$.ig.util.changeGlobalRegional("en-US");
 				var stringValue = $.ig.encode("<script>alert()<\/script>");
 
 				equal("&lt;script&gt;alert()&lt;/script&gt;", stringValue);


### PR DESCRIPTION
Closes #1151

### Additional information related to this pull request:

Remove $.ig.setRegionalDefault method, but keep the functionality that sets regional.defaults to the last included regional file.
