### PR TITLE
Fix specialization handling for self referencing interfaces

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -645,6 +645,10 @@
 			if (specId) {
 			    this.specializationCache[ specId ] = ret;
 			    ret.stringId = ret.generateString();
+			} else {
+			    // the self referencing type needs to be able to put itself into the specialization cache
+			    // of the original type
+			    ret.specializationCache = this.specializationCache;
 			}
 
 			var _self = this;

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -173,6 +173,19 @@
 			equal($.ig.Date.prototype.toStringFormat(dt, "yyyy"), "1980", "Date.toStringFormat formats yyyy correctly");
 		});
 
+		test("Test IsAssignableFrom", function () {
+		    // type itself
+		    ok($.ig.Enum.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum type");
+
+		    // base type
+		    ok($.ig.IEnumerable.prototype.$type.isAssignableFrom($.ig.IList.prototype.$type), "Base type of IList is IEnumerable");
+
+		    // interfaces
+		    ok($.ig.IConvertible.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum implements IConvertible");
+		    ok($.ig.IComparable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IComparable<Int32>");
+		    ok($.ig.IEquatable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IEquatable<Int32>");
+		});
+
 		test("Test $.ig.encode", function () {
 			equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
 			equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");


### PR DESCRIPTION
This fixes a bug I found in the specialization handling for self referencing interfaces. (e.g. Int32 implementing IEquatable).