### PR TITLE
Fixed an issue in trimStart|trimEnd when provided an empty array.

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -3649,9 +3649,12 @@
 	String.prototype.trimStart = function () {
 		var args = [ " " ];
 		if (arguments.length > 0) {
-			args = Array.prototype.slice.call(arguments);
-			if (args.length === 1 && Array.isArray(args[ 0 ])) {
-				args = args[ 0 ];
+			if (arguments.length == 1 && Array.isArray(arguments[ 0 ])) {
+				if (arguments[ 0 ].length > 0) {
+					args = arguments[ 0 ];
+				}
+			} else {
+				args = Array.prototype.slice.call(arguments);
 			}
 		}
 		if (this.length === 0) {
@@ -3665,9 +3668,12 @@
 	String.prototype.trimEnd = function () {
 		var args = [ " " ];
 		if (arguments.length > 0) {
-			args = Array.prototype.slice.call(arguments);
-			if (args.length === 1 && Array.isArray(args[ 0 ])) {
-				args = args[ 0 ];
+			if (arguments.length == 1 && Array.isArray(arguments[ 0 ])) {
+				if (arguments[ 0 ].length > 0) {
+					args = arguments[ 0 ];
+				}
+			} else {
+				args = Array.prototype.slice.call(arguments);
 			}
 		}
 		var i = this.length - 1;

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -192,6 +192,24 @@
 		    equal($.ig.util.stringCompare2("", null, c, o), 1, "empty after null");
 		});
 
+		test("Test trimStart", function () {
+		    equal("  ABC  ".trimStart(), "ABC  ", "No arguments");
+		    equal("  ABC  ".trimStart([]), "ABC  ", "Empty array argument");
+		    equal("  ABC  ".trimStart([' ']), "ABC  ", "Explicit space argument");
+		    equal("aa  ABC  aa".trimStart(['a']), "  ABC  aa", "Nonstandard trim character");
+		    equal("aa  ABC  aa".trimStart('a'), "  ABC  aa", "character only");
+		    equal("aa  ABC  aa".trimStart('a', ' '), "ABC  aa", "Multiple characters only");
+		});
+
+		test("Test trimEnd", function () {
+		    equal("  ABC  ".trimEnd(), "  ABC", "No arguments");
+		    equal("  ABC  ".trimEnd([]), "  ABC", "Empty array argument");
+		    equal("  ABC  ".trimEnd([' ']), "  ABC", "Explicit space argument");
+		    equal("aa  ABC  aa".trimEnd(['a']), "aa  ABC  ", "Nonstandard trim character");
+		    equal("aa  ABC  aa".trimEnd('a'), "aa  ABC  ", "character only");
+		    equal("aa  ABC  aa".trimEnd('a', ' '), "aa  ABC", "Multiple characters only");
+		});
+
 		test("Test $.ig.encode", function () {
 			equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
 			equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");


### PR DESCRIPTION
When trimStart and trimEnd are provided an empty array it should be treated as if no custom characters to trim were provided.