### PR TITLE
Removing the encode method from the igTemplating

### DIFF
--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -9,6 +9,7 @@
  *
  * Depends on:
  *	jquery-1.9.1.js
+ *  infragistics.util.jquery.js
  */
 
  /*
@@ -108,19 +109,6 @@
 		clearTmplCache: function () {
 			delete this._internalTmplCache;
 			this._internalTmplCache = {};
-		},
-		encode: function (value) {
-			/* Encoding < > ' and "
-				paramType="string" The string to be encoded.
-				returnType="string" Returns the encoded string.
-			 */
-		    return value !== null && value !== undefined ?
-            value.toString()
-				.replace(this.regExp.amp, "&amp;")
-				.replace(this.regExp.lt, "&lt;")
-				.replace(this.regExp.gt, "&gt;")
-				.replace(this.regExp.ap, "&#39;")
-				.replace(this.regExp.ic, "&#34;") : "";
 		},
 		/* type="RegExp" Used to tokenize the template string. */
 		regExp: {

--- a/src/js/modules/infragistics.util.jquery.js
+++ b/src/js/modules/infragistics.util.jquery.js
@@ -141,12 +141,12 @@
 			returnType="string" Returns the encoded string.
 		*/
 		return value !== null && value !== undefined ?
-		value.toString()
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/'/g, "&#39;")
-		.replace(/"/g, "&#34;") : "";
+			value.toString()
+			.replace(/&/g, "&amp;")
+			.replace(/</g, "&lt;")
+			.replace(/>/g, "&gt;")
+			.replace(/'/g, "&#39;")
+			.replace(/"/g, "&#34;") : "";
 	};
 
 	$.ig.millisecondsToString = function(milliseconds, flag) {


### PR DESCRIPTION
Closes #1177

### Additional information related to this pull request:

Adding a dependency on `util.jquery` in `templating`.

@mpavlinov Btw, the encode method doesn't use `jQuery`, and I don't know why it's being put in the `jQuery` file. In fact, quite a few of the new methods I saw there are the same way - no dependency on `jQuery`.