### PR TITLE
#1358 - igDatePicker regional fallback to global regional

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11099,6 +11099,13 @@
 			regional = ($.datepicker && typeof reg === "string") ?
 				$.datepicker.regional[ (reg === "defaults" || reg === "en-US") ? "" : reg ] :
 				null;
+
+			//V.S. March 7th 2018 - #1358 if no regional option is provided and a global regional is set, uses the global one
+			if (typeof $.ig.util.regional === "string") {
+				if ($.ig.util.regional !== reg && (reg === "defaults" || reg === "en-US")) {
+					regional = $.datepicker.regional[ $.ig.util.regional ] || $.datepicker.regional[ "" ];
+				}
+			}
 			if (regional === null && $.datepicker) {
 				for (lastRegional in $.datepicker.regional) { }
 				if ($.datepicker.regional[ lastRegional ]) {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11095,16 +11095,18 @@
 			this._attachButtonsEvents("dropdown", dropDownButton);
 		},
 		_dpRegion: function () {
-			var reg = this.options.regional, lastRegional, regional;
-			regional = ($.datepicker && typeof reg === "string") ?
-				$.datepicker.regional[ (reg === "defaults" || reg === "en-US") ? "" : reg ] :
-				null;
+			var reg = this.options.regional, lastRegional, regional = null, regAbbr = "";
 
 			//V.S. March 7th 2018 - #1358 if no regional option is provided and a global regional is set, uses the global one
-			if (typeof $.ig.util.regional === "string") {
-				if ($.ig.util.regional !== reg && (reg === "defaults" || reg === "en-US")) {
-					regional = $.datepicker.regional[ $.ig.util.regional ] || $.datepicker.regional[ "" ];
+			if ($.datepicker && typeof reg === "string") {
+				if (reg === "defaults" || reg === "en-US") {
+					if (typeof $.ig.util.regional === "string" && $.ig.util.regional) {
+						regAbbr = $.ig.util.regional;
+					}
+				} else {
+					regAbbr = reg;
 				}
+				regional = $.datepicker.regional[ regAbbr ] || $.datepicker.regional[ "" ];
 			}
 			if (regional === null && $.datepicker) {
 				for (lastRegional in $.datepicker.regional) { }

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11095,18 +11095,18 @@
 			this._attachButtonsEvents("dropdown", dropDownButton);
 		},
 		_dpRegion: function () {
-			var reg = this.options.regional, lastRegional, regional = null, regAbbr = "";
+			var reg = this.options.regional, lastRegional, regional = null, abbreviation = "";
 
 			//V.S. March 7th 2018 - #1358 if no regional option is provided and a global regional is set, uses the global one
 			if ($.datepicker && typeof reg === "string") {
 				if (reg === "defaults" || reg === "en-US") {
 					if (typeof $.ig.util.regional === "string" && $.ig.util.regional) {
-						regAbbr = $.ig.util.regional;
+						abbreviation = $.ig.util.regional;
 					}
 				} else {
-					regAbbr = reg;
+					abbreviation = reg;
 				}
-				regional = $.datepicker.regional[ regAbbr ] || $.datepicker.regional[ "" ];
+				regional = $.datepicker.regional[ abbreviation ] || $.datepicker.regional[ "" ];
 			}
 			if (regional === null && $.datepicker) {
 				for (lastRegional in $.datepicker.regional) { }

--- a/tests/unit/editors/datePicker/tests.html
+++ b/tests/unit/editors/datePicker/tests.html
@@ -1275,6 +1275,24 @@
 				},100);
 				
 			});
+			//$.ig.util.regional
+			testId = 'Calendar should fallback to locale settings, if no region is specified.';
+			QUnit.test(testId, function (assert) {
+				assert.expect(1);
+				var holder = "" + $.ig.util.regional;
+				if($.ig.util && $.ig.util.regional != "ja"){
+					$.ig.util.changeGlobalRegional("ja");
+				}
+				var $editor, $currentDate;
+				$editor = $('<input id="datePickerLocale"/>').appendTo("#testBedContainer").igDatePicker({
+					value: new Date("2018-03-04T00:00:00.000Z"),
+					dataMode: "date",					
+				});
+				$editor.igDatePicker("dropDownButton").click();
+				$currentDate = $editor.igDatePicker("getCalendar").find(".ui-datepicker-header > .ui-datepicker-title").text();
+				assert.ok($currentDate === "2018年 3月", "Test values are undefined by default.");
+				$.ig.util.changeGlobalRegional(holder);	
+			});
 		});
 		
 		function mouseInteraction(type, element) {


### PR DESCRIPTION
Closes #1358 

igDatePicker now checks for the global regional settings and fallbacks to them if no regional option is passed.

