### PR TITLE
#1109 Date Picker displayTimeOffset and calendar interaction

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -9484,9 +9484,8 @@
 				}
 			} else {
 
-				// extractedDate = this._dateObjectValue;
 				// N.A. 11/10/2015 Bug #207560: Set new date using timestamp.
-				// N.A. September 4th, 2017 #1109: When date picker displayTimeOffset is defined and calendar interaction happens, then date needs offset.
+				// N.A. September 4th, 2017 #1109: When displayTimeOffset is defined and mask of that editor doesn't contain hours, then date needs offset.
 				if (this.options.displayTimeOffset !== null) {
 					extractedDate = this._getDateOffset(this._dateObjectValue);
 				} else {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -9486,7 +9486,12 @@
 
 				// extractedDate = this._dateObjectValue;
 				// N.A. 11/10/2015 Bug #207560: Set new date using timestamp.
-				extractedDate = new Date(this._dateObjectValue.getTime());
+				// N.A. September 4th, 2017 #1109: When date picker displayTimeOffset is defined and calendar interaction happens, then date needs offset.
+				if (this.options.displayTimeOffset !== null) {
+					extractedDate = this._getDateOffset(this._dateObjectValue);
+				} else {
+					extractedDate = new Date(this._dateObjectValue.getTime());
+				}
 			}
 			if (yearField !== null && yearField !== undefined) {
 				this._setDateField("FullYear", extractedDate, yearField);

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -1129,7 +1129,7 @@
 				$editor.trigger("blur").remove();
 			});
 			var testId = 'displayTimeOffset enabled and setting date from drop down calendar';
-			test(testId, 3, function () {
+			test(testId, 6, function () {
 				var $editor, $ddButton, $input;
 
 				$editor = $('<input/>').appendTo("#testBedContainer").igDatePicker({
@@ -1151,7 +1151,29 @@
 				$ddButton.click();
 				$(".ui-datepicker-current-day").next().click();
 				$input.blur();
-				equal($editor.igDatePicker("displayValue"), "12/8/2017 12:00 AM", "Display value is not correct");
+				equal($editor.igDatePicker("displayValue"), "12/9/2017 12:00 AM", "Display value is not correct");
+				$editor.remove();
+
+				$editor = $('<input/>').appendTo("#testBedContainer").igDatePicker({
+					value: new Date("2017-12-08T00:00:00.000Z"),
+					dataMode: "date",
+					dateDisplayFormat: "dateTime",
+					enableUTCDates: true,
+					displayTimeOffset: 240,
+					dropDownAnimationDuration: 1
+				});
+				$ddButton = $editor.igDatePicker("dropDownButton");
+				$input = $editor.igDatePicker("field");
+
+				equal($editor.igDatePicker("displayValue"), "12/8/2017 4:00 AM", "Display value is not correct");
+				$ddButton.click();
+				$ddButton.click();
+				$input.blur();
+				equal($editor.igDatePicker("displayValue"), "12/8/2017 4:00 AM", "Display value is not correct");
+				$ddButton.click();
+				$(".ui-datepicker-current-day").next().click();
+				$input.blur();
+				equal($editor.igDatePicker("displayValue"), "12/9/2017 4:00 AM", "Display value is not correct");
 				$editor.remove();
 			});
 	    });

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -1128,6 +1128,32 @@
 				equal($editor.igDatePicker("field").val(), "08/18/2017 06:06 PM", "Format should be in English");
 				$editor.trigger("blur").remove();
 			});
+			var testId = 'displayTimeOffset enabled and setting date from drop down calendar';
+			test(testId, 3, function () {
+				var $editor, $ddButton, $input;
+
+				$editor = $('<input/>').appendTo("#testBedContainer").igDatePicker({
+					value: new Date("2017-12-08T00:00:00.000Z"),
+					dataMode: "date",
+					dateDisplayFormat: "dateTime",
+					enableUTCDates: true,
+					displayTimeOffset: 0,
+					dropDownAnimationDuration: 1
+				});
+				$ddButton = $editor.igDatePicker("dropDownButton");
+				$input = $editor.igDatePicker("field");
+
+				equal($editor.igDatePicker("displayValue"), "12/8/2017 12:00 AM", "Display value is not correct");
+				$ddButton.click();
+				$ddButton.click();
+				$input.blur();
+				equal($editor.igDatePicker("displayValue"), "12/8/2017 12:00 AM", "Display value is not correct");
+				$ddButton.click();
+				$(".ui-datepicker-current-day").next().click();
+				$input.blur();
+				equal($editor.igDatePicker("displayValue"), "12/8/2017 12:00 AM", "Display value is not correct");
+				$editor.remove();
+			});
 	    });
 		function mouseInteraction(type, element) {
 		    // create a mouse click event

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -472,7 +472,6 @@
 				editor.blur();
 
 				var expectedDate = new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 0, 12, today.getSeconds()));
-				debugger;
 				equal(editor.igDatePicker("value").getDate(), expectedDate.getDate(), "The date is not set");
 				equal(editor.igDatePicker("value").getHours(), expectedDate.getHours(), "The hours is not set");
 				equal(editor.igDatePicker("value").getMinutes(), expectedDate.getMinutes(), "The minutes is not set");


### PR DESCRIPTION
Closes #1109 

Initial commit is with failing tests.

When displayTimeOffset is defined and mask of that editor doesn't contain hours, then date needs offset.