### PR TITLE
Add lowercase fallback to base widget

### DIFF
--- a/src/js/modules/infragistics.ui.widget.js
+++ b/src/js/modules/infragistics.ui.widget.js
@@ -140,7 +140,9 @@
 			var language = this.options.language,
 				widgetName = this.localeWidgetName || this.widgetName.replace("ig", ""),
 				localeObj = ($.ig.locale[ language ] && $.ig.locale[ language ][ widgetName ]) ||
-					($.ig[ widgetName ] && $.ig[ widgetName ].locale);
+					($.ig[ widgetName ] && $.ig[ widgetName ].locale) ||
+					/* excel, spreadsheet locale generated with lower cases for its defaults */
+					($.ig[ widgetName.toLowerCase() ] && $.ig[ widgetName.toLowerCase() ].locale);
 			return localeObj;
 		},
 		_getLocaleValue: function (key) {

--- a/tests/unit/locale/tests.html
+++ b/tests/unit/locale/tests.html
@@ -268,6 +268,30 @@
 				equal(button.attr("title"), locale.spinLowerTitle, "The title attribute should be: " + locale.spinLowerTitle);
 			});
 
+			test("Locale lowercase fallback", 3, function () {
+				/* Mock a widget with lowercased locale */
+				$.ig.locale.bg = $.ig.locale.bg || {};
+				$.ig.locale.bg.Mock = {
+					test: "Тест"
+				};
+				$.ig.mock = $.ig.mock || {};
+				$.ig.mock.locale = $.ig.mock.locale || $.ig.locale.bg.Mock;
+				$.widget('ui.igMock', $.ui.igWidget, {
+					checkLocale: function (key) {
+						return this._getLocaleValue(key);
+					}
+				});
+
+				var $elem = $("<div></div>").igMock({
+					language: "en" //force fallback
+				});
+				equal($elem.igMock("checkLocale", "test"), $.ig.locale.bg.Mock.test, "The locale value should fallback to default");
+				$elem.igMock("option", "language", "bg");
+				equal($elem.igMock("checkLocale", "test"), $.ig.locale.bg.Mock.test, "The locale value should be corrct");
+				$elem.igMock("option", "language", "ja");
+				equal($elem.igMock("checkLocale", "test"), $.ig.locale.bg.Mock.test, "The locale value should fallback to default");
+			});
+
 			test("Changing language globally", 10, function () {
 				var locale = $.ig.locale;
 				$.ig.util.changeGlobalLanguage("de");


### PR DESCRIPTION
Add lowercase fallback to base widget for controls with lower case locale default

### Additional information related to this pull request:
Appies to igSpreadsheet and igExcel (latter change was already applied to the util method in 66e2ff5ba6468895e69ee83c86e9a0387865261a)
