### PR TITLE
Update npm deploy tag 17.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_deploy:
 
 # update package versions
 - npm version "${TRAVIS_TAG}" --no-git-tag-version --save
+- if [[ "${TRAVIS_TAG}" == *"beta"* ]]; then export NPM_TAG="next"; else export NPM_TAG="latest"; fi
 # can't skip git commit on bower version call, bower/bower#2019
 # - bower version "${TRAVIS_TAG}" --save
 
@@ -37,6 +38,7 @@ before_deploy:
 
 deploy:
   provider: npm
+  tag: ${NPM_TAG}
   skip_cleanup: true
   email: igniteui@infragistics.com
   api_key:


### PR DESCRIPTION
When the release is tagged as "beta" the respective npm package will now also be tagged as `@next`.

Applying change from #1680
