### PR TITLE
Fix for jQueryUI 1.12.1 bug

### DIFF
--- a/src/css/themes/bootstrap3/default/icons-styles.css
+++ b/src/css/themes/bootstrap3/default/icons-styles.css
@@ -346,7 +346,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/bootstrap3/flatly/icons-styles.css
+++ b/src/css/themes/bootstrap3/flatly/icons-styles.css
@@ -346,7 +346,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/bootstrap3/superhero/icons-styles.css
+++ b/src/css/themes/bootstrap3/superhero/icons-styles.css
@@ -346,7 +346,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/bootstrap3/yeti/icons-styles.css
+++ b/src/css/themes/bootstrap3/yeti/icons-styles.css
@@ -346,7 +346,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/bootstrap4/default/icons-styles.css
+++ b/src/css/themes/bootstrap4/default/icons-styles.css
@@ -346,7 +346,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/infragistics/icons-styles.css
+++ b/src/css/themes/infragistics/icons-styles.css
@@ -345,7 +345,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different in different version of jQueryUi, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/infragistics2012/icons-styles.css
+++ b/src/css/themes/infragistics2012/icons-styles.css
@@ -345,7 +345,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/ios/icons-styles.css
+++ b/src/css/themes/ios/icons-styles.css
@@ -345,7 +345,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}

--- a/src/css/themes/metro/icons-styles.css
+++ b/src/css/themes/metro/icons-styles.css
@@ -345,7 +345,11 @@
 .ui-icon-carat-1-n:before{content:'\e636'}
 .ui-icon-caret-u:before{content:'\e636'}
 .ui-icon-carat-1-ne:before{content:'\e637'}
+
+/* This two classes are actually different, do not delete them*/
 .ui-icon-carat-1-e:before{content:'\e638'}
+.ui-icon-caret-1-e:before{content:'\e638'}
+
 .ui-icon-caret-r:before{content:'\e638'}
 .ui-icon-carat-1-se:before{content:'\e639'}
 .ui-icon-carat-1-s:before{content:'\e63a'}


### PR DESCRIPTION
The problem is that the class “ui-icon-caret-1-e” in the new version of jQueryUI it’s different from the one “ui-icon-carat-1-e” in the old version. 
Now I know it seems odd but there is actually a different ASCI symbol in the class from the new version. 
At some point whoever wrote that class from jQueryUI team, probably put some Cyrillic character in that class.


