### PR TITLE
Use correct scientific precision in case minDecimal option is set. (16.2)

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -5118,9 +5118,11 @@
 						if (scientificPrecision > 0) {
 							stringValue = this._convertScientificToNumeric(stringValue);
 						} else {
+							if (scientificPrecision < this.options.maxDecimals) {
+								scientificPrecision = this.options.maxDecimals;
+							}
 							stringValue = stringValue.toFixed(Math.abs(scientificPrecision));
 						}
-
 					}
 
 					// There are edge cases where the value after convertion still contains scientific format. In that case we just pass that value.

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -5118,8 +5118,8 @@
 						if (scientificPrecision > 0) {
 							stringValue = this._convertScientificToNumeric(stringValue);
 						} else {
-							if (scientificPrecision < this.options.maxDecimals) {
-								scientificPrecision = this.options.maxDecimals;
+							if (scientificPrecision < this.options.minDecimals) {
+								scientificPrecision = this.options.minDecimals;
 							}
 							stringValue = stringValue.toFixed(Math.abs(scientificPrecision));
 						}

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1272,6 +1272,21 @@
 					}, 0);
 				}, 0);
 			});
+			testId = 'Bug 1205 Decimal numbers are rounded when the editor is blurred';
+ 			test(testId, 1, function () {
+ 				var $editor;
+ 	 				// value not matching mask (fails validation)
+ 				$editor = $('<input/>').appendTo("#testBedContainer")
+ 				.igNumericEditor({
+ 					minDecimals: 10,
+ 					maxDecimals: 10
+ 				});
+ 				$editor.trigger("focus").val("0.0000005880").blur();
+ 				equal($editor.val(), "0.0000005880", "(wrong value) Numeric editor display value is not: 0.0000005880.");
+ 				$editor.remove();
+ 			
+ 				$editor.remove();
+ 			});
 		});
 
 			


### PR DESCRIPTION
#1205

Closes #1205

### Additional information related to this pull request:

