### PR TITLE
test: fix spin boundary test case expectation data

### DIFF
--- a/tests/unit/editors/dateEditor/tests.html
+++ b/tests/unit/editors/dateEditor/tests.html
@@ -3857,7 +3857,7 @@
 						dateInputFormat: "yy"
 					},
 					expRes: [{
-						display: (new Date(new Date().setMonth(new Date().getMonth() + 1)).getFullYear()).toString().replace("20", "")
+						display: new Date().getFullYear().toString().replace("20", "")
 					}, {
 						display: (new Date().getFullYear() - 1).toString().replace("20", "")
 					}]


### PR DESCRIPTION
### Additional information related to this pull request:
Fixed a test expectation that was reducing the year by 1 month expecting it to match default value (`new Date()` since none is set).