### PR TITLE
Fix and test for bug 248224

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -7276,9 +7276,7 @@
 				res = this._groupedRecordsByExpr(data, i, gbExpr, gbRec);
 				gbRec.fieldName = gbExpr.fieldName;
 				resLen = res.length;
-				if (dt === undefined) {
-					dt = !!(gbRec.val && gbRec.val.getTime);
-				}
+				dt = !!(gbRec.val && gbRec.val.getTime);
 				gbRec.val = dt ? gbRec.val.getTime() : gbRec.val;
 				hc = gbRec.val ? String(gbRec.val).getHashCode() : "";
 				gbRec.id = parentId + gbExpr.fieldName + ":" + hc;

--- a/tests/unit/dataSource/groupby/tests.html
+++ b/tests/unit/dataSource/groupby/tests.html
@@ -2574,6 +2574,68 @@
 				}, 500);
 			});
 
+			//test for bug 248224
+			test("Test grouping by dates and sorting when some of the dates are null.", function(){
+				var fields = [
+					{
+						name : "Column1"
+					},
+					{
+						name : "Column2"
+					},
+					{
+						name : "Column3",
+						type: "date"
+					}
+				];
+				var recs = [
+					{
+					Column1  : "Test Data 1",
+					Column2 : "Hidden 1",
+					Column3 : "12/27/2017"		
+					},
+					{
+					Column1  : "Test Data 2",
+					Column2 : "Hidden 2",
+					Column3 : "12/28/2017"		
+					},
+					{
+					Column1  : "Test Data 2",
+					Column2 : "Hidden 12",
+					Column3 : "1/27/2017"
+					},
+					{
+					Column1  : "Test Data 3",
+					Column2 : "Hidden 21",
+					Column3 : "12/27/2018"
+					},
+					{
+					Column1  : "Test Data 3",
+					Column2 : "Hidden 21"
+					}
+				];
+
+				var ds = new $.ig.DataSource({
+					schema: {
+						fields: fields
+					},
+					sorting: {
+						expressions:[]
+					},
+					dataSource: recs
+				});
+				ds.dataBind();
+				var errorCount = 0;
+				try {
+					ds.settings.sorting.expressions.push({"fieldName": "Column3", "dir": "desc", "isGroupBy": true});
+					ds.dataBind();
+				} catch(e){
+					errorCount++;
+					ok(false, "Error was thrown. Message: " + e.message);
+				}
+				equal(errorCount, 0, "No errors should be thrown.");
+			});
+
 			
 		});
 	</script>


### PR DESCRIPTION
Making sure date type check is done each time, not just for the first rec value, since it’s possible the first value to be null, in which case the result will be incorrect.