### PR TITLE
1752 - IgValidator `temporaryUrl` code snippet fix

### DIFF
--- a/src/js/modules/infragistics.ui.dialog.js
+++ b/src/js/modules/infragistics.ui.dialog.js
@@ -736,7 +736,10 @@
 				});
 
 				//Get
-				var url = $(".selector").igDialog("option", "http://infragistics.com");
+				var url = $(".selector").igDialog("option", "temporaryUrl");
+
+				//Set
+				$(".selector").igDialog("option", "temporaryUrl", "http://infragistics.com");
 				```
 			*/
 			temporaryUrl: null,


### PR DESCRIPTION
Closes #1752  

Adjust the code snippet in igValidator for get/set `temporaryUrl` option

