### PR TITLE
#1112 Dialog header buttons touch

### DIFF
--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -1596,14 +1596,12 @@
 						self[ "_" + $(this).attr("data-id") ](e);
 					} catch (ex) {}
 					$(this).removeClass(css.headerButtonHover); // This is needed to remove selected class under touch devices
-					delete self._headerButtonClicked;
 					_stopEvt(e);
 				},
-				touchstart: function () { self._headerButtonClicked = true; },
-				touchmove: function (e) { _stopEvt(e); }
 
-				// N.A. September 21th, 2017, #1112: When clicking dialog header buttons, don't cancel event propagation and default action, because some new browsers under touch devices, will not fire the click event.
-				// It seems that if we start drag and drop over header buttons, it should be terminated as an action.
+				// N.A. September 21th, 2017, #1112: Don't propagate to touchstart handler on the header (header is parent of the buttons) which prevents default action (in this case click, which is required).
+				touchstart: function (e) { e.stopPropagation(); },
+				touchmove: function (e) { _stopEvt(e); } // Do not drag dialog when touch starts from header buttons.
 			};
 
 			// i=order of buttons in header:pin,min,max,close
@@ -2016,8 +2014,7 @@
 					one = touches && touches.length === 1;
 
 				// type: null-end
-				// N.A. September 21th, 2017, #1112: Cancel propagation of event when dialog is dragged. This will prevent the browser window from moving along with the dialog.
-				if (one && type && !self._headerButtonClicked) {
+				if (one && type) {
 					_stopEvt(evt);
 				}
 

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -1596,11 +1596,13 @@
 						self[ "_" + $(this).attr("data-id") ](e);
 					} catch (ex) {}
 					$(this).removeClass(css.headerButtonHover); // This is needed to remove selected class under touch devices
+					delete self._headerButtonClicked;
 					_stopEvt(e);
 				},
+				touchstart: function () { self._headerButtonClicked = true; },
 				touchmove: function (e) { _stopEvt(e); }
 
-				// N.A. September 21th, 2017, #1112: Don't cancel event propagation and default action, in touch events, cause now new browsers under touch devices also cancel click event.
+				// N.A. September 21th, 2017, #1112: When clicking dialog header buttons, don't cancel event propagation and default action, because some new browsers under touch devices, will not fire the click event.
 				// It seems that if we start drag and drop over header buttons, it should be terminated as an action.
 			};
 
@@ -2012,6 +2014,12 @@
 				var act, e = evt.originalEvent,
 					touches = e ? e.touches : null,
 					one = touches && touches.length === 1;
+
+				// type: null-end
+				// N.A. September 21th, 2017, #1112: Cancel propagation of event when dialog is dragged. This will prevent the browser window from moving along with the dialog.
+				if (one && type && !self._headerButtonClicked) {
+					_stopEvt(e);
+				}
 
 				// !one: scrolling should be ended
 				one = one && type === "move";

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -1595,6 +1595,7 @@
 					try {
 						self[ "_" + $(this).attr("data-id") ](e);
 					} catch (ex) {}
+					$(this).removeClass(css.headerButtonHover); // This is needed to remove selected class under touch devices
 					_stopEvt(e);
 				},
 				touchmove: function (e) { _stopEvt(e); }

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -1597,9 +1597,10 @@
 					} catch (ex) {}
 					_stopEvt(e);
 				},
-				touchstart: function (e) { this._drag = null; _stopEvt(e); },
-				touchmove: function (e) { this._drag = 1; _stopEvt(e); },
-				touchend: function () { if (!this._drag) { $(this).trigger("click"); } }
+				touchmove: function (e) { _stopEvt(e); }
+
+				// N.A. September 21th, 2017, #1112: Don't cancel event propagation and default action, in touch events, cause now new browsers under touch devices also cancel click event.
+				// It seems that if we start drag and drop over header buttons, it should be terminated as an action.
 			};
 
 			// i=order of buttons in header:pin,min,max,close
@@ -2010,11 +2011,6 @@
 				var act, e = evt.originalEvent,
 					touches = e ? e.touches : null,
 					one = touches && touches.length === 1;
-
-				// type: null-end
-				if (one && type) {
-					_stopEvt(evt);
-				}
 
 				// !one: scrolling should be ended
 				one = one && type === "move";

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -2018,7 +2018,7 @@
 				// type: null-end
 				// N.A. September 21th, 2017, #1112: Cancel propagation of event when dialog is dragged. This will prevent the browser window from moving along with the dialog.
 				if (one && type && !self._headerButtonClicked) {
-					_stopEvt(e);
+					_stopEvt(evt);
 				}
 
 				// !one: scrolling should be ended


### PR DESCRIPTION
Closes #1112  

### Additional information related to this pull request:

Don't cancel event propagation and default action, in touch events, cause now some of the new browsers under touch devices also cancel click event. This was not the case before and somehow after touchstart/end event were canceled, then click was fired (it's still the case in some browsers under touch devices).
The logic that was added inside the touch event handlers, was related to the drag and drop functionality of the dialog. You can check in TFS changeset 275437 for more information. The idea was that when we start drag and drop over header buttons, then drag and drop should be terminated. With this fix I achieve the same functionality. Other drag and drop functionality, as well as resizing dialog is still working after that fix, and in the same time now header buttons can be also clicked.

I've tried to find some more information about that problem in those two documents - [Touch event behavior details across browsers](https://docs.google.com/document/d/12k_LL_Ot9GjF8zGWP9eI_3IMbSizD72susba0frg44Y/edit) and [Issues with touch events](https://docs.google.com/document/d/12-HPlSIF7-ISY8TQHtuQ3IqDi-isZVI0Yzv5zwl90VU/edit). Anyway the core problem was that the dialog was canceling default event propagation and was after clicking the buttons.




