### PR TITLE
Fix for bug #242699.

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -35,8 +35,8 @@
 (function () {
 	window.igRoot = window.igRoot || {};
 	/* jshint ignore:start */
-	if (window.$ !== undefined || typeof $ === "function") {
-		window.igRoot = window.$ || $;
+	if (window.jQuery !== undefined || typeof jQuery === "function") {
+		window.igRoot = window.jQuery || jQuery;
 	}
 	/* jshint ignore:end */
 


### PR DESCRIPTION
Changing window.$ or global $ to jQuey for noConflict support.

The bug cannot be automated as part of the loader tests as it needs a clean window state.

