### PR TITLE
Fixing an issue with the sorting function of the igUtil getFlaggedName() method

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -913,7 +913,9 @@
 				}
 			}
 
-			values.sort(function (a, b) { return this[ a ] - this[ b ]; });
+			//P.M. April 30th, 2018 Caching 'this' so that it does not point to the Window and sorting is done on the values array
+			var _self = this;
+			values.sort(function (a, b) { return _self[ a ] - _self[ b ]; });
 
 			for (var i = values.length - 1; i >= 0; i--) {
 				value = this[ values[ i ] ];


### PR DESCRIPTION
Fix of the igUtil sorting function in the getFlaggedName() method, so that the sorting is done on the array itself instead on the Window. 
This issue was discovered while running the igUtil tests. As a result of the incorrect sorting the defEnum test was failing when parsing 'number'.