### PR TITLE
The Visual Data option should be visible in the loader/download page.

### DIFF
--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -434,7 +434,6 @@ $.ig.dependencies = [
 		widget: "VisualData",
 		group: $.ig.loaderClass.locale.miscGroup,
 		dependency: [ { name: "_ig_dv_visualdata" }],
-		internal: true,
 		description: $.ig.loaderClass.locale.descriptions.visualDataDescription
 	},
 


### PR DESCRIPTION
The misc VisualData feature was marked as internal but it should be shown in case someone needs that for components like igRadialMenu and any other non-chart component exporting visual data.