### PR TITLE
#1204 Changing open and close animation handling for igDialog

### DIFF
--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -1493,10 +1493,23 @@
 			self._opened = true;
 			self._doSize(1);
 			if (anim) {
-				elem.hide().show(anim, function () {
-					self._trigger("animationEnded", e, arg);
-					self.moveToTop(true);
-				});
+
+				//V.S. 21 February, 2018 - #1204 animation chaining was not always calling moveToTop properly
+				if (typeof anim === "string") {
+					elem.hide().show(anim, function () {
+						self._trigger("animationEnded", e, arg);
+						self.moveToTop(true);
+					});
+				} else {
+					if (typeof anim !== "object") {
+						anim = { easing: anim };
+					}
+					anim.complete = function () {
+						self._trigger("animationEnded", e, arg);
+						self.moveToTop(true);
+					};
+					elem.hide(0).show(anim);
+				}
 			} else {
 				self.moveToTop(true);
 			}
@@ -1825,9 +1838,21 @@
 			}
 			self._doModal();
 			if (anim) {
-				elem.hide(anim, function () {
-					self._trigger("animationEnded", e, arg);
-				});
+
+				//V.S. 21 February, 2018 - #1204 animation chaining was not always calling moveToTop properly
+				if (typeof anim === "string") {
+					elem.hide(anim, function () {
+						self._trigger("animationEnded", e, arg);
+					});
+				} else {
+					if (typeof anim !== "object") {
+						anim = { easing: anim };
+					}
+					anim.complete = function () {
+						self._trigger("animationEnded", e, arg);
+					};
+					elem.hide(anim);
+				}
 			} else if (!destroy) {
 				elem.hide();
 			}

--- a/tests/unit/dialog/tests.html
+++ b/tests/unit/dialog/tests.html
@@ -76,7 +76,7 @@
 			},
 			teardown: function() {
 			}
-		});
+        });
 
         var testId = '[ID1] dialog structure and layout';
         test(testId, function () {
@@ -456,6 +456,65 @@
             }, 1000);
 
         });
+     
+        test("#1204 Modal openAnimation should display modal overlay on end", 1, function () {
+            var $dialog = $("<div id='openAnimationDialog'><h1>Hello World!</h1></div>").prependTo("#newContainer")
+            .igDialog({
+                state: 'open',
+                modal: true,
+                height: '400px',
+                width: '600px',
+                openAnimation: { effect: 'scale', duration: 1000 },
+                stateChanged: function (evt, ui) {
+                    if (ui.action === 'close') {
+                        popup.remove();
+                    }
+                    return true;
+                }
+            });
+            var backgroundIndex = parseInt($dialog.data("igDialog")._modalDiv.css("zIndex"));
+            stop();
+            setTimeout(function(){
+                start();
+                ok(backgroundIndex > 0, "z-Index of overlay is not greater than 1");
+                $dialog.remove();
+            }, 100);
+        });
+        
+        test("#1204 Modal Open and Close animations, passed as objects, should fire 'animationEnded'", 3, function () {
+            var animationEventFlag = false;
+            var $dialog = $("<div id='openAnimationDialog'><h1>Hello World!</h1></div>").prependTo("#newContainer")
+            .igDialog({
+                state: 'open',
+                modal: true,
+                height: '400px',
+                width: '600px',
+                openAnimation: { effect: 'scale', duration: 1000 },
+                closeAnimation: { effect: 'explode', duration: 1000 },
+                stateChanged: function (evt, ui) {
+                    if (ui.action === 'close') {
+                        $dialog.remove();
+                    }
+                    return true;
+                },
+                animationEnded: function(){
+                    animationEventFlag = true;
+                }
+            });
+            ok(!animationEventFlag, "Animation flag should be false by default");
+            stop();
+            setTimeout(function(){
+                start();
+                ok(animationEventFlag, "Animation flag should be true after openAnimation is completed");
+                $dialog.igDialog("close");
+                animationEventFlag = false;
+                stop();
+                setTimeout(function(){
+                    start();
+                    ok(animationEventFlag, "Animation flag should be true after closeAnimation is completed");
+                },1100)
+            }, 1100);
+        });
     });
     </script>
 </head>
@@ -480,6 +539,7 @@
             <iframe id="testFrame"></iframe>
         </div>
         <div id="dialog5"></div>
+        <div id="dialog6"></div>
         <div id="newContainer"></div>
     </div>
     <div id="newContainer"></div>


### PR DESCRIPTION
openAnimation and closeAnimation options of igDialog were not triggering correctly when objects are passed. Adjusted events to check for type of data passed in the options and trigger accordingly.

Closes #1204 