### PR TITLE
Fix for bug 245082. Merge 17.2.

### DIFF
--- a/src/js/modules/infragistics.ui.combo.js
+++ b/src/js/modules/infragistics.ui.combo.js
@@ -48,6 +48,7 @@
 		Editing of field supports auto-complete, editing multiple items, synchronization with selection in drop-down list, clear button, etc.
 	*/
 	$.widget("ui.igCombo", $.ui.igWidget, {
+		widgetEventPrefix: "igCombo",
 		options: {
 			/* type="number|string" Gets/Sets the width of combo. The numeric and string values (valid html units for size) are supported. It includes %, px, em and other units.
 			```

--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -123,6 +123,7 @@
 		elements located inside and outside of dialog.
 	*/
 	$.widget("ui.igDialog", $.ui.igWidget, {
+		widgetEventPrefix: "igDialog",
 		options: {
 			/* type="dom" Gets the jquery DIV object which is used as the main container for the dialog.
 				Notes:

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -33,6 +33,7 @@
 (function ($) {
 	/* The igBaseEditor is a widget based on jQuery UI. */
 	$.widget("ui.igBaseEditor", $.ui.igWidget, {
+		widgetEventPrefix: "igBaseEditor",
 		localeWidgetName: "Editor",
 		options: {
 			/* type="string|number|null" Gets/Sets the width of the control.

--- a/src/js/modules/infragistics.ui.htmleditor.js
+++ b/src/js/modules/infragistics.ui.htmleditor.js
@@ -52,6 +52,7 @@
         The igHtmlEditor is a jQuery based widget which allow you to convert a simple html element into a rich text area.
     */
     $.widget("ui.igHtmlEditor", $.ui.igWidget, {
+		widgetEventPrefix: "igHtmlEditor",
         options: {
             /* type="boolean" Shows/hides the "Formatting" toolbar.
             ```
@@ -2638,6 +2639,7 @@
        igHtmlEditorPopover
    ************************************/
     $.widget("ui.igHtmlEditorPopover", $.ui.igWidget, {
+		widgetEventPrefix: "igHtmlEditorPopover",
         localeWidgetName: "HtmlEditor",
         options: {
             item: null,

--- a/src/js/modules/infragistics.ui.popover.js
+++ b/src/js/modules/infragistics.ui.popover.js
@@ -30,6 +30,7 @@
 }
 (function ($) {
 	$.widget("ui.igPopover", $.ui.igWidget, {
+		widgetEventPrefix: "igPopover",
 		css: {
 			/* classes applied to the main popover container */
 			baseClasses: "ui-widget ui-igpopover",

--- a/src/js/modules/infragistics.ui.rating.js
+++ b/src/js/modules/infragistics.ui.rating.js
@@ -44,6 +44,7 @@
 		igRating is a widget based on jQuery UI that provides functionality to edit numeric value by mouse, which appears as a row or a column of vote/star images.
 	*/
 	$.widget("ui.igRating", $.ui.igWidget, {
+		widgetEventPrefix: "igRating",
 		options: {
 			/* type="bool" Gets a vertical or horizontal orientation for the votes.
 				Change of that option is not supported after igRating was created.

--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -38,6 +38,7 @@
 									"releasePointerCapture";
 
 	$.widget("ui.igScroll", $.ui.igWidget, {
+		widgetEventPrefix: "igScroll",
 		options: {
 			/* type="bool" Sets or gets if the scrollbars should be always visible (on all environments). Otherwise it will be the default behavior. Note: this option is only for the custom scrollbars set through the scrollbarType option.
 			```

--- a/src/js/modules/infragistics.ui.splitter.js
+++ b/src/js/modules/infragistics.ui.splitter.js
@@ -33,6 +33,7 @@
             igSplitter is a widget based on jQuery UI that manages layout into two panels with split bar and providers the end user with a rich interaction functionality including the ability to expand/collapse panel, and resize panels via split bar.
         */
         $.widget("ui.igSplitter", $.ui.igWidget, {
+            widgetEventPrefix: "igSplitter",
             _const: {
                 orientations: {
                     horizontal: {

--- a/src/js/modules/infragistics.ui.tilemanager.js
+++ b/src/js/modules/infragistics.ui.tilemanager.js
@@ -43,6 +43,7 @@
 		grid layout.
 	*/
     $.widget("ui.igTileManager", $.ui.igWidget, {
+        widgetEventPrefix: "igTileManager",
         css: {
             /* classes applied to the top container element */
             container: "ui-widget ui-igtilemanager ui-widget-content",

--- a/src/js/modules/infragistics.ui.toolbar.js
+++ b/src/js/modules/infragistics.ui.toolbar.js
@@ -154,6 +154,7 @@
         split buttons, color picker split buttons, and combos.
 	*/
     $.widget("ui.igToolbar", $.ui.igWidget, {
+        widgetEventPrefix: "igToolbar",
         options: {
             /* type="numeric" Set/Get the widget height.
             ```

--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -47,6 +47,7 @@
 		providers, etc.
 	*/
 	$.widget("ui.igTree", $.ui.igWidget, {
+        widgetEventPrefix: "igTree",
 		_const: {
 			dragCursorAt: {
 				top: -10,

--- a/src/js/modules/infragistics.ui.upload.js
+++ b/src/js/modules/infragistics.ui.upload.js
@@ -339,6 +339,7 @@
 	$.extend($.ui.igBrowseButton, { version: "<build_number>" });
 
 	$.widget("ui.igUpload", $.ui.igWidget, {
+        widgetEventPrefix: "igUpload",
 		_const: {
 			fileNameLimit: 100,
 			AjaxQueueName: "uploadrequestsqueue",

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -32,6 +32,7 @@
 (function ($) {
 
 	$.widget("ui.igVideoPlayer", $.ui.igWidget, {
+        widgetEventPrefix: "igVideoPlayer",
 		_const: {
 			VOLUME_MAX: 1.0,
 			VOLUME_MIN: 0.0,

--- a/src/js/modules/infragistics.ui.zoombar.js
+++ b/src/js/modules/infragistics.ui.zoombar.js
@@ -35,6 +35,7 @@
 		igZoombar is a widget based on jQuery UI that provides ability to easily zoom in and out a chart or other compatible control.
 	*/
 	$.widget("ui.igZoombar", $.ui.igWidget, {
+        widgetEventPrefix: "igZoombar",
 		options: {
 			/* type="object" Specifies a provider class which interfaces the widget that is being zoomed.
 				object Provider class to use. The provider should implement all methods in the $.ig.ZoombarProviderDefault class and is suggested to be extended from it.


### PR DESCRIPTION
All widgets require to have 'widgetEventPrefix' set when inheriting another widget e.g. igWidget. Otherwise for example if we reload the IgniteUI source files and reinitialize the controls without reloading jquery-ui the 'widgetEventPrefix' for all controls is the parent one. 

For example if we have igGrid, after reloading only IgniteUI the 'widgetEventPrefix' becomes "igWidget" in the prototype. When this happens the event names from "iggridrendered" become "igwidgetrendered".