### PR TITLE
#1571 - ignumericeditor dropdown scrollbar fix

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -3203,6 +3203,11 @@
 				editorInput: this._editorInput,
 				list: this._dropDownList
 			};
+
+			//V.S. 23 February 2018, #1571 - Fix render of dropDown using jQuery UI versions below 1.12.1. Capture scrollTop at start and reapply at end of anim.
+			if (this._scrollTopDropDownPosition !== undefined) {
+				this._dropDownList.scrollTop(this._scrollTopDropDownPosition);
+			}
 			return this._trigger(this.events.dropDownListOpened, null, args);
 		},
 		_triggerDropDownItemSelecting: function (item) {
@@ -3432,6 +3437,12 @@
 
 			if (!activeItem.length) {
 				return;
+			}
+
+			//V.S. 23 February 2018, #1571 - Fix render of dropDown using jQuery UI versions below 1.12.1. Capture scrollTop at start and reapply at end of anim.
+			if (this._dropDownList.parent().hasClass("ui-effects-wrapper")) {
+				this._scrollTopDropDownPosition = this._dropDownList.scrollTop() +
+				activeItem.position().top;
 			}
 			if (this._elementPositionInViewport(activeItem) !== "inside") {
 				this._dropDownList.scrollTop(this._dropDownList.scrollTop() +

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -2563,6 +2563,30 @@
 		equal($editor.igNumericEditor("value"), null, "Value should be null");
 		$editor.remove();
 	});
+
+	testId = 'Numeric Editor Scrollbar maintains scroll position after animation';
+	QUnit.test(testId,function (assert) {
+		assert.expect(2);
+		done = assert.async();
+		var dropDownScrollPosition = 0;
+		var listValues = [10, 15, 20, 25, 30, 35, 40];
+		var $editor = $("<input id='scrollbarNumericEditor'/>").appendTo("#testBedContainer").igNumericEditor({
+			 allowNullValue: true, nullValue: null, value: 40, listItems : listValues
+		});
+		
+		$editor.igNumericEditor("dropDownContainer").wrap("<div class='ui-effects-wrapper'></div>");
+		$editor.igNumericEditor("dropDownButton").click();
+		$editor.igNumericEditor("dropDownContainer").scrollTop(0);
+		$.ig.TestUtil.wait(400).then(function () {
+			assert.ok($editor.igNumericEditor("value") === 40, "Value should be changed to 40.");
+			assert.ok($editor.igNumericEditor("dropDownContainer").scrollTop() !== 0, "The scroll should not be positioned at the top of the dropdown");
+			done();
+		}).catch(function (er) {
+			assert.pushResult({ result: false, message: er.message });
+			throw er;
+			done();
+		});
+	});
 });
 	function testSelection(input, start, end) {
 		equal(input[0].selectionStart, start, "The selection doesn't start from index " + start);


### PR DESCRIPTION
Closes #1571

Adjusted how igNumericEditor dropdown show animation is handled in order for the control to work with jQuery UI versions older than 1.12.1. jQuery UI animation rendering was reworked in 1.12.1.

igNumericEditor drop down animation adjusted to capture scrollTop at the start and reapply scrollTop at the end of the show animation

