### PR TITLE
Update igLoader for modularization of barcode/olap/radialmenu/sparkline

### DIFF
--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -131,6 +131,9 @@ $.ig.loaderClass.locale.descriptions = {
 	overviewPlusDetailPaneDescription: "Component that display an OverviewPlusDetailPane over the igDataChart plot area.",
 	zoombarDescription: "The igZoombar control provides zooming functionality to range-based controls.",
 	mapDescription: "The igMap visualize various kinds of maps based on the HTML5 canvas element and performs all rendering on the client-side.",
+	visualDataDescription: "Enables visual data exporting for automated testing.",
+	chartVisualDataDescription: "Enables visual data exporting for automated testing for the charts.",
+	chartInteractivityDescription: "Provides support for user interaction such as panning, zooming, dragging, etc.",
 	schedulerDescription: "Component that provides scheduling solution for presenting and managing time periods and associated activities."
 };
 
@@ -181,8 +184,16 @@ $.ig.dependencies = [
 		description: $.ig.loaderClass.locale.descriptions.dataSourceDescription
 	},
 	{
+        widget: "_igOlap",
+        dependency: [ { name: "igUtil" } ],
+        scripts: [ "$path$/modules/infragistics.olap.js" ],
+        group: $.ig.loaderClass.locale.frameworkGroup,
+        internal: true,
+        css: []
+	},
+	{
 		widget: "igOlapXmlaDataSource",
-		dependency: [ { name: "igUtil" } ],
+		dependency: [ { name: "_igOlap" } ],
 		scripts: [ "$path$/modules/infragistics.olapxmladatasource.js" ],
 		group: $.ig.loaderClass.locale.frameworkGroup,
 		css: [  ],
@@ -190,7 +201,7 @@ $.ig.dependencies = [
 	},
 	{
 		widget: "igOlapFlatDataSource",
-		dependency: [ { name: "igUtil" } ],
+		dependency: [ { name: "_igOlap" } ],
 		scripts: [ "$path$/modules/infragistics.olapflatdatasource.js" ],
 		group: $.ig.loaderClass.locale.frameworkGroup,
 		css: [  ],
@@ -368,6 +379,41 @@ $.ig.dependencies = [
 		internal: true,
 		scripts: [ "$path$/modules/infragistics.dv_dataseriesadapter.js" ]
 	},
+	{
+		widget: "_ig_dv_interactivity",
+		group: $.ig.loaderClass.locale.dvGroup,
+		dependency: [ { name: "_ig_dv_core" }],
+		internal: true,
+		scripts: [ "$path$/modules/infragistics.dv_interactivity.js" ]
+	},
+	{
+	    widget: "_ig_datachart_interactivity",
+	    group: $.ig.loaderClass.locale.dvGroup,
+	    dependency: [ { name: "_ig_dv_interactivity" } ],
+	    internal: true,
+	    scripts: [ "$path$/modules/infragistics.datachart_interactivity.js" ]
+	},
+	{
+		widget: "_ig_dv_visualdata",
+		group: $.ig.loaderClass.locale.dvGroup,
+		dependency: [ { name: "_ig_dv_visualdata" }],
+		internal: true,
+		scripts: [ "$path$/modules/infragistics.dv_visualdata.js" ]
+	},
+	{
+		widget: "_ig_datachart_visualdata",
+		group: $.ig.loaderClass.locale.dvGroup,
+		dependency: [ { name: "_ig_dv_visualdata" }],
+		internal: true,
+		scripts: [ "$path$/modules/infragistics.datachart_visualdata.js" ]
+	},
+	{
+		widget: "VisualData",
+		group: $.ig.loaderClass.locale.miscGroup,
+		dependency: [ { name: "_ig_dv_visualdata" }],
+		internal: true,
+		description: $.ig.loaderClass.locale.descriptions.visualDataDescription
+	},
 
 	{
 		widget: "igChartLegend",
@@ -485,6 +531,20 @@ $.ig.dependencies = [
 		description: $.ig.loaderClass.locale.descriptions.annotationDescription
 	},
 	{
+	    widget: "Interactivity",
+	    parentWidget: "igDataChart",
+		dependency: [ { name: "_ig_datachart_interactivity" } ],
+		group: $.ig.loaderClass.locale.dvGroup,
+	    description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
+    },
+	{
+	    widget: "VisualData",
+	    parentWidget: "igDataChart",
+		dependency: [ { name: "_ig_datachart_visualdata" } ],
+		group: $.ig.loaderClass.locale.dvGroup,
+	    description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
+    },
+	{
 		widget: "igDataChart.*",
 		dependency: [ { name: "Category" },
 					{ name: "RangeCategory" },
@@ -495,12 +555,14 @@ $.ig.dependencies = [
 					{ name: "Radial" },
 					{ name: "Scatter" },
 					{ name: "Stacked" },
-					{ name: "Annotation" } ]
+					{ name: "Annotation" },
+					{ name: "Interactivity", parentWidget: "igDataChart" },
+					{ name: "VisualData", parentWidget: "igDataChart" }]
 	},
 
 	{
 		widget: "igPieChart",
-		dependency: [ { name: "igDataChart" } ],
+		dependency: [ { name: "igDataChart" }, { name: "_ig_dv_interactivity" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
 			"$path$/modules/infragistics.piechart.js"
@@ -524,7 +586,8 @@ $.ig.dependencies = [
 	{
 		widget: "igFunnelChart",
 		dependency: [ { name: "_ig_dv_geometry" }, { name: "_ig_dv_commonwidget" },
-					{ name: "igTemplating" }, { name: "igDataSource" } ],
+					{ name: "igTemplating" }, { name: "igDataSource" },
+					{ name: "_ig_dv_interactivity" } ],
 		scripts: [
 			"$path$/modules/infragistics.funnelchart.js",
 			"$path$/modules/infragistics.ui.basechart.js",
@@ -535,13 +598,6 @@ $.ig.dependencies = [
 		description: $.ig.loaderClass.locale.descriptions.funnelChartDescription
 	},
 
-	{
-		widget: "_ig_dv_simple_core",
-		priority: true,
-		group: $.ig.loaderClass.locale.dvGroup,
-		internal: true,
-		scripts: [ "$path$/modules/infragistics.dv.simple.core.js" ]
-	},
 	{
 		widget: "_ig_simple_datachart_core",
 		dependency: [ { name: "igUtil" }, { name: "igTemplating" },
@@ -558,10 +614,13 @@ $.ig.dependencies = [
 
 	{
 		widget: "igSparkline",
-		dependency: [ { name: "_ig_dv_geometry" }, { name: "_ig_dv_simple_core" },
-					{ name: "_ig_simple_datachart_core" } ],
+		dependency: [
+			{ name: "_ig_simple_datachart_core" },
+			{ name: "_ig_dv_geometry" },
+			{ name: "_ig_dv_interactivity" }
+		],
 		scripts: [
-			"$path$/modules/infragistics.chart_sparkline.js",
+			"$path$/modules/infragistics.sparkline.js",
 			"$path$/modules/infragistics.ui.sparkline.js"
 			],
 		group: $.ig.loaderClass.locale.dvGroup,
@@ -571,7 +630,11 @@ $.ig.dependencies = [
 
 	{
 		widget: "igRadialGauge",
-		dependency: [ { name: "_ig_dv_geometry" }, { name: "_ig_dv_jquerydom" } ],
+		dependency: [
+			{ name: "_ig_dv_geometry" },
+			{ name: "_ig_dv_jquerydom" },
+			{ name: "_ig_dv_interactivity" }
+		],
 		scripts: [
 			"$path$/modules/infragistics.radialgauge.js",
 			"$path$/modules/infragistics.ui.radialgauge.js"
@@ -583,7 +646,11 @@ $.ig.dependencies = [
 
 	{
 		widget: "igLinearGauge",
-		dependency: [ { name: "_ig_dv_geometry" }, { name: "_ig_dv_jquerydom" } ],
+		dependency: [
+			{ name: "_ig_dv_geometry" },
+			{ name: "_ig_dv_jquerydom" },
+			{ name: "_ig_dv_interactivity" }
+		],
 		scripts: [
 			"$path$/modules/infragistics.lineargauge.js",
 			"$path$/modules/infragistics.ui.lineargauge.js"
@@ -594,7 +661,11 @@ $.ig.dependencies = [
 
 	{
 		widget: "igBulletGraph",
-		dependency: [ { name: "_ig_dv_geometry" } ],
+		dependency: [
+			{ name: "_ig_dv_geometry" },
+			{ name: "_ig_dv_jquerydom" },
+			{ name: "_ig_dv_interactivity" }
+		],
 		scripts: [
 			"$path$/modules/infragistics.ui.bulletgraph.js",
 			"$path$/modules/infragistics.bulletgraph.js"
@@ -620,17 +691,38 @@ $.ig.dependencies = [
 			],
 		description: $.ig.loaderClass.locale.descriptions.categoryChartDescription
 	},
+	{
+	    widget: "Interactivity",
+	    parentWidget: "igCategoryChart",
+		dependency: [ { name: "_ig_datachart_interactivity" } ],
+		group: $.ig.loaderClass.locale.dvGroup,
+	    description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
+    },
+	{
+	    widget: "VisualData",
+	    parentWidget: "igCategoryChart",
+		dependency: [ { name: "_ig_datachart_visualdata" } ],
+		group: $.ig.loaderClass.locale.dvGroup,
+	    description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
+    },
+	{
+	    widget: "igCategoryChart.*",
+		dependency: [ { name: "Interactivity", parentWidget: "igCategoryChart" },
+					{ name: "VisualData", parentWidget: "igCategoryChart" }
+		]
+	},
 /* /// End Data Visualization /// */
 
 	{
 		widget: "igRadialMenu",
 		dependency: [
-			{ name: "igUtil" },
+			{ name: "_ig_ext_collections_extended" },
 			{ name: "_ig_dv_core" },
+			{ name: "_ig_dv_interactivity" },
 			{ name: "_ig_dv_jquerydom" }
 			],
 		scripts: [
-			"$path$/modules/infragistics.radialmenu_core.js",
+			"$path$/modules/infragistics.radialmenu.js",
 			"$path$/modules/infragistics.ui.radialmenu.js"
 			],
 		group: $.ig.loaderClass.locale.interactionsGroup,
@@ -639,24 +731,39 @@ $.ig.dependencies = [
 	},
 
 	{
+	    widget: "_encoding_core",
+	    dependency: [
+			{ name: "_ig_ext_text" },
+			{ name: "_ig_ext_collections" }
+	    ],
+	    scripts: [ "$path$/modules/infragistics.encoding.core.js" ],
+	    internal: true
+	},
+	{
+		widget: "_barcode_core",
+		dependency: [
+			{ name: "_encoding_core" },
+			{ name: "_ig_dv_core" },
+			{ name: "_ig_ext_text" },
+			{ name: "_ig_ext_collections_extended" }
+		],
+		scripts: [ "$path$/modules/infragistics.barcode_core.js" ],
+		internal: true,
+		locale: [ "$localePath$/infragistics.ui.barcode-$locale$.js" ]
+	},
+	{
 		widget: "igQRCodeBarcode",
 		dependency: [
 			{ name: "igWidget" },
-			{ name: "_ig_dv_simple_core" },
+			{ name: "_barcode_core" },
 			{ name: "_ig_dv_jquerydom" }
 			],
 		scripts: [
 			"$path$/modules/infragistics.barcode_qrcodebarcode.js",
-			"$path$/modules/infragistics.ui.barcode.js"
+			"$path$/modules/infragistics.ui.qrcodebarcode.js"
 			],
-		locale: [ "$localePath$/infragistics.ui.barcode-$locale$.js" ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		description: $.ig.loaderClass.locale.descriptions.qrCodeBarcodeDescription
-	},
-	{
-		widget: "igQRCodeBarcode.*",
-		dependency: [ { name: "igQRCodeBarcode" } ],
-		scripts: [ "$path$/modules/encoding/infragistics.encoding.js" ]
 	},
 	{
 		widget: "Big5",
@@ -664,7 +771,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_big5.js"
 			]
 	},
@@ -674,7 +780,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_cp437.js"
 			]
 	},
@@ -684,7 +789,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_gb2312.js"
 			]
 	},
@@ -694,7 +798,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso646-us.js"
 			]
 	},
@@ -704,7 +807,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-1.js"
 			]
 	},
@@ -714,7 +816,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-2.js"
 			]
 	},
@@ -724,7 +825,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-3.js"
 			]
 	},
@@ -734,7 +834,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-4.js"
 			]
 	},
@@ -744,7 +843,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-5.js"
 			]
 	},
@@ -754,7 +852,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-6.js"
 			]
 	},
@@ -764,7 +861,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-7.js"
 			]
 	},
@@ -774,7 +870,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-8.js"
 			]
 	},
@@ -784,7 +879,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-9.js"
 			]
 	},
@@ -794,7 +888,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-11.js"
 			]
 	},
@@ -804,7 +897,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-13.js"
 			]
 	},
@@ -814,7 +906,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_iso-8859-15.js"
 			]
 	},
@@ -824,7 +915,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_ksc5601.js"
 			]
 	},
@@ -834,7 +924,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_shift_jis.js"
 			]
 	},
@@ -844,7 +933,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_windows-1250.js"
 			]
 	},
@@ -854,7 +942,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_windows-1251.js"
 			]
 	},
@@ -864,7 +951,6 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_windows-1252.js"
 			]
 	},
@@ -874,9 +960,34 @@ $.ig.dependencies = [
 		dependency: [ { name: "igQRCodeBarcode" } ],
 		group: $.ig.loaderClass.locale.dvGroup,
 		scripts: [
-			"$path$/modules/encoding/infragistics.encoding.core.js",
 			"$path$/modules/encoding/infragistics.encoding_windows-1256.js"
 			]
+	},
+	{
+		widget: "igQRCodeBarcode.*",
+		dependency: [ { name: "Big5" },
+					{ name: "CP437" },
+					{ name: "GB2312" },
+					{ name: "ISO646-US" },
+					{ name: "ISO-8859-1" },
+					{ name: "ISO-8859-2" },
+					{ name: "ISO-8859-3" },
+					{ name: "ISO-8859-4" },
+					{ name: "ISO-8859-5" },
+					{ name: "ISO-8859-6" },
+					{ name: "ISO-8859-7" },
+					{ name: "ISO-8859-8" },
+					{ name: "ISO-8859-9" },
+					{ name: "ISO-8859-11" },
+					{ name: "ISO-8859-13" },
+					{ name: "ISO-8859-15" },
+					{ name: "KSC5601" },
+					{ name: "Shift_JIS" },
+					{ name: "Windows-1250" },
+					{ name: "Windows-1251" },
+					{ name: "Windows-1252" },
+					{ name: "Windows-1256" }
+		]
 	},
 
 	{
@@ -1238,6 +1349,26 @@ $.ig.dependencies = [
 			"$path$/structure/modules/infragistics.ui.map.css"
 			],
 		description: $.ig.loaderClass.locale.descriptions.mapDescription
+	},
+	{
+	    widget: "Interactivity",
+	    parentWidget: "igMap",
+		dependency: [ { name: "_ig_datachart_interactivity" } ],
+		group: $.ig.loaderClass.locale.dvGroup,
+	    description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
+    },
+	{
+	    widget: "VisualData",
+	    parentWidget: "igMap",
+		dependency: [ { name: "_ig_datachart_visualdata" } ],
+		group: $.ig.loaderClass.locale.dvGroup,
+	    description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
+    },
+	{
+	    widget: "igMap.*",
+		dependency: [ { name: "Interactivity", parentWidget: "igMap" },
+					{ name: "VisualData", parentWidget: "igMap" }
+		]
 	},
 /*/ end igMap /// */
 
@@ -1805,6 +1936,7 @@ $.ig.dependencies = [
             { name: "igScroll" },
             { name: "_ig_dv_core" },
             { name: "_ig_dv_jquerydom" },
+			{ name: "_ig_dv_interactivity" },
             { name: "igDataSource" },
             { name: "igShared" },
             { name: "igCombo" },

--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -387,11 +387,11 @@ $.ig.dependencies = [
 		scripts: [ "$path$/modules/infragistics.dv_interactivity.js" ]
 	},
 	{
-	    widget: "_ig_datachart_interactivity",
-	    group: $.ig.loaderClass.locale.dvGroup,
-	    dependency: [ { name: "_ig_dv_interactivity" } ],
-	    internal: true,
-	    scripts: [ "$path$/modules/infragistics.datachart_interactivity.js" ]
+        widget: "_ig_datachart_interactivity",
+        group: $.ig.loaderClass.locale.dvGroup,
+        dependency: [ { name: "_ig_dv_interactivity" } ],
+        internal: true,
+        scripts: [ "$path$/modules/infragistics.datachart_interactivity.js" ]
 	},
 	{
 		widget: "_ig_dv_visualdata",
@@ -531,18 +531,18 @@ $.ig.dependencies = [
 		description: $.ig.loaderClass.locale.descriptions.annotationDescription
 	},
 	{
-	    widget: "Interactivity",
-	    parentWidget: "igDataChart",
-		dependency: [ { name: "_ig_datachart_interactivity" } ],
-		group: $.ig.loaderClass.locale.dvGroup,
-	    description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
+        widget: "Interactivity",
+        parentWidget: "igDataChart",
+        dependency: [ { name: "_ig_datachart_interactivity" } ],
+        group: $.ig.loaderClass.locale.dvGroup,
+        description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
     },
 	{
-	    widget: "VisualData",
-	    parentWidget: "igDataChart",
-		dependency: [ { name: "_ig_datachart_visualdata" } ],
-		group: $.ig.loaderClass.locale.dvGroup,
-	    description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
+        widget: "VisualData",
+        parentWidget: "igDataChart",
+        dependency: [ { name: "_ig_datachart_visualdata" } ],
+        group: $.ig.loaderClass.locale.dvGroup,
+        description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
     },
 	{
 		widget: "igDataChart.*",
@@ -692,21 +692,21 @@ $.ig.dependencies = [
 		description: $.ig.loaderClass.locale.descriptions.categoryChartDescription
 	},
 	{
-	    widget: "Interactivity",
-	    parentWidget: "igCategoryChart",
-		dependency: [ { name: "_ig_datachart_interactivity" } ],
-		group: $.ig.loaderClass.locale.dvGroup,
-	    description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
+        widget: "Interactivity",
+        parentWidget: "igCategoryChart",
+        dependency: [ { name: "_ig_datachart_interactivity" } ],
+        group: $.ig.loaderClass.locale.dvGroup,
+        description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
     },
 	{
-	    widget: "VisualData",
-	    parentWidget: "igCategoryChart",
-		dependency: [ { name: "_ig_datachart_visualdata" } ],
-		group: $.ig.loaderClass.locale.dvGroup,
-	    description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
+        widget: "VisualData",
+        parentWidget: "igCategoryChart",
+        dependency: [ { name: "_ig_datachart_visualdata" } ],
+        group: $.ig.loaderClass.locale.dvGroup,
+        description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
     },
 	{
-	    widget: "igCategoryChart.*",
+        widget: "igCategoryChart.*",
 		dependency: [ { name: "Interactivity", parentWidget: "igCategoryChart" },
 					{ name: "VisualData", parentWidget: "igCategoryChart" }
 		]
@@ -731,13 +731,13 @@ $.ig.dependencies = [
 	},
 
 	{
-	    widget: "_encoding_core",
-	    dependency: [
+        widget: "_encoding_core",
+        dependency: [
 			{ name: "_ig_ext_text" },
 			{ name: "_ig_ext_collections" }
-	    ],
-	    scripts: [ "$path$/modules/infragistics.encoding.core.js" ],
-	    internal: true
+        ],
+        scripts: [ "$path$/modules/infragistics.encoding.core.js" ],
+        internal: true
 	},
 	{
 		widget: "_barcode_core",
@@ -1351,21 +1351,21 @@ $.ig.dependencies = [
 		description: $.ig.loaderClass.locale.descriptions.mapDescription
 	},
 	{
-	    widget: "Interactivity",
-	    parentWidget: "igMap",
-		dependency: [ { name: "_ig_datachart_interactivity" } ],
-		group: $.ig.loaderClass.locale.dvGroup,
-	    description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
+        widget: "Interactivity",
+        parentWidget: "igMap",
+        dependency: [ { name: "_ig_datachart_interactivity" } ],
+        group: $.ig.loaderClass.locale.dvGroup,
+        description: $.ig.loaderClass.locale.descriptions.chartInteractivityDescription
     },
 	{
-	    widget: "VisualData",
-	    parentWidget: "igMap",
-		dependency: [ { name: "_ig_datachart_visualdata" } ],
-		group: $.ig.loaderClass.locale.dvGroup,
-	    description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
+        widget: "VisualData",
+        parentWidget: "igMap",
+        dependency: [ { name: "_ig_datachart_visualdata" } ],
+        group: $.ig.loaderClass.locale.dvGroup,
+        description: $.ig.loaderClass.locale.descriptions.chartVisualDataDescription
     },
 	{
-	    widget: "igMap.*",
+        widget: "igMap.*",
 		dependency: [ { name: "Interactivity", parentWidget: "igMap" },
 					{ name: "VisualData", parentWidget: "igMap" }
 		]


### PR DESCRIPTION
Update igLoader to account for modularization of barcode, olap, radialmenu and sparkline. Also includes fix ups for interactivity & visual data modularization done earlier in the cycle that affected other controls.

### Additional information related to this pull request:
