### PR TITLE
Fix issue in getDate for dates on the day of a daylight savings change

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -1410,7 +1410,9 @@
 				value.getMilliseconds();
 		},
 		getDate: function (value) {
-			return new Date(value - $.ig.Date.prototype.getTimeOfDay(value));
+			var newDate = new Date(+value);
+			newDate.setHours(0, 0, 0, 0);
+			return newDate;
 		},
 		_requiresISOCorrection: !isNaN(+new Date("2000-01-01T00:00:00")) &&
 			new Date("2000-01-01T00:00:00").getHours() !== 0,

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -27,278 +27,278 @@
     font-size: 18px;
 }
 </style>
-<script type="text/javascript">
-    module("igUtil Basic Tests");
-    // run tests
+	<script type="text/javascript">		
+		module("igUtil Basic Tests");
+        // run tests
+		
+		test("Test getColType function",function(){
+			var result = $.ig.getColType(new Date());
+			equal(result, "date", "Check if result is correct for the object type.");
+			
+			result = $.ig.getColType(1);
+			equal(result, "number", "Check if result is correct for the object type.");
+			
+			result = $.ig.getColType("1");
+			equal(result, "string", "Check if result is correct for the object type.");
+			
+			result = $.ig.getColType(true);
+			equal(result, "bool", "Check if result is correct for the object type.");
+			
+			result = $.ig.getColType([1, 2, 3]);
+			equal(result, "object", "Check if result is correct for the object type.");
+			
+			result = $.ig.getColType(undefined);
+			equal(result, "string", "Check if result is correct for the object type.");			
+		});
 
-    test("Test getColType function", function () {
-        var result = $.ig.getColType(new Date());
-        equal(result, "date", "Check if result is correct for the object type.");
+		test("Test getRelativeOffset function", function () {
+			$("#container").append("<div class='container'><span id='span1' class='bottomleft'> Span elem</span><div>");
+			
+			$("#container").append("<div class='container'><div class='topright'><table id='table1'><tr><td>Table cell 1</td><td>Table cell 2</td></tr></table><div></div>");
+			
+			$("#container").append("<div  style='height: 500px;' class='container topright'><div class='bottomleft' style='position:static;'><span id='span2'  style='position:static;'>Span2</span></div></div>");
 
-        result = $.ig.getColType(1);
-        equal(result, "number", "Check if result is correct for the object type.");
+			//check getRelativeOffset with relative positioning of the parent
+			var relOffset = $.ig.util.getRelativeOffset($("#span1"));
+			ok($("#span1").parent().offset().left - $("#span1").parent().scrollLeft() === relOffset.left && $("#span1").parent().offset().top - $("#span1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+			
+			//check getRelativeOffset with absolute positioning of the parent
+			relOffset = $.ig.util.getRelativeOffset($("#table1"));
+			ok($("#table1").parent().offset().left - $("#table1").parent().scrollLeft() === relOffset.left && $("#table1").parent().offset().top - $("#table1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+			
+			//check getRelativeOffset with static positioning of the parent
+			relOffset = $.ig.util.getRelativeOffset($("#span2"));
+			ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+		});
 
-        result = $.ig.getColType("1");
-        equal(result, "string", "Check if result is correct for the object type.");
+		test("Test defEnum", function () {
+			// simple non-flagged enum
+			equal(3, $.ig.DayOfWeek.prototype.wednesday, "Simple enum member - Access value via prototype");
+			equal("Wednesday", $.ig.DayOfWeek.prototype.getBox(3).toString(), "Simple enum member - ToString.");
+			equal("Wednesday", $.ig.Enum.prototype.parse($.ig.DayOfWeek.prototype.$type, "wednesday", true).toString(), "Simple enum member - Parse");
+			
+			// flagged enum
+			equal(111, $.ig.NumberStyles.prototype.number, "Simple flagged enum member - Access value via prototype");
+			equal(167, $.ig.NumberStyles.prototype.floatNumber, "Complex flagged enum member - Access value via prototype");
+			equal("Number", $.ig.NumberStyles.prototype.getBox(111).toString(), "Simple enum member - ToString.");
+			equal("Float", $.ig.NumberStyles.prototype.getBox(167).toString(), "Complex enum member - ToString.");
+			equal("Number", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "number", true).toString(), "Simple flagged enum member - Parse");
+			equal("Float", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "float", true).toString(), "Complex flagged enum member - Parse");
 
-        result = $.ig.getColType(true);
-        equal(result, "bool", "Check if result is correct for the object type.");
+			// and some tests for public enums which differ in that the values are on the type instead of the prototype
+			$.ig.util.defEnum("TestPublicEnum", false, true, {
+				Foo: 0,
+				Bar: 1
+			});
 
-        result = $.ig.getColType([1, 2, 3]);
-        equal(result, "object", "Check if result is correct for the object type.");
+			equal(1, $.ig.TestPublicEnum.bar, "Simple public enum member - Access value via prototype");
+			equal("Bar", $.ig.TestPublicEnum.prototype.getBox(1).toString(), "Simple public enum member - ToString.");
+			equal("Bar", $.ig.Enum.prototype.parse($.ig.TestPublicEnum.prototype.$type, "bar", true).toString(), "Simple public enum member - Parse");
+		});
 
-        result = $.ig.getColType(undefined);
-        equal(result, "string", "Check if result is correct for the object type.");
-    });
+		test("Test getDate", function () {
+			var hoursArray = [ 1, 5 ];
+			var hoursSuffix = [" - before", " - after"];
 
-    test("Test getRelativeOffset function", function () {
-        $("#container").append("<div class='container'><span id='span1' class='bottomleft'> Span elem</span><div>");
+			for (var i = 0; i < hoursArray.length; i++) {
+				var hour = hoursArray[i];
+				var suffix = hoursSuffix[i];
 
-        $("#container").append("<div class='container'><div class='topright'><table id='table1'><tr><td>Table cell 1</td><td>Table cell 2</td></tr></table><div></div>");
+				// test some dst dates with a time after the change
+				equal(0, $.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour)).getHours(), "Hours of US daylight savings start" + suffix);
+				equal(0, $.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour)).getHours(), "Hours 0f BG daylight savings start" + suffix);
+				equal(0, $.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour)).getHours(), "Hours of US daylight savings end" + suffix);
+				equal(0, $.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour)).getHours(), "Hours of BG daylight savings end" + suffix);
 
-        $("#container").append("<div  style='height: 500px;' class='container topright'><div class='bottomleft' style='position:static;'><span id='span2'  style='position:static;'>Span2</span></div></div>");
+				equal(11, $.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour)).getDate(), "getDate of US daylight savings start" + suffix);
+				equal(25, $.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour)).getDate(), "getDate of BG daylight savings start" + suffix);
+				equal(11, $.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour)).getDate(), "getDate of US daylight savings end" + suffix);
+				equal(28, $.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour)).getDate(), "getDate of BG daylight savings end" + suffix);
 
-        //check getRelativeOffset with relative positioning of the parent
-        var relOffset = $.ig.util.getRelativeOffset($("#span1"));
-        ok($("#span1").parent().offset().left - $("#span1").parent().scrollLeft() === relOffset.left && $("#span1").parent().offset().top - $("#span1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+				equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour))), "getTimeOfDay of US daylight savings start" + suffix);
+				equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour))), "getTimeOfDay 0f BG daylight savings start" + suffix);
+				equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour))), "getTimeOfDay of US daylight savings end" + suffix);
+				equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour))), "getTimeOfDay of BG daylight savings end" + suffix);
+			}
 
-        //check getRelativeOffset with absolute positioning of the parent
-        relOffset = $.ig.util.getRelativeOffset($("#table1"));
-        ok($("#table1").parent().offset().left - $("#table1").parent().scrollLeft() === relOffset.left && $("#table1").parent().offset().top - $("#table1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+			var dateWithTime = $.ig.Date.prototype.getDate(new Date(2018, 2, 11, 23, 25, 15, 19));
+			equal(0, dateWithTime.getHours(), "Hours of Date with time");
+			equal(0, dateWithTime.getMinutes(), "Minutes of Date with time");
+			equal(0, dateWithTime.getSeconds(), "Seconds of Date with time");
+			equal(0, dateWithTime.getMilliseconds(), "Milliseconds of Date with time");
+			equal(0, $.ig.Date.prototype.getTimeOfDay(dateWithTime), "getTimeOfDay of Date with time");
+		});
+		test("Test appendToQueryString and prependToQueryString util functions", function () {
+			var url = "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID";
+			var newUrl = $.ig.util.appendToQueryString(url, "additionalParam=1");
+			equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID&additionalParam=1", "Verify url is correct and the new param is appended.");
+			newUrl = $.ig.util.prependToQueryString (url, "('ALFKI')/Orders");
+			equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers('ALFKI')/Orders?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID","Verify url is correct and the new string is prepended.");
+		});
+		
+		test("Test calcSummaries function by specifying summary name", function () {
+			var data = [ 114601, 82742, 63895, 27186, 63198, 73758 ];
+			
+			//Min
+			equal($.ig.calcSummaries("min", data, null, "number"), 27186, "Function did determine the minimum number correctly");
+			equal($.ig.calcSummaries("min", [], null, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
+			equal($.ig.calcSummaries("min", [], null, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
 
-        //check getRelativeOffset with static positioning of the parent
-        relOffset = $.ig.util.getRelativeOffset($("#span2"));
-        ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
-    });
+			//Max
+			equal($.ig.calcSummaries("max", data, null, "number"), 114601, "Max function did determine the minimum number correctly");
+			equal($.ig.calcSummaries("max", [], null, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
+			equal($.ig.calcSummaries("max", [], null, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
+			
+			//Sum
+			equal($.ig.calcSummaries("sum", data, null, "number"), 425380, "Sum function calculated the sum correctly");
+			equal($.ig.calcSummaries("sum", data), 425380, "Sum function calculated the sum correctly");
+			equal($.ig.calcSummaries("sum", [], null, "number"), 0, "Sum function return 0 when the array is empty");
+			
+			//Avg
+			equal($.ig.calcSummaries("avg", data, null, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
+			equal($.ig.calcSummaries("avg", data).toFixed(0), 70897, "Avg function calculated the average correctly");
+			equal($.ig.calcSummaries("avg", [], null, "number"), 0, "Avg function return 0 when the array is empty");
+			
+			//Count
+			equal($.ig.calcSummaries("count", data, null, "number"), 6, "Count function return the number of elements correctly");
+			equal($.ig.calcSummaries("count", [], null, "number"), 0, "Count function return 0 when the array is empty");
+		});
+		
+				
+		test("Test calcSummaries function by specifying summary function directly", function () {
+			var data = [ 114601, 82742, 63895, 27186, 63198, 73758 ];
+			
+			//Min
+			equal($.ig.calcSummaries("customMin", data, $.ig.util.summaries.min, "number"), 27186, "Function did determine the minimum number correctly");
+			equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
+			equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
 
-    test("Test defEnum", function () {
-        // simple non-flagged enum
-        equal(3, $.ig.DayOfWeek.prototype.wednesday, "Simple enum member - Access value via prototype");
-        equal("Wednesday", $.ig.DayOfWeek.prototype.getBox(3).toString(), "Simple enum member - ToString.");
-        equal("Wednesday", $.ig.Enum.prototype.parse($.ig.DayOfWeek.prototype.$type, "wednesday", true).toString(), "Simple enum member - Parse");
+			//Max
+			equal($.ig.calcSummaries("customMax", data, $.ig.util.summaries.max, "number"), 114601, "Max function did determine the minimum number correctly");
+			equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
+			equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
+			
+			//Sum
+			equal($.ig.calcSummaries("customSum", data, $.ig.util.summaries.sum, "number"), 425380, "Sum function calculated the sum correctly");
+			equal($.ig.calcSummaries("customSum", [], $.ig.util.summaries.sum), 0, "Sum function return 0 when the array is empty");
+			
+			//Avg
+			equal($.ig.calcSummaries("customAvg", data, $.ig.util.summaries.avg, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
+			equal($.ig.calcSummaries("customAvg", [], $.ig.util.summaries.avg, "number"), 0, "Avg function return 0 when the array is empty");
+			
+			//Count
+			equal($.ig.calcSummaries("custom", data, $.ig.util.summaries.count), 6, "Count function return the number of elements correctly");
+			equal($.ig.calcSummaries("custom", [], $.ig.util.summaries.count), 0, "Count function return 0 when the array is empty");
+			
+			equal($.ig.calcSummaries("random", [], $.ig.util.summaries.count), null, "Count function returns null when the summary name is not starting with custom");
+			equal($.ig.calcSummaries("custom", []), null, "Count function returns null when the custom summary function is not defined");
+		});
+		test("Test Complex Generic TypeArguments", function () {
+			var listNullInt = $.ig.IList$1.prototype.$type.specialize($.ig.Nullable$1.prototype.$type.specialize($.ig.Number.prototype.$type));
+			equal($.ig.Number.prototype.$type, listNullInt.typeArguments[0].typeArguments[0], "List<Nullable<int>>");
+		});
+		test("Test Date.toStringFormat", function() {
+			var dt = new Date("1980-10-11T12:00:00");
+			equal($.ig.Date.prototype.toStringFormat(dt, "MM/dd"), "10/11", "Date.toStringFormat formats MM/dd correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "MMM dd"), "Oct 11", "Date.toStringFormat formats MMM dd correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "MMM"), "Oct", "Date.toStringFormat formats MMM correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "yyyy"), "1980", "Date.toStringFormat formats yyyy correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "yy"), "80", "Date.toStringFormat formats yy correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "HH"), "12", "Date.toStringFormat formats HH correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "hh"), "12", "Date.toStringFormat formats hh correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "mm"), "00", "Date.toStringFormat formats mm correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "ss"), "00", "Date.toStringFormat formats ss correctly");	
+			equal($.ig.Date.prototype.toStringFormat(dt, "hh:mmtt"), "12:00PM", "Date.toStringFormat formats hh:mmtt correctly");	
+			equal($.ig.Date.prototype.toStringFormat(dt, "d"), "10/11/1980", "Date.toStringFormat formats d correctly");
+			// travis ci build doesn't seem to fully implement the part of toLocaleString where it infers the format based on the given options, causing several of these tests to fail. commenting for now.
+			// equal($.ig.Date.prototype.toStringFormat(dt, "D"), "Saturday, October 11, 1980", "Date.toStringFormat formats D correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "f"), "Saturday, October 11, 1980, 12:00 PM", "Date.toStringFormat formats f correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "F"), "Saturday, October 11, 1980, 12:00:00 PM", "Date.toStringFormat formats F correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "g"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats g correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "G"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats G correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "M"), "October 11", "Date.toStringFormat formats M correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "m"), "October 11", "Date.toStringFormat formats m correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "t"), "12:00 PM", "Date.toStringFormat formats t correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "T"), "12:00:00 PM", "Date.toStringFormat formats T correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "y"), "October 1980", "Date.toStringFormat formats y correctly");
+			// equal($.ig.Date.prototype.toStringFormat(dt, "Y"), "October 1980", "Date.toStringFormat formats Y correctly");
+			equal($.ig.Date.prototype.toStringFormat(dt, "hh:mm:ss:ff"), "12:00:00:00", "Date.toStringFormat formats hh:mm:ss:ff correctly");
+		});
 
-        // flagged enum
-        equal(111, $.ig.NumberStyles.prototype.number, "Simple flagged enum member - Access value via prototype");
-        equal(167, $.ig.NumberStyles.prototype.floatNumber, "Complex flagged enum member - Access value via prototype");
-        equal("Number", $.ig.NumberStyles.prototype.getBox(111).toString(), "Simple enum member - ToString.");
-        equal("Float", $.ig.NumberStyles.prototype.getBox(167).toString(), "Complex enum member - ToString.");
-        equal("Number", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "number", true).toString(), "Simple flagged enum member - Parse");
-        equal("Float", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "float", true).toString(), "Complex flagged enum member - Parse");
+		test("Test IsAssignableFrom", function () {
+		    // type itself
+		    ok($.ig.Enum.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum type");
 
-        // and some tests for public enums which differ in that the values are on the type instead of the prototype
-        $.ig.util.defEnum("TestPublicEnum", false, true, {
-            Foo: 0,
-            Bar: 1
-        });
+		    // base type
+		    ok($.ig.IEnumerable.prototype.$type.isAssignableFrom($.ig.IList.prototype.$type), "Base type of IList is IEnumerable");
 
-        equal(1, $.ig.TestPublicEnum.bar, "Simple public enum member - Access value via prototype");
-        equal("Bar", $.ig.TestPublicEnum.prototype.getBox(1).toString(), "Simple public enum member - ToString.");
-        equal("Bar", $.ig.Enum.prototype.parse($.ig.TestPublicEnum.prototype.$type, "bar", true).toString(), "Simple public enum member - Parse");
-    });
+		    // interfaces
+		    ok($.ig.IConvertible.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum implements IConvertible");
+		    ok($.ig.IComparable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IComparable<Int32>");
+		    ok($.ig.IEquatable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IEquatable<Int32>");
+		});
 
-    test("Test getDate", function () {
-        var hoursArray = [ 1, 5 ];
-        var hoursSuffix = [" - before", " - after"];
+		test("Test stringCompare2", function () {
+			var c = $.ig.CultureInfo.prototype.currentCulture();
+			var o = $.ig.CompareOptions.prototype.none;
+			
+		    equal($.ig.util.stringCompare2("A", "B", c, o), -1, "A before B");
+		    equal($.ig.util.stringCompare2("B", "A", c, o), 1, "B before A");
+		    equal($.ig.util.stringCompare2("A", "A", c, o), 0, "A === A");
+		    equal($.ig.util.stringCompare2(null, "A", c, o), -1, "null befoe A");
+		    equal($.ig.util.stringCompare2("A", null, c, o), 1, "A after null");
+		    equal($.ig.util.stringCompare2(null, "", c, o), -1, "null before empty");
+		    equal($.ig.util.stringCompare2("", null, c, o), 1, "empty after null");
+		});
 
-        for (var i = 0; i < hoursArray.length; i++) {
-            var hour = hoursArray[i];
-            var suffix = hoursSuffix[i];
+		test("Test trimStart", function () {
+		    equal("  ABC  ".trimStart(), "ABC  ", "No arguments");
+		    equal("  ABC  ".trimStart([]), "ABC  ", "Empty array argument");
+		    equal("  ABC  ".trimStart([' ']), "ABC  ", "Explicit space argument");
+		    equal("aa  ABC  aa".trimStart(['a']), "  ABC  aa", "Nonstandard trim character");
+		    equal("aa  ABC  aa".trimStart('a'), "  ABC  aa", "character only");
+		    equal("aa  ABC  aa".trimStart('a', ' '), "ABC  aa", "Multiple characters only");
+		});
 
-            // test some dst dates with a time after the change
-            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour)).getHours(), "Hours of US daylight savings start" + suffix);
-            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour)).getHours(), "Hours 0f BG daylight savings start" + suffix);
-            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour)).getHours(), "Hours of US daylight savings end" + suffix);
-            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour)).getHours(), "Hours of BG daylight savings end" + suffix);
+		test("Test trimEnd", function () {
+		    equal("  ABC  ".trimEnd(), "  ABC", "No arguments");
+		    equal("  ABC  ".trimEnd([]), "  ABC", "Empty array argument");
+		    equal("  ABC  ".trimEnd([' ']), "  ABC", "Explicit space argument");
+		    equal("aa  ABC  aa".trimEnd(['a']), "aa  ABC  ", "Nonstandard trim character");
+		    equal("aa  ABC  aa".trimEnd('a'), "aa  ABC  ", "character only");
+		    equal("aa  ABC  aa".trimEnd('a', ' '), "aa  ABC", "Multiple characters only");
+		});
 
-            equal(11, $.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour)).getDate(), "getDate of US daylight savings start" + suffix);
-            equal(25, $.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour)).getDate(), "getDate of BG daylight savings start" + suffix);
-            equal(11, $.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour)).getDate(), "getDate of US daylight savings end" + suffix);
-            equal(28, $.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour)).getDate(), "getDate of BG daylight savings end" + suffix);
-
-            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour))), "getTimeOfDay of US daylight savings start" + suffix);
-            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour))), "getTimeOfDay 0f BG daylight savings start" + suffix);
-            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour))), "getTimeOfDay of US daylight savings end" + suffix);
-            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour))), "getTimeOfDay of BG daylight savings end" + suffix);
-        }
-
-        var dateWithTime = $.ig.Date.prototype.getDate(new Date(2018, 2, 11, 23, 25, 15, 19));
-        equal(0, dateWithTime.getHours(), "Hours of Date with time");
-        equal(0, dateWithTime.getMinutes(), "Minutes of Date with time");
-        equal(0, dateWithTime.getSeconds(), "Seconds of Date with time");
-        equal(0, dateWithTime.getMilliseconds(), "Milliseconds of Date with time");
-        equal(0, $.ig.Date.prototype.getTimeOfDay(dateWithTime), "getTimeOfDay of Date with time");
-    });
-    test("Test appendToQueryString and prependToQueryString util functions", function () {
-        var url = "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID";
-        var newUrl = $.ig.util.appendToQueryString(url, "additionalParam=1");
-        equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID&additionalParam=1", "Verify url is correct and the new param is appended.");
-        newUrl = $.ig.util.prependToQueryString(url, "('ALFKI')/Orders");
-        equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers('ALFKI')/Orders?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID", "Verify url is correct and the new string is prepended.");
-    });
-
-    test("Test calcSummaries function by specifying summary name", function () {
-        var data = [114601, 82742, 63895, 27186, 63198, 73758];
-
-        //Min
-        equal($.ig.calcSummaries("min", data, null, "number"), 27186, "Function did determine the minimum number correctly");
-        equal($.ig.calcSummaries("min", [], null, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
-        equal($.ig.calcSummaries("min", [], null, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
-
-        //Max
-        equal($.ig.calcSummaries("max", data, null, "number"), 114601, "Max function did determine the minimum number correctly");
-        equal($.ig.calcSummaries("max", [], null, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
-        equal($.ig.calcSummaries("max", [], null, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
-
-        //Sum
-        equal($.ig.calcSummaries("sum", data, null, "number"), 425380, "Sum function calculated the sum correctly");
-        equal($.ig.calcSummaries("sum", data), 425380, "Sum function calculated the sum correctly");
-        equal($.ig.calcSummaries("sum", [], null, "number"), 0, "Sum function return 0 when the array is empty");
-
-        //Avg
-        equal($.ig.calcSummaries("avg", data, null, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
-        equal($.ig.calcSummaries("avg", data).toFixed(0), 70897, "Avg function calculated the average correctly");
-        equal($.ig.calcSummaries("avg", [], null, "number"), 0, "Avg function return 0 when the array is empty");
-
-        //Count
-        equal($.ig.calcSummaries("count", data, null, "number"), 6, "Count function return the number of elements correctly");
-        equal($.ig.calcSummaries("count", [], null, "number"), 0, "Count function return 0 when the array is empty");
-    });
-
-
-    test("Test calcSummaries function by specifying summary function directly", function () {
-        var data = [114601, 82742, 63895, 27186, 63198, 73758];
-
-        //Min
-        equal($.ig.calcSummaries("customMin", data, $.ig.util.summaries.min, "number"), 27186, "Function did determine the minimum number correctly");
-        equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
-        equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
-
-        //Max
-        equal($.ig.calcSummaries("customMax", data, $.ig.util.summaries.max, "number"), 114601, "Max function did determine the minimum number correctly");
-        equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
-        equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
-
-        //Sum
-        equal($.ig.calcSummaries("customSum", data, $.ig.util.summaries.sum, "number"), 425380, "Sum function calculated the sum correctly");
-        equal($.ig.calcSummaries("customSum", [], $.ig.util.summaries.sum), 0, "Sum function return 0 when the array is empty");
-
-        //Avg
-        equal($.ig.calcSummaries("customAvg", data, $.ig.util.summaries.avg, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
-        equal($.ig.calcSummaries("customAvg", [], $.ig.util.summaries.avg, "number"), 0, "Avg function return 0 when the array is empty");
-
-        //Count
-        equal($.ig.calcSummaries("custom", data, $.ig.util.summaries.count), 6, "Count function return the number of elements correctly");
-        equal($.ig.calcSummaries("custom", [], $.ig.util.summaries.count), 0, "Count function return 0 when the array is empty");
-
-        equal($.ig.calcSummaries("random", [], $.ig.util.summaries.count), null, "Count function returns null when the summary name is not starting with custom");
-        equal($.ig.calcSummaries("custom", []), null, "Count function returns null when the custom summary function is not defined");
-    });
-    test("Test Complex Generic TypeArguments", function () {
-        var listNullInt = $.ig.IList$1.prototype.$type.specialize($.ig.Nullable$1.prototype.$type.specialize($.ig.Number.prototype.$type));
-        equal($.ig.Number.prototype.$type, listNullInt.typeArguments[0].typeArguments[0], "List<Nullable<int>>");
-    });
-    test("Test Date.toStringFormat", function () {
-        var dt = new Date("1980-10-11T12:00:00");
-        equal($.ig.Date.prototype.toStringFormat(dt, "MM/dd"), "10/11", "Date.toStringFormat formats MM/dd correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "MMM dd"), "Oct 11", "Date.toStringFormat formats MMM dd correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "MMM"), "Oct", "Date.toStringFormat formats MMM correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "yyyy"), "1980", "Date.toStringFormat formats yyyy correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "yy"), "80", "Date.toStringFormat formats yy correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "HH"), "12", "Date.toStringFormat formats HH correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "hh"), "12", "Date.toStringFormat formats hh correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "mm"), "00", "Date.toStringFormat formats mm correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "ss"), "00", "Date.toStringFormat formats ss correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "hh:mmtt"), "12:00PM", "Date.toStringFormat formats hh:mmtt correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "d"), "10/11/1980", "Date.toStringFormat formats d correctly");
-        // travis ci build doesn't seem to fully implement the part of toLocaleString where it infers the format based on the given options, causing several of these tests to fail. commenting for now.
-        // equal($.ig.Date.prototype.toStringFormat(dt, "D"), "Saturday, October 11, 1980", "Date.toStringFormat formats D correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "f"), "Saturday, October 11, 1980, 12:00 PM", "Date.toStringFormat formats f correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "F"), "Saturday, October 11, 1980, 12:00:00 PM", "Date.toStringFormat formats F correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "g"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats g correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "G"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats G correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "M"), "October 11", "Date.toStringFormat formats M correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "m"), "October 11", "Date.toStringFormat formats m correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "t"), "12:00 PM", "Date.toStringFormat formats t correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "T"), "12:00:00 PM", "Date.toStringFormat formats T correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "y"), "October 1980", "Date.toStringFormat formats y correctly");
-        // equal($.ig.Date.prototype.toStringFormat(dt, "Y"), "October 1980", "Date.toStringFormat formats Y correctly");
-        equal($.ig.Date.prototype.toStringFormat(dt, "hh:mm:ss:ff"), "12:00:00:00", "Date.toStringFormat formats hh:mm:ss:ff correctly");
-    });
-
-    test("Test IsAssignableFrom", function () {
-        // type itself
-        ok($.ig.Enum.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum type");
-
-        // base type
-        ok($.ig.IEnumerable.prototype.$type.isAssignableFrom($.ig.IList.prototype.$type), "Base type of IList is IEnumerable");
-
-        // interfaces
-        ok($.ig.IConvertible.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum implements IConvertible");
-        ok($.ig.IComparable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IComparable<Int32>");
-        ok($.ig.IEquatable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IEquatable<Int32>");
-    });
-
-    test("Test stringCompare2", function () {
-        var c = $.ig.CultureInfo.prototype.currentCulture();
-        var o = $.ig.CompareOptions.prototype.none;
-
-        equal($.ig.util.stringCompare2("A", "B", c, o), -1, "A before B");
-        equal($.ig.util.stringCompare2("B", "A", c, o), 1, "B before A");
-        equal($.ig.util.stringCompare2("A", "A", c, o), 0, "A === A");
-        equal($.ig.util.stringCompare2(null, "A", c, o), -1, "null befoe A");
-        equal($.ig.util.stringCompare2("A", null, c, o), 1, "A after null");
-        equal($.ig.util.stringCompare2(null, "", c, o), -1, "null before empty");
-        equal($.ig.util.stringCompare2("", null, c, o), 1, "empty after null");
-    });
-
-    test("Test trimStart", function () {
-        equal("  ABC  ".trimStart(), "ABC  ", "No arguments");
-        equal("  ABC  ".trimStart([]), "ABC  ", "Empty array argument");
-        equal("  ABC  ".trimStart([' ']), "ABC  ", "Explicit space argument");
-        equal("aa  ABC  aa".trimStart(['a']), "  ABC  aa", "Nonstandard trim character");
-        equal("aa  ABC  aa".trimStart('a'), "  ABC  aa", "character only");
-        equal("aa  ABC  aa".trimStart('a', ' '), "ABC  aa", "Multiple characters only");
-    });
-
-    test("Test trimEnd", function () {
-        equal("  ABC  ".trimEnd(), "  ABC", "No arguments");
-        equal("  ABC  ".trimEnd([]), "  ABC", "Empty array argument");
-        equal("  ABC  ".trimEnd([' ']), "  ABC", "Explicit space argument");
-        equal("aa  ABC  aa".trimEnd(['a']), "aa  ABC  ", "Nonstandard trim character");
-        equal("aa  ABC  aa".trimEnd('a'), "aa  ABC  ", "character only");
-        equal("aa  ABC  aa".trimEnd('a', ' '), "aa  ABC", "Multiple characters only");
-    });
-
-    test("Test $.ig.encode", function () {
-        equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
-        equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");
-        equal($.ig.encode("<span id='span1'></span>"), "&lt;span id=&#39;span1&#39;&gt;&lt;/span&gt;", "Should encode span element with attribute and single quote");
-        equal($.ig.encode("<span id=\"span1\"></span>"), "&lt;span id=&#34;span1&#34;&gt;&lt;/span&gt;", "Should encode span element with attribute and double quote")
-    });
-
-    test("Test $.ig.util.stringToColor", function () {
-        deepEqual($.ig.util.stringToColor(null), { a: 0, r: 0, g: 0, b: 0 }, "Passing null to stringToColor should return transparent.");
-        deepEqual($.ig.util.stringToColor("papayawhip"), { a: 255, r: 255, g: 239, b: 213 }, "Passing papayawhip to stringToColor should look as delicious as whipped papaya.");
-        deepEqual($.ig.util.stringToColor("rgba(13, 14, 15, 0.2)"), { r: 13, g: 14, b: 15, a: 51 }, "Passing rgba(13, 14, 15, 16) to stringToColor should return that color.");
-        deepEqual($.ig.util.stringToColor("rgb(13, 14, 15)"), { a: 255, r: 13, g: 14, b: 15 }, "Passing rgb(13, 14, 15) to stringToColor should return that color.");
-        deepEqual($.ig.util.stringToColor("#beefed"), { a: 255, r: 190, g: 239, b: 237 }, "Passing #beefed to stringToColor should return a nice pale cyan color.");
-        deepEqual($.ig.util.stringToColor("#def"), { a: 255, r: 221, g: 238, b: 255 }, "Passing #def to stringToColor should return a nice pale lavender color.");
-    });
-    test("Test numberToString", function () {
-        equal($.ig.util.numberToString1(Math.PI, "0"), "3", "numberToString1 truncates all decimals when format is 0");
-        equal($.ig.util.numberToString1(Math.PI, "0.0"), "3.1", "numberToString1 truncates to 1 decimal place when format is 0.0 and 2nd decimal place rounds down");
-        equal($.ig.util.numberToString1(Math.PI, "00"), "03", "numberToString1 truncates all decimals and prepends leading 0 when format is 00 and number integral part has 1 digit");
-        equal($.ig.util.numberToString1(Math.PI, "00.00"), "03.14", "numberToString1 truncates to 2 decimal places and prepends leading 0 when format is 00.00 and number integral part has 1 digit and 3rd decimal place rounds down");
-        equal($.ig.util.numberToString1(Math.PI, "0.000"), "3.142", "numberToString1 rounds up when format is 0.000 and 4th decimal place rounds up");
-        equal($.ig.util.numberToString1(.1, "00.00"), "00.10", "numberToString1 prepends 2 leading 0s and appends 1 trailing 0 when format is 00.00 and number has 0 integral digits and 1 decimal digit");
-        equal($.ig.util.numberToString1(.1, "00.0#"), "00.1", "numberToString1 prepends 2 leading 0s and includes only significant decimal when format is 00.0# and number has 0 integral digits and 1 decimal digit");
-        equal($.ig.util.numberToString1(.19, "00.0#"), "00.19", "numberToString1 prepends 2 leading 0s and includes all significant decimals when format is 00.0# and number has 0 integral digits and 2 decimal digits");
-        equal($.ig.util.numberToString1(.1, "#"), "", "numberToString1 returns an empty string when format is # and number has 0 integral digits");
-        equal($.ig.util.numberToString1(1.1, "#"), "1", "numberToString1 truncates decimal portion when format is #");
-        equal($.ig.util.numberToString1(1.1, "0"), "1", "numberToString1 truncates decimal portion when format is 0");
-        equal($.ig.util.numberToString1(300, "0.#"), "300", "numberToString1 truncates decimal portion when format is 0.# and number has 0 decimal digits");
-    });
-</script>
+		test("Test $.ig.encode", function () {
+			equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
+			equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");
+			equal($.ig.encode("<span id='span1'></span>"), "&lt;span id=&#39;span1&#39;&gt;&lt;/span&gt;", "Should encode span element with attribute and single quote");
+			equal($.ig.encode("<span id=\"span1\"></span>"), "&lt;span id=&#34;span1&#34;&gt;&lt;/span&gt;", "Should encode span element with attribute and double quote")
+		});
+		
+		test("Test $.ig.util.stringToColor", function () {
+			deepEqual($.ig.util.stringToColor(null), { a: 0, r: 0, g: 0, b: 0 }, "Passing null to stringToColor should return transparent.");
+			deepEqual($.ig.util.stringToColor("papayawhip"), { a: 255, r: 255, g: 239, b: 213 }, "Passing papayawhip to stringToColor should look as delicious as whipped papaya.");
+			deepEqual($.ig.util.stringToColor("rgba(13, 14, 15, 0.2)"), { r: 13, g: 14, b: 15, a: 51 }, "Passing rgba(13, 14, 15, 16) to stringToColor should return that color.");
+			deepEqual($.ig.util.stringToColor("rgb(13, 14, 15)"), { a: 255, r: 13, g: 14, b: 15 }, "Passing rgb(13, 14, 15) to stringToColor should return that color.");
+			deepEqual($.ig.util.stringToColor("#beefed"), { a: 255, r: 190, g: 239, b: 237 }, "Passing #beefed to stringToColor should return a nice pale cyan color.");
+			deepEqual($.ig.util.stringToColor("#def"), { a: 255, r: 221, g: 238, b: 255 }, "Passing #def to stringToColor should return a nice pale lavender color.");
+		});
+		test("Test numberToString", function() {
+			equal($.ig.util.numberToString1(Math.PI, "0"), "3", "numberToString1 truncates all decimals when format is 0");   
+			equal($.ig.util.numberToString1(Math.PI, "0.0"), "3.1", "numberToString1 truncates to 1 decimal place when format is 0.0 and 2nd decimal place rounds down");
+			equal($.ig.util.numberToString1(Math.PI, "00"), "03", "numberToString1 truncates all decimals and prepends leading 0 when format is 00 and number integral part has 1 digit");
+			equal($.ig.util.numberToString1(Math.PI, "00.00"), "03.14", "numberToString1 truncates to 2 decimal places and prepends leading 0 when format is 00.00 and number integral part has 1 digit and 3rd decimal place rounds down");
+			equal($.ig.util.numberToString1(Math.PI, "0.000"), "3.142", "numberToString1 rounds up when format is 0.000 and 4th decimal place rounds up");
+			equal($.ig.util.numberToString1(.1, "00.00"), "00.10", "numberToString1 prepends 2 leading 0s and appends 1 trailing 0 when format is 00.00 and number has 0 integral digits and 1 decimal digit");
+			equal($.ig.util.numberToString1(.1, "00.0#"), "00.1", "numberToString1 prepends 2 leading 0s and includes only significant decimal when format is 00.0# and number has 0 integral digits and 1 decimal digit");
+			equal($.ig.util.numberToString1(.19, "00.0#"), "00.19", "numberToString1 prepends 2 leading 0s and includes all significant decimals when format is 00.0# and number has 0 integral digits and 2 decimal digits");
+			equal($.ig.util.numberToString1(.1, "#"), "", "numberToString1 returns an empty string when format is # and number has 0 integral digits");
+			equal($.ig.util.numberToString1(1.1, "#"), "1", "numberToString1 truncates decimal portion when format is #");
+			equal($.ig.util.numberToString1(1.1, "0"), "1", "numberToString1 truncates decimal portion when format is 0");
+			equal($.ig.util.numberToString1(300, "0.#"), "300", "numberToString1 truncates decimal portion when format is 0.# and number has 0 decimal digits");
+		});
+	</script>
 </head>
 <body>
 	<div style="float:right;width:400px;overflow:auto;">

--- a/tests/unit/util/tests.html
+++ b/tests/unit/util/tests.html
@@ -27,245 +27,278 @@
     font-size: 18px;
 }
 </style>
-	<script type="text/javascript">		
-		module("igUtil Basic Tests");
-        // run tests
-		
-		test("Test getColType function",function(){
-			var result = $.ig.getColType(new Date());
-			equal(result, "date", "Check if result is correct for the object type.");
-			
-			result = $.ig.getColType(1);
-			equal(result, "number", "Check if result is correct for the object type.");
-			
-			result = $.ig.getColType("1");
-			equal(result, "string", "Check if result is correct for the object type.");
-			
-			result = $.ig.getColType(true);
-			equal(result, "bool", "Check if result is correct for the object type.");
-			
-			result = $.ig.getColType([1, 2, 3]);
-			equal(result, "object", "Check if result is correct for the object type.");
-			
-			result = $.ig.getColType(undefined);
-			equal(result, "string", "Check if result is correct for the object type.");			
-		});
+<script type="text/javascript">
+    module("igUtil Basic Tests");
+    // run tests
 
-		test("Test getRelativeOffset function", function () {
-			$("#container").append("<div class='container'><span id='span1' class='bottomleft'> Span elem</span><div>");
-			
-			$("#container").append("<div class='container'><div class='topright'><table id='table1'><tr><td>Table cell 1</td><td>Table cell 2</td></tr></table><div></div>");
-			
-			$("#container").append("<div  style='height: 500px;' class='container topright'><div class='bottomleft' style='position:static;'><span id='span2'  style='position:static;'>Span2</span></div></div>");
+    test("Test getColType function", function () {
+        var result = $.ig.getColType(new Date());
+        equal(result, "date", "Check if result is correct for the object type.");
 
-			//check getRelativeOffset with relative positioning of the parent
-			var relOffset = $.ig.util.getRelativeOffset($("#span1"));
-			ok($("#span1").parent().offset().left - $("#span1").parent().scrollLeft() === relOffset.left && $("#span1").parent().offset().top - $("#span1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
-			
-			//check getRelativeOffset with absolute positioning of the parent
-			relOffset = $.ig.util.getRelativeOffset($("#table1"));
-			ok($("#table1").parent().offset().left - $("#table1").parent().scrollLeft() === relOffset.left && $("#table1").parent().offset().top - $("#table1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
-			
-			//check getRelativeOffset with static positioning of the parent
-			relOffset = $.ig.util.getRelativeOffset($("#span2"));
-			ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
-		});
+        result = $.ig.getColType(1);
+        equal(result, "number", "Check if result is correct for the object type.");
 
-		test("Test defEnum", function () {
-			// simple non-flagged enum
-			equal(3, $.ig.DayOfWeek.prototype.wednesday, "Simple enum member - Access value via prototype");
-			equal("Wednesday", $.ig.DayOfWeek.prototype.getBox(3).toString(), "Simple enum member - ToString.");
-			equal("Wednesday", $.ig.Enum.prototype.parse($.ig.DayOfWeek.prototype.$type, "wednesday", true).toString(), "Simple enum member - Parse");
-			
-			// flagged enum
-			equal(111, $.ig.NumberStyles.prototype.number, "Simple flagged enum member - Access value via prototype");
-			equal(167, $.ig.NumberStyles.prototype.floatNumber, "Complex flagged enum member - Access value via prototype");
-			equal("Number", $.ig.NumberStyles.prototype.getBox(111).toString(), "Simple enum member - ToString.");
-			equal("Float", $.ig.NumberStyles.prototype.getBox(167).toString(), "Complex enum member - ToString.");
-			equal("Number", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "number", true).toString(), "Simple flagged enum member - Parse");
-			equal("Float", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "float", true).toString(), "Complex flagged enum member - Parse");
+        result = $.ig.getColType("1");
+        equal(result, "string", "Check if result is correct for the object type.");
 
-			// and some tests for public enums which differ in that the values are on the type instead of the prototype
-			$.ig.util.defEnum("TestPublicEnum", false, true, {
-				Foo: 0,
-				Bar: 1
-			});
+        result = $.ig.getColType(true);
+        equal(result, "bool", "Check if result is correct for the object type.");
 
-			equal(1, $.ig.TestPublicEnum.bar, "Simple public enum member - Access value via prototype");
-			equal("Bar", $.ig.TestPublicEnum.prototype.getBox(1).toString(), "Simple public enum member - ToString.");
-			equal("Bar", $.ig.Enum.prototype.parse($.ig.TestPublicEnum.prototype.$type, "bar", true).toString(), "Simple public enum member - Parse");
-		});
-		test("Test appendToQueryString and prependToQueryString util functions", function () {
-			var url = "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID";
-			var newUrl = $.ig.util.appendToQueryString(url, "additionalParam=1");
-			equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID&additionalParam=1", "Verify url is correct and the new param is appended.");
-			newUrl = $.ig.util.prependToQueryString (url, "('ALFKI')/Orders");
-			equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers('ALFKI')/Orders?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID","Verify url is correct and the new string is prepended.");
-		});
-		
-		test("Test calcSummaries function by specifying summary name", function () {
-			var data = [ 114601, 82742, 63895, 27186, 63198, 73758 ];
-			
-			//Min
-			equal($.ig.calcSummaries("min", data, null, "number"), 27186, "Function did determine the minimum number correctly");
-			equal($.ig.calcSummaries("min", [], null, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
-			equal($.ig.calcSummaries("min", [], null, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
+        result = $.ig.getColType([1, 2, 3]);
+        equal(result, "object", "Check if result is correct for the object type.");
 
-			//Max
-			equal($.ig.calcSummaries("max", data, null, "number"), 114601, "Max function did determine the minimum number correctly");
-			equal($.ig.calcSummaries("max", [], null, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
-			equal($.ig.calcSummaries("max", [], null, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
-			
-			//Sum
-			equal($.ig.calcSummaries("sum", data, null, "number"), 425380, "Sum function calculated the sum correctly");
-			equal($.ig.calcSummaries("sum", data), 425380, "Sum function calculated the sum correctly");
-			equal($.ig.calcSummaries("sum", [], null, "number"), 0, "Sum function return 0 when the array is empty");
-			
-			//Avg
-			equal($.ig.calcSummaries("avg", data, null, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
-			equal($.ig.calcSummaries("avg", data).toFixed(0), 70897, "Avg function calculated the average correctly");
-			equal($.ig.calcSummaries("avg", [], null, "number"), 0, "Avg function return 0 when the array is empty");
-			
-			//Count
-			equal($.ig.calcSummaries("count", data, null, "number"), 6, "Count function return the number of elements correctly");
-			equal($.ig.calcSummaries("count", [], null, "number"), 0, "Count function return 0 when the array is empty");
-		});
-		
-				
-		test("Test calcSummaries function by specifying summary function directly", function () {
-			var data = [ 114601, 82742, 63895, 27186, 63198, 73758 ];
-			
-			//Min
-			equal($.ig.calcSummaries("customMin", data, $.ig.util.summaries.min, "number"), 27186, "Function did determine the minimum number correctly");
-			equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
-			equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
+        result = $.ig.getColType(undefined);
+        equal(result, "string", "Check if result is correct for the object type.");
+    });
 
-			//Max
-			equal($.ig.calcSummaries("customMax", data, $.ig.util.summaries.max, "number"), 114601, "Max function did determine the minimum number correctly");
-			equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
-			equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
-			
-			//Sum
-			equal($.ig.calcSummaries("customSum", data, $.ig.util.summaries.sum, "number"), 425380, "Sum function calculated the sum correctly");
-			equal($.ig.calcSummaries("customSum", [], $.ig.util.summaries.sum), 0, "Sum function return 0 when the array is empty");
-			
-			//Avg
-			equal($.ig.calcSummaries("customAvg", data, $.ig.util.summaries.avg, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
-			equal($.ig.calcSummaries("customAvg", [], $.ig.util.summaries.avg, "number"), 0, "Avg function return 0 when the array is empty");
-			
-			//Count
-			equal($.ig.calcSummaries("custom", data, $.ig.util.summaries.count), 6, "Count function return the number of elements correctly");
-			equal($.ig.calcSummaries("custom", [], $.ig.util.summaries.count), 0, "Count function return 0 when the array is empty");
-			
-			equal($.ig.calcSummaries("random", [], $.ig.util.summaries.count), null, "Count function returns null when the summary name is not starting with custom");
-			equal($.ig.calcSummaries("custom", []), null, "Count function returns null when the custom summary function is not defined");
-		});
-		test("Test Complex Generic TypeArguments", function () {
-			var listNullInt = $.ig.IList$1.prototype.$type.specialize($.ig.Nullable$1.prototype.$type.specialize($.ig.Number.prototype.$type));
-			equal($.ig.Number.prototype.$type, listNullInt.typeArguments[0].typeArguments[0], "List<Nullable<int>>");
-		});
-		test("Test Date.toStringFormat", function() {
-			var dt = new Date("1980-10-11T12:00:00");
-			equal($.ig.Date.prototype.toStringFormat(dt, "MM/dd"), "10/11", "Date.toStringFormat formats MM/dd correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "MMM dd"), "Oct 11", "Date.toStringFormat formats MMM dd correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "MMM"), "Oct", "Date.toStringFormat formats MMM correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "yyyy"), "1980", "Date.toStringFormat formats yyyy correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "yy"), "80", "Date.toStringFormat formats yy correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "HH"), "12", "Date.toStringFormat formats HH correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "hh"), "12", "Date.toStringFormat formats hh correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "mm"), "00", "Date.toStringFormat formats mm correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "ss"), "00", "Date.toStringFormat formats ss correctly");	
-			equal($.ig.Date.prototype.toStringFormat(dt, "hh:mmtt"), "12:00PM", "Date.toStringFormat formats hh:mmtt correctly");	
-			equal($.ig.Date.prototype.toStringFormat(dt, "d"), "10/11/1980", "Date.toStringFormat formats d correctly");
-			// travis ci build doesn't seem to fully implement the part of toLocaleString where it infers the format based on the given options, causing several of these tests to fail. commenting for now.
-			// equal($.ig.Date.prototype.toStringFormat(dt, "D"), "Saturday, October 11, 1980", "Date.toStringFormat formats D correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "f"), "Saturday, October 11, 1980, 12:00 PM", "Date.toStringFormat formats f correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "F"), "Saturday, October 11, 1980, 12:00:00 PM", "Date.toStringFormat formats F correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "g"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats g correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "G"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats G correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "M"), "October 11", "Date.toStringFormat formats M correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "m"), "October 11", "Date.toStringFormat formats m correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "t"), "12:00 PM", "Date.toStringFormat formats t correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "T"), "12:00:00 PM", "Date.toStringFormat formats T correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "y"), "October 1980", "Date.toStringFormat formats y correctly");
-			// equal($.ig.Date.prototype.toStringFormat(dt, "Y"), "October 1980", "Date.toStringFormat formats Y correctly");
-			equal($.ig.Date.prototype.toStringFormat(dt, "hh:mm:ss:ff"), "12:00:00:00", "Date.toStringFormat formats hh:mm:ss:ff correctly");
-		});
+    test("Test getRelativeOffset function", function () {
+        $("#container").append("<div class='container'><span id='span1' class='bottomleft'> Span elem</span><div>");
 
-		test("Test IsAssignableFrom", function () {
-		    // type itself
-		    ok($.ig.Enum.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum type");
+        $("#container").append("<div class='container'><div class='topright'><table id='table1'><tr><td>Table cell 1</td><td>Table cell 2</td></tr></table><div></div>");
 
-		    // base type
-		    ok($.ig.IEnumerable.prototype.$type.isAssignableFrom($.ig.IList.prototype.$type), "Base type of IList is IEnumerable");
+        $("#container").append("<div  style='height: 500px;' class='container topright'><div class='bottomleft' style='position:static;'><span id='span2'  style='position:static;'>Span2</span></div></div>");
 
-		    // interfaces
-		    ok($.ig.IConvertible.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum implements IConvertible");
-		    ok($.ig.IComparable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IComparable<Int32>");
-		    ok($.ig.IEquatable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IEquatable<Int32>");
-		});
+        //check getRelativeOffset with relative positioning of the parent
+        var relOffset = $.ig.util.getRelativeOffset($("#span1"));
+        ok($("#span1").parent().offset().left - $("#span1").parent().scrollLeft() === relOffset.left && $("#span1").parent().offset().top - $("#span1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
 
-		test("Test stringCompare2", function () {
-			var c = $.ig.CultureInfo.prototype.currentCulture();
-			var o = $.ig.CompareOptions.prototype.none;
-			
-		    equal($.ig.util.stringCompare2("A", "B", c, o), -1, "A before B");
-		    equal($.ig.util.stringCompare2("B", "A", c, o), 1, "B before A");
-		    equal($.ig.util.stringCompare2("A", "A", c, o), 0, "A === A");
-		    equal($.ig.util.stringCompare2(null, "A", c, o), -1, "null befoe A");
-		    equal($.ig.util.stringCompare2("A", null, c, o), 1, "A after null");
-		    equal($.ig.util.stringCompare2(null, "", c, o), -1, "null before empty");
-		    equal($.ig.util.stringCompare2("", null, c, o), 1, "empty after null");
-		});
+        //check getRelativeOffset with absolute positioning of the parent
+        relOffset = $.ig.util.getRelativeOffset($("#table1"));
+        ok($("#table1").parent().offset().left - $("#table1").parent().scrollLeft() === relOffset.left && $("#table1").parent().offset().top - $("#table1").parent().scrollTop() === relOffset.top, "The element offset should be correct.");
 
-		test("Test trimStart", function () {
-		    equal("  ABC  ".trimStart(), "ABC  ", "No arguments");
-		    equal("  ABC  ".trimStart([]), "ABC  ", "Empty array argument");
-		    equal("  ABC  ".trimStart([' ']), "ABC  ", "Explicit space argument");
-		    equal("aa  ABC  aa".trimStart(['a']), "  ABC  aa", "Nonstandard trim character");
-		    equal("aa  ABC  aa".trimStart('a'), "  ABC  aa", "character only");
-		    equal("aa  ABC  aa".trimStart('a', ' '), "ABC  aa", "Multiple characters only");
-		});
+        //check getRelativeOffset with static positioning of the parent
+        relOffset = $.ig.util.getRelativeOffset($("#span2"));
+        ok($("#span2").parent().parent().offset().left - $("#span2").parent().parent().scrollLeft() === relOffset.left && $("#span2").parent().parent().offset().top - $("#span2").parent().parent().scrollTop() === relOffset.top, "The element offset should be correct.");
+    });
 
-		test("Test trimEnd", function () {
-		    equal("  ABC  ".trimEnd(), "  ABC", "No arguments");
-		    equal("  ABC  ".trimEnd([]), "  ABC", "Empty array argument");
-		    equal("  ABC  ".trimEnd([' ']), "  ABC", "Explicit space argument");
-		    equal("aa  ABC  aa".trimEnd(['a']), "aa  ABC  ", "Nonstandard trim character");
-		    equal("aa  ABC  aa".trimEnd('a'), "aa  ABC  ", "character only");
-		    equal("aa  ABC  aa".trimEnd('a', ' '), "aa  ABC", "Multiple characters only");
-		});
+    test("Test defEnum", function () {
+        // simple non-flagged enum
+        equal(3, $.ig.DayOfWeek.prototype.wednesday, "Simple enum member - Access value via prototype");
+        equal("Wednesday", $.ig.DayOfWeek.prototype.getBox(3).toString(), "Simple enum member - ToString.");
+        equal("Wednesday", $.ig.Enum.prototype.parse($.ig.DayOfWeek.prototype.$type, "wednesday", true).toString(), "Simple enum member - Parse");
 
-		test("Test $.ig.encode", function () {
-			equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
-			equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");
-			equal($.ig.encode("<span id='span1'></span>"), "&lt;span id=&#39;span1&#39;&gt;&lt;/span&gt;", "Should encode span element with attribute and single quote");
-			equal($.ig.encode("<span id=\"span1\"></span>"), "&lt;span id=&#34;span1&#34;&gt;&lt;/span&gt;", "Should encode span element with attribute and double quote")
-		});
-		
-		test("Test $.ig.util.stringToColor", function () {
-			deepEqual($.ig.util.stringToColor(null), { a: 0, r: 0, g: 0, b: 0 }, "Passing null to stringToColor should return transparent.");
-			deepEqual($.ig.util.stringToColor("papayawhip"), { a: 255, r: 255, g: 239, b: 213 }, "Passing papayawhip to stringToColor should look as delicious as whipped papaya.");
-			deepEqual($.ig.util.stringToColor("rgba(13, 14, 15, 0.2)"), { r: 13, g: 14, b: 15, a: 51 }, "Passing rgba(13, 14, 15, 16) to stringToColor should return that color.");
-			deepEqual($.ig.util.stringToColor("rgb(13, 14, 15)"), { a: 255, r: 13, g: 14, b: 15 }, "Passing rgb(13, 14, 15) to stringToColor should return that color.");
-			deepEqual($.ig.util.stringToColor("#beefed"), { a: 255, r: 190, g: 239, b: 237 }, "Passing #beefed to stringToColor should return a nice pale cyan color.");
-			deepEqual($.ig.util.stringToColor("#def"), { a: 255, r: 221, g: 238, b: 255 }, "Passing #def to stringToColor should return a nice pale lavender color.");
-		});
-		test("Test numberToString", function() {
-			equal($.ig.util.numberToString1(Math.PI, "0"), "3", "numberToString1 truncates all decimals when format is 0");   
-			equal($.ig.util.numberToString1(Math.PI, "0.0"), "3.1", "numberToString1 truncates to 1 decimal place when format is 0.0 and 2nd decimal place rounds down");
-			equal($.ig.util.numberToString1(Math.PI, "00"), "03", "numberToString1 truncates all decimals and prepends leading 0 when format is 00 and number integral part has 1 digit");
-			equal($.ig.util.numberToString1(Math.PI, "00.00"), "03.14", "numberToString1 truncates to 2 decimal places and prepends leading 0 when format is 00.00 and number integral part has 1 digit and 3rd decimal place rounds down");
-			equal($.ig.util.numberToString1(Math.PI, "0.000"), "3.142", "numberToString1 rounds up when format is 0.000 and 4th decimal place rounds up");
-			equal($.ig.util.numberToString1(.1, "00.00"), "00.10", "numberToString1 prepends 2 leading 0s and appends 1 trailing 0 when format is 00.00 and number has 0 integral digits and 1 decimal digit");
-			equal($.ig.util.numberToString1(.1, "00.0#"), "00.1", "numberToString1 prepends 2 leading 0s and includes only significant decimal when format is 00.0# and number has 0 integral digits and 1 decimal digit");
-			equal($.ig.util.numberToString1(.19, "00.0#"), "00.19", "numberToString1 prepends 2 leading 0s and includes all significant decimals when format is 00.0# and number has 0 integral digits and 2 decimal digits");
-			equal($.ig.util.numberToString1(.1, "#"), "", "numberToString1 returns an empty string when format is # and number has 0 integral digits");
-			equal($.ig.util.numberToString1(1.1, "#"), "1", "numberToString1 truncates decimal portion when format is #");
-			equal($.ig.util.numberToString1(1.1, "0"), "1", "numberToString1 truncates decimal portion when format is 0");
-			equal($.ig.util.numberToString1(300, "0.#"), "300", "numberToString1 truncates decimal portion when format is 0.# and number has 0 decimal digits");
-		});
-	</script>
+        // flagged enum
+        equal(111, $.ig.NumberStyles.prototype.number, "Simple flagged enum member - Access value via prototype");
+        equal(167, $.ig.NumberStyles.prototype.floatNumber, "Complex flagged enum member - Access value via prototype");
+        equal("Number", $.ig.NumberStyles.prototype.getBox(111).toString(), "Simple enum member - ToString.");
+        equal("Float", $.ig.NumberStyles.prototype.getBox(167).toString(), "Complex enum member - ToString.");
+        equal("Number", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "number", true).toString(), "Simple flagged enum member - Parse");
+        equal("Float", $.ig.Enum.prototype.parse($.ig.NumberStyles.prototype.$type, "float", true).toString(), "Complex flagged enum member - Parse");
+
+        // and some tests for public enums which differ in that the values are on the type instead of the prototype
+        $.ig.util.defEnum("TestPublicEnum", false, true, {
+            Foo: 0,
+            Bar: 1
+        });
+
+        equal(1, $.ig.TestPublicEnum.bar, "Simple public enum member - Access value via prototype");
+        equal("Bar", $.ig.TestPublicEnum.prototype.getBox(1).toString(), "Simple public enum member - ToString.");
+        equal("Bar", $.ig.Enum.prototype.parse($.ig.TestPublicEnum.prototype.$type, "bar", true).toString(), "Simple public enum member - Parse");
+    });
+
+    test("Test getDate", function () {
+        var hoursArray = [ 1, 5 ];
+        var hoursSuffix = [" - before", " - after"];
+
+        for (var i = 0; i < hoursArray.length; i++) {
+            var hour = hoursArray[i];
+            var suffix = hoursSuffix[i];
+
+            // test some dst dates with a time after the change
+            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour)).getHours(), "Hours of US daylight savings start" + suffix);
+            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour)).getHours(), "Hours 0f BG daylight savings start" + suffix);
+            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour)).getHours(), "Hours of US daylight savings end" + suffix);
+            equal(0, $.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour)).getHours(), "Hours of BG daylight savings end" + suffix);
+
+            equal(11, $.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour)).getDate(), "getDate of US daylight savings start" + suffix);
+            equal(25, $.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour)).getDate(), "getDate of BG daylight savings start" + suffix);
+            equal(11, $.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour)).getDate(), "getDate of US daylight savings end" + suffix);
+            equal(28, $.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour)).getDate(), "getDate of BG daylight savings end" + suffix);
+
+            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 2, 11, hour))), "getTimeOfDay of US daylight savings start" + suffix);
+            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 2, 25, hour))), "getTimeOfDay 0f BG daylight savings start" + suffix);
+            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 10, 11, hour))), "getTimeOfDay of US daylight savings end" + suffix);
+            equal(0, $.ig.Date.prototype.getTimeOfDay($.ig.Date.prototype.getDate(new Date(2018, 9, 28, hour))), "getTimeOfDay of BG daylight savings end" + suffix);
+        }
+
+        var dateWithTime = $.ig.Date.prototype.getDate(new Date(2018, 2, 11, 23, 25, 15, 19));
+        equal(0, dateWithTime.getHours(), "Hours of Date with time");
+        equal(0, dateWithTime.getMinutes(), "Minutes of Date with time");
+        equal(0, dateWithTime.getSeconds(), "Seconds of Date with time");
+        equal(0, dateWithTime.getMilliseconds(), "Milliseconds of Date with time");
+        equal(0, $.ig.Date.prototype.getTimeOfDay(dateWithTime), "getTimeOfDay of Date with time");
+    });
+    test("Test appendToQueryString and prependToQueryString util functions", function () {
+        var url = "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID";
+        var newUrl = $.ig.util.appendToQueryString(url, "additionalParam=1");
+        equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID&additionalParam=1", "Verify url is correct and the new param is appended.");
+        newUrl = $.ig.util.prependToQueryString(url, "('ALFKI')/Orders");
+        equal(newUrl, "http://services.odata.org/V2/Northwind/Northwind.svc/Customers('ALFKI')/Orders?$format=json&%24skip=0&%24top=25&%24inlinecount=allpages&dbdepth=0&pk=CustomerID", "Verify url is correct and the new string is prepended.");
+    });
+
+    test("Test calcSummaries function by specifying summary name", function () {
+        var data = [114601, 82742, 63895, 27186, 63198, 73758];
+
+        //Min
+        equal($.ig.calcSummaries("min", data, null, "number"), 27186, "Function did determine the minimum number correctly");
+        equal($.ig.calcSummaries("min", [], null, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
+        equal($.ig.calcSummaries("min", [], null, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
+
+        //Max
+        equal($.ig.calcSummaries("max", data, null, "number"), 114601, "Max function did determine the minimum number correctly");
+        equal($.ig.calcSummaries("max", [], null, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
+        equal($.ig.calcSummaries("max", [], null, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
+
+        //Sum
+        equal($.ig.calcSummaries("sum", data, null, "number"), 425380, "Sum function calculated the sum correctly");
+        equal($.ig.calcSummaries("sum", data), 425380, "Sum function calculated the sum correctly");
+        equal($.ig.calcSummaries("sum", [], null, "number"), 0, "Sum function return 0 when the array is empty");
+
+        //Avg
+        equal($.ig.calcSummaries("avg", data, null, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
+        equal($.ig.calcSummaries("avg", data).toFixed(0), 70897, "Avg function calculated the average correctly");
+        equal($.ig.calcSummaries("avg", [], null, "number"), 0, "Avg function return 0 when the array is empty");
+
+        //Count
+        equal($.ig.calcSummaries("count", data, null, "number"), 6, "Count function return the number of elements correctly");
+        equal($.ig.calcSummaries("count", [], null, "number"), 0, "Count function return 0 when the array is empty");
+    });
+
+
+    test("Test calcSummaries function by specifying summary function directly", function () {
+        var data = [114601, 82742, 63895, 27186, 63198, 73758];
+
+        //Min
+        equal($.ig.calcSummaries("customMin", data, $.ig.util.summaries.min, "number"), 27186, "Function did determine the minimum number correctly");
+        equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "number"), 0, "Min return 0 when the data is empty and dataType is 'number'");
+        equal($.ig.calcSummaries("customMin", [], $.ig.util.summaries.min, "date"), null, "Min returns null when the data is empty and dataType is 'date'");
+
+        //Max
+        equal($.ig.calcSummaries("customMax", data, $.ig.util.summaries.max, "number"), 114601, "Max function did determine the minimum number correctly");
+        equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "number"), 0, "Max return 0 when the data is empty and dataType is 'number'");
+        equal($.ig.calcSummaries("customMax", [], $.ig.util.summaries.max, "date"), null, "Max returns null when the data is empty and dataType is 'date'");
+
+        //Sum
+        equal($.ig.calcSummaries("customSum", data, $.ig.util.summaries.sum, "number"), 425380, "Sum function calculated the sum correctly");
+        equal($.ig.calcSummaries("customSum", [], $.ig.util.summaries.sum), 0, "Sum function return 0 when the array is empty");
+
+        //Avg
+        equal($.ig.calcSummaries("customAvg", data, $.ig.util.summaries.avg, "number").toFixed(0), 70897, "Avg function calculated the average correctly");
+        equal($.ig.calcSummaries("customAvg", [], $.ig.util.summaries.avg, "number"), 0, "Avg function return 0 when the array is empty");
+
+        //Count
+        equal($.ig.calcSummaries("custom", data, $.ig.util.summaries.count), 6, "Count function return the number of elements correctly");
+        equal($.ig.calcSummaries("custom", [], $.ig.util.summaries.count), 0, "Count function return 0 when the array is empty");
+
+        equal($.ig.calcSummaries("random", [], $.ig.util.summaries.count), null, "Count function returns null when the summary name is not starting with custom");
+        equal($.ig.calcSummaries("custom", []), null, "Count function returns null when the custom summary function is not defined");
+    });
+    test("Test Complex Generic TypeArguments", function () {
+        var listNullInt = $.ig.IList$1.prototype.$type.specialize($.ig.Nullable$1.prototype.$type.specialize($.ig.Number.prototype.$type));
+        equal($.ig.Number.prototype.$type, listNullInt.typeArguments[0].typeArguments[0], "List<Nullable<int>>");
+    });
+    test("Test Date.toStringFormat", function () {
+        var dt = new Date("1980-10-11T12:00:00");
+        equal($.ig.Date.prototype.toStringFormat(dt, "MM/dd"), "10/11", "Date.toStringFormat formats MM/dd correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "MMM dd"), "Oct 11", "Date.toStringFormat formats MMM dd correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "MMM"), "Oct", "Date.toStringFormat formats MMM correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "yyyy"), "1980", "Date.toStringFormat formats yyyy correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "yy"), "80", "Date.toStringFormat formats yy correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "HH"), "12", "Date.toStringFormat formats HH correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "hh"), "12", "Date.toStringFormat formats hh correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "mm"), "00", "Date.toStringFormat formats mm correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "ss"), "00", "Date.toStringFormat formats ss correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "hh:mmtt"), "12:00PM", "Date.toStringFormat formats hh:mmtt correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "d"), "10/11/1980", "Date.toStringFormat formats d correctly");
+        // travis ci build doesn't seem to fully implement the part of toLocaleString where it infers the format based on the given options, causing several of these tests to fail. commenting for now.
+        // equal($.ig.Date.prototype.toStringFormat(dt, "D"), "Saturday, October 11, 1980", "Date.toStringFormat formats D correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "f"), "Saturday, October 11, 1980, 12:00 PM", "Date.toStringFormat formats f correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "F"), "Saturday, October 11, 1980, 12:00:00 PM", "Date.toStringFormat formats F correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "g"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats g correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "G"), "10/11/1980, 12:00:00 PM", "Date.toStringFormat formats G correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "M"), "October 11", "Date.toStringFormat formats M correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "m"), "October 11", "Date.toStringFormat formats m correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "t"), "12:00 PM", "Date.toStringFormat formats t correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "T"), "12:00:00 PM", "Date.toStringFormat formats T correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "y"), "October 1980", "Date.toStringFormat formats y correctly");
+        // equal($.ig.Date.prototype.toStringFormat(dt, "Y"), "October 1980", "Date.toStringFormat formats Y correctly");
+        equal($.ig.Date.prototype.toStringFormat(dt, "hh:mm:ss:ff"), "12:00:00:00", "Date.toStringFormat formats hh:mm:ss:ff correctly");
+    });
+
+    test("Test IsAssignableFrom", function () {
+        // type itself
+        ok($.ig.Enum.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum type");
+
+        // base type
+        ok($.ig.IEnumerable.prototype.$type.isAssignableFrom($.ig.IList.prototype.$type), "Base type of IList is IEnumerable");
+
+        // interfaces
+        ok($.ig.IConvertible.prototype.$type.isAssignableFrom($.ig.Enum.prototype.$type), "Enum implements IConvertible");
+        ok($.ig.IComparable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IComparable<Int32>");
+        ok($.ig.IEquatable$1.prototype.$type.specialize($.ig.Int32.prototype.$type).isAssignableFrom($.ig.Int32.prototype.$type), "Int32 implements IEquatable<Int32>");
+    });
+
+    test("Test stringCompare2", function () {
+        var c = $.ig.CultureInfo.prototype.currentCulture();
+        var o = $.ig.CompareOptions.prototype.none;
+
+        equal($.ig.util.stringCompare2("A", "B", c, o), -1, "A before B");
+        equal($.ig.util.stringCompare2("B", "A", c, o), 1, "B before A");
+        equal($.ig.util.stringCompare2("A", "A", c, o), 0, "A === A");
+        equal($.ig.util.stringCompare2(null, "A", c, o), -1, "null befoe A");
+        equal($.ig.util.stringCompare2("A", null, c, o), 1, "A after null");
+        equal($.ig.util.stringCompare2(null, "", c, o), -1, "null before empty");
+        equal($.ig.util.stringCompare2("", null, c, o), 1, "empty after null");
+    });
+
+    test("Test trimStart", function () {
+        equal("  ABC  ".trimStart(), "ABC  ", "No arguments");
+        equal("  ABC  ".trimStart([]), "ABC  ", "Empty array argument");
+        equal("  ABC  ".trimStart([' ']), "ABC  ", "Explicit space argument");
+        equal("aa  ABC  aa".trimStart(['a']), "  ABC  aa", "Nonstandard trim character");
+        equal("aa  ABC  aa".trimStart('a'), "  ABC  aa", "character only");
+        equal("aa  ABC  aa".trimStart('a', ' '), "ABC  aa", "Multiple characters only");
+    });
+
+    test("Test trimEnd", function () {
+        equal("  ABC  ".trimEnd(), "  ABC", "No arguments");
+        equal("  ABC  ".trimEnd([]), "  ABC", "Empty array argument");
+        equal("  ABC  ".trimEnd([' ']), "  ABC", "Explicit space argument");
+        equal("aa  ABC  aa".trimEnd(['a']), "aa  ABC  ", "Nonstandard trim character");
+        equal("aa  ABC  aa".trimEnd('a'), "aa  ABC  ", "character only");
+        equal("aa  ABC  aa".trimEnd('a', ' '), "aa  ABC", "Multiple characters only");
+    });
+
+    test("Test $.ig.encode", function () {
+        equal($.ig.encode("<div></div>"), "&lt;div&gt;&lt;/div&gt;", "Should encode div element");
+        equal($.ig.encode("&lt;div&gt;&lt;/div&gt;"), "&amp;lt;div&amp;gt;&amp;lt;/div&amp;gt;", "Should encode encoded div element");
+        equal($.ig.encode("<span id='span1'></span>"), "&lt;span id=&#39;span1&#39;&gt;&lt;/span&gt;", "Should encode span element with attribute and single quote");
+        equal($.ig.encode("<span id=\"span1\"></span>"), "&lt;span id=&#34;span1&#34;&gt;&lt;/span&gt;", "Should encode span element with attribute and double quote")
+    });
+
+    test("Test $.ig.util.stringToColor", function () {
+        deepEqual($.ig.util.stringToColor(null), { a: 0, r: 0, g: 0, b: 0 }, "Passing null to stringToColor should return transparent.");
+        deepEqual($.ig.util.stringToColor("papayawhip"), { a: 255, r: 255, g: 239, b: 213 }, "Passing papayawhip to stringToColor should look as delicious as whipped papaya.");
+        deepEqual($.ig.util.stringToColor("rgba(13, 14, 15, 0.2)"), { r: 13, g: 14, b: 15, a: 51 }, "Passing rgba(13, 14, 15, 16) to stringToColor should return that color.");
+        deepEqual($.ig.util.stringToColor("rgb(13, 14, 15)"), { a: 255, r: 13, g: 14, b: 15 }, "Passing rgb(13, 14, 15) to stringToColor should return that color.");
+        deepEqual($.ig.util.stringToColor("#beefed"), { a: 255, r: 190, g: 239, b: 237 }, "Passing #beefed to stringToColor should return a nice pale cyan color.");
+        deepEqual($.ig.util.stringToColor("#def"), { a: 255, r: 221, g: 238, b: 255 }, "Passing #def to stringToColor should return a nice pale lavender color.");
+    });
+    test("Test numberToString", function () {
+        equal($.ig.util.numberToString1(Math.PI, "0"), "3", "numberToString1 truncates all decimals when format is 0");
+        equal($.ig.util.numberToString1(Math.PI, "0.0"), "3.1", "numberToString1 truncates to 1 decimal place when format is 0.0 and 2nd decimal place rounds down");
+        equal($.ig.util.numberToString1(Math.PI, "00"), "03", "numberToString1 truncates all decimals and prepends leading 0 when format is 00 and number integral part has 1 digit");
+        equal($.ig.util.numberToString1(Math.PI, "00.00"), "03.14", "numberToString1 truncates to 2 decimal places and prepends leading 0 when format is 00.00 and number integral part has 1 digit and 3rd decimal place rounds down");
+        equal($.ig.util.numberToString1(Math.PI, "0.000"), "3.142", "numberToString1 rounds up when format is 0.000 and 4th decimal place rounds up");
+        equal($.ig.util.numberToString1(.1, "00.00"), "00.10", "numberToString1 prepends 2 leading 0s and appends 1 trailing 0 when format is 00.00 and number has 0 integral digits and 1 decimal digit");
+        equal($.ig.util.numberToString1(.1, "00.0#"), "00.1", "numberToString1 prepends 2 leading 0s and includes only significant decimal when format is 00.0# and number has 0 integral digits and 1 decimal digit");
+        equal($.ig.util.numberToString1(.19, "00.0#"), "00.19", "numberToString1 prepends 2 leading 0s and includes all significant decimals when format is 00.0# and number has 0 integral digits and 2 decimal digits");
+        equal($.ig.util.numberToString1(.1, "#"), "", "numberToString1 returns an empty string when format is # and number has 0 integral digits");
+        equal($.ig.util.numberToString1(1.1, "#"), "1", "numberToString1 truncates decimal portion when format is #");
+        equal($.ig.util.numberToString1(1.1, "0"), "1", "numberToString1 truncates decimal portion when format is 0");
+        equal($.ig.util.numberToString1(300, "0.#"), "300", "numberToString1 truncates decimal portion when format is 0.# and number has 0 decimal digits");
+    });
+</script>
 </head>
 <body>
 	<div style="float:right;width:400px;overflow:auto;">


### PR DESCRIPTION
The getDate method is meant to return a Date based on the specified date but excluding time portion. The previous implementation was incorrectly adjusting based on the time of that date as obtained using getHours/Minutes/Seconds/Milliseconds but on a date where the daylight savings time has shifted that might result in a date with 11pm of the prior day or 1am of the date.
