### PR TITLE
1634 - igTree checkStateChanging trigger on events

### DIFF
--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -3669,7 +3669,7 @@
 				paramType="object" optional="true" Indicates the browser event which triggered this action, if this is not an API call.
 			*/
 			var self = this, opt = self.options, css = self.css, childCheckboxes, childCheckIcons,
-				checkbox, checkIcon, parentLi, noCancel;
+				checkbox, checkIcon, parentLi, noCancel = true;
 
 			// K.D. November 28th, 2011 Bug #96672 Checking if no argument is provided when doing the API call
 			if (!node) {
@@ -3681,7 +3681,9 @@
 
 			checkbox = node.children("span[data-role=checkbox]");
 			checkIcon = checkbox.children("span");
-			noCancel = self._triggerNodeCheckstateChanging(event, node);
+			if(event){
+				noCancel = self._triggerNodeCheckstateChanging(event, node);
+			}
 			if (noCancel) {
 				if (opt.checkboxMode.toLowerCase() === "tristate") {
 					if (checkbox.attr("data-chk") === "on" || checkbox.attr("data-chk") === "partial") {
@@ -3756,7 +3758,9 @@
 						checkIcon.removeClass(css.checkboxOff).addClass(css.checkboxOn);
 					}
 				}
-				self._triggerNodeCheckstateChanged(event, node);
+				if(event){
+					self._triggerNodeCheckstateChanged(event, node);
+				}
 			}
 		},
 		toggle: function (node, event) {

--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -3681,7 +3681,9 @@
 
 			checkbox = node.children("span[data-role=checkbox]");
 			checkIcon = checkbox.children("span");
-			if(event){
+
+			//V.S. March 1st, 2018 - Issue #1634 - nodeCheckstateChanging and nodeCheckstateChanged should not fire on programmatic trigger. Fixed to match 17.2 functionality
+			if (event) {
 				noCancel = self._triggerNodeCheckstateChanging(event, node);
 			}
 			if (noCancel) {
@@ -3758,7 +3760,9 @@
 						checkIcon.removeClass(css.checkboxOff).addClass(css.checkboxOn);
 					}
 				}
-				if(event){
+
+				//V.S. March 1st, 2018 - Issue #1634 - nodeCheckstateChanging and nodeCheckstateChanged should not fire on programmatic trigger. Fixed to match 17.2 functionality
+				if (event) {
 					self._triggerNodeCheckstateChanged(event, node);
 				}
 			}

--- a/tests/unit/tree/tests.htm
+++ b/tests/unit/tree/tests.htm
@@ -1634,6 +1634,7 @@
 			testId_4 = "igTree expanding and collapsing events";
 			testId_5 = "igTree checkstateChanging/Changed events";
 			testId_6 = "igTree node populating/populated events";
+			testId_7 = "igTree nodeCheckStateChanged should not fire when triggered programatically.";
 			
 			test(testId_1, function () {
 				var dataBoundFired = false;
@@ -1892,6 +1893,56 @@
 				});
 				var node = $('#tree7').igTree('nodeByPath', '0');
 				$('#tree7').igTree('toggle', node);
+			});
+
+			test(testId_7, function(assert){
+				assert.expect(2);
+				var stateChangeFlag = false;
+				var $tree = $("<div id='checkTestTree'></div>").appendTo("#tree-container").igTree({
+					dataSource: results2,
+					bindings: {
+						textKey: 'Text',
+						valueKey: 'Value',
+						imageUrlKey: 'ImageUrl',
+						navigateUrlKey: 'URL',
+						childDataProperty: 'Children',
+						bindings: {
+							textKey: 'Text1',
+							valueKey: 'Value1',
+							imageUrlKey: 'ImageUrl1',
+							navigateUrlKey: 'URL1',
+							childDataProperty: 'Children1',
+							bindings: {
+								textKey: 'Text2',
+								valueKey: 'Value2',
+								imageUrlKey: 'ImageUrl2',
+								navigateUrlKey: 'URL2',
+								childDataProperty: 'Children2',
+								bindings: {
+									textKey: 'Text3',
+									valueKey: 'Value3'
+								}
+							}
+						}
+					},
+					checkboxMode: "triState",
+					rendered: function (evt, ui) {
+						var nodes = $("#checkTestTree").igTree("uncheckedNodes");
+						for (var i = 0; i < nodes.length; i++) {
+							var node = nodes[i];
+							$("#checkTestTree").igTree("toggleCheckstate", node.element);
+						};
+					},
+					nodeCheckstateChanging: function (evt, ui) {
+						stateChangeFlag = true;
+					}
+				});
+				assert.ok(!stateChangeFlag, "nodeCheckStateChanging should not be fired on event render");
+				stateChangeFlag = false;
+				var node = $("#checkTestTree").igTree('nodeByPath', '0_0_0_0');
+				node.children(".ui-igcheckbox-normal").children().focus().trigger("click");
+				assert.ok(stateChangeFlag, "nodeCheckStateChanging should fire when triggered by an event");
+				$("#checkTestTree").remove();
 			});
 			
 			/* ***************** END igTree Client events ***************** */

--- a/tests/unit/tree/tests.htm
+++ b/tests/unit/tree/tests.htm
@@ -1842,9 +1842,9 @@
 					}
 				});
 				var node = $('#tree6').igTree('nodeByPath', '0');
-				$('#tree6').igTree('toggleCheckstate', node);
+				$('#tree6').igTree('toggleCheckstate', node, true);
 				var node = $('#tree6').igTree('nodeByPath', '0_0');
-				$('#tree6').igTree('toggleCheckstate', node);
+				$('#tree6').igTree('toggleCheckstate', node, true);
 			});
 			test(testId_6, function () {
 				var populatingFired = false, populatedFired = false, renderingFired = false, renderedFired = false;


### PR DESCRIPTION
Closes #1634 

Adjusting igTree checkStateChanging to trigger only on events, as it is on versions 17.2, 18.1

