### PR TITLE
1754 - Hide scrollbar during editor drop down animation

### DIFF
--- a/src/css/structure/modules/infragistics.ui.editors.css
+++ b/src/css/structure/modules/infragistics.ui.editors.css
@@ -83,6 +83,11 @@
 	  box-sizing: border-box;
 }
 
+/* V.S. Aug 16th, 2018 #1754: Hide dropdown scrollbar during animation when using jQuery UI ver < 1.12.1 */
+.ui-effects-wrapper > .ui-igedit-dropdown {
+	overflow-y: hidden;
+}
+
 /* Styles copied from combo control adapted for igedit-dropdown */
 
 .ui-igedit-dropdown-orientation-top {


### PR DESCRIPTION
Closes #1754

Editor drop down will have overflow hidden during animation in jQueryUI versions prior 1.12.1
Issues #1754 is not reproducible with jQueryUI animations in version 1.12.1
