### PR TITLE
Spreadsheet depends on igDialog as of 18.1

### DIFF
--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -2017,6 +2017,7 @@ $.ig.dependencies = [
 			{ name: "igExcel" },
 			{ name: "Functions", parentWidget: "igExcel" },
 			{ name: "igCombo" },
+			{ name: "igDialog" },
 			{ name: "_ig_undo" }
 		],
 		group: $.ig.loaderClass.locale.gridGroup,


### PR DESCRIPTION
The Spreadsheet needs igDialog for the new custom filter dialog feature.