### PR TITLE
#1362 Escape unicode characters in maskEditor validate

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -7344,8 +7344,10 @@
 			var maskSymbol, mask, isValid,
 				regex,
 				inputChar = ch,
-				letterOrDigitRegEx = "[\\d\u00C0-\u1FFF\u2C00-\uD7FFa-zA-Z]",
-				letterRegEx = "[\u00C0-\u1FFF\u2C00-\uD7FFa-zA-Z]",
+
+				//V.S. February 19th, 2018 #1362 Escaped unicode characters in RegEx;
+				letterOrDigitRegEx = "[\\d\\u00C0-\\u1FFF\\u2C00-\\uD7FFa-zA-Z]",
+				letterRegEx = "[\\u00C0-\\u1FFF\\u2C00-\\uD7FFa-zA-Z]",
 				digitRegEx = "[\\d]",
 				digitSpecialRegEx = "[\\d_\\+]";
 				mask = inputMask || this.options.inputMask;

--- a/tests/unit/editors/maskEditor/tests.html
+++ b/tests/unit/editors/maskEditor/tests.html
@@ -1115,6 +1115,50 @@
 				equal(field.val(), "MM-MMMM-MMLM", "Text is not MM-MMMM-MMLM");
 				$editor.remove();
 			});
+
+			testId = "Test with special characters";
+			QUnit.test(testId, function (assert) {
+				assert.expect(14);
+				var $editor;
+				$editor = $('<input/>').appendTo("#testBedContainer").igMaskEditor({ inputMask: "LLLLL" });
+				var field = $editor.igMaskEditor("field");
+				function enterValue(value){
+					$editor.focus()[0].setSelectionRange(0,0);
+					$.ig.TestUtil.type(value, field);
+				}
+				var testValues = [{
+					value: "たかむごひ",
+					valid: true
+				},{
+					value: "ⰁⰂⰃⰄⰅ",
+					valid: true
+				},{
+					value: "ퟻퟺퟯퟮퟭ",
+					valid: true
+				},{
+					value: "₩₩₩₩₩",
+					valid: false,
+					expected: "_____"
+				},{
+					value: "Ⰰ⯿⯾⯽⯼",
+					valid: false,
+					expected: "Ⰰ____"
+				},{
+					value: "‐‑‒–—",
+					valid: false,
+					expected: "_____"
+				},{
+					value: "¿¾½¼»",
+					valid: false,
+					expected: "_____"
+				}]
+				for(var i=0; i< testValues.length; i++){
+					$editor.igMaskEditor("field").val("_____");
+					enterValue(testValues[i].value);
+					assert.ok($editor.igMaskEditor("isValid") == testValues[i].valid, "Value is expected to be accepted.");
+					assert.equal(field.val(), testValues[i].valid ? testValues[i].value : testValues[i].expected, "The text is not as expected");
+				}
+			});
 		});
 
 		function checkMaskState(editor, keyCode, editValue, displayValue, value) {


### PR DESCRIPTION
Closes #1362 

Escape unicode characters in maskEditor validate

Added tests for maskEditor validation
