### PR TITLE
1724 - igTree - Node no longer executes html-encoded scripts on drag

### DIFF
--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -2091,7 +2091,7 @@
 				helper = dragAndDropSettings.helper === "default" ? function (event) {
 					var target = $(event.target).closest("li[data-role=node]"),
 						markup = $(self.options.dragAndDropSettings.invalidMoveToMarkup
-						.replace("{0}", target.children("a").text()));
+						.replace("{0}", target.children("a").html()));
 					markup.addClass(self.css.invalidDropIndicator)
 						.find("span")
 						.addClass(self.css.invalidMoveMarkupIcon);
@@ -2183,10 +2183,10 @@
 			if ((target.is("a") || target.closest("a").parent().is("li[data-role=node]")) &&
 				this._validationObject.valid) {
 				if (copy) {
-					markup = $(this.options.dragAndDropSettings.copyToMarkup.replace("{0}", target.text()));
+					markup = $(this.options.dragAndDropSettings.copyToMarkup.replace("{0}", target.html()));
 					markup.find("span").addClass(this.css.copyMarkupIcon);
 				} else {
-					markup = $(this.options.dragAndDropSettings.moveToMarkup.replace("{0}", target.text()));
+					markup = $(this.options.dragAndDropSettings.moveToMarkup.replace("{0}", target.html()));
 					markup.find("span").addClass(this.css.moveMarkupIcon);
 				}
 				this._helper = markup.html();
@@ -2201,24 +2201,24 @@
 					if (copy) {
 						if (target.next("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.copyBetweenMarkup.replace("{0}", target
-								.children("a").text()).replace("{1}",
-								target.next("li[data-role=node]").children("a").text()));
+								.children("a").html()).replace("{1}",
+								target.next("li[data-role=node]").children("a").html()));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.copyAfterMarkup.replace(
-										"{0}", target.children("a").text()
+										"{0}", target.children("a").html()
 									));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						}
 					} else {
 						if (target.next("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.moveBetweenMarkup.replace("{0}", target
-								.children("a").text()).replace("{1}", target
-								.next("li[data-role=node]").children("a").text()));
+								.children("a").html()).replace("{1}", target
+								.next("li[data-role=node]").children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.moveAfterMarkup
-								.replace("{0}", target.children("a").text()));
+								.replace("{0}", target.children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						}
 					}
@@ -2232,25 +2232,25 @@
 					if (copy) {
 						if (target.prev("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.copyBetweenMarkup
-								.replace("{0}", target.children("a").text())
+								.replace("{0}", target.children("a").html())
 								.replace("{1}", target.prev("li[data-role=node]")
-								.children("a").text()));
+								.children("a").html()));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.copyBeforeMarkup
-								.replace("{0}", target.children("a").text()));
+								.replace("{0}", target.children("a").html()));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						}
 					} else {
 						if (target.prev("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.moveBetweenMarkup
 								.replace("{0}", target.prev("li[data-role=node]")
-								.children("a").text())
-								.replace("{1}", target.children("a").text()));
+								.children("a").html())
+								.replace("{1}", target.children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.moveBeforeMarkup
-								.replace("{0}", target.children("a").text()));
+								.replace("{0}", target.children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						}
 					}

--- a/tests/unit/tree/tree-test.js
+++ b/tests/unit/tree/tree-test.js
@@ -4687,6 +4687,34 @@ QUnit.test("[Add/Remove nodes 08] igTree simulate drag events", function (assert
 		throw er;
 	});
 });
+QUnit.test("[Add/Remove nodes 14] Drag and Drop node header with script tag", function (assert) {
+	assert.expect(1);
+	delete window.testVarDragAndDrop;
+	window.testVarDragAndDrop = 0;
+	var path = "0",
+		data = [
+		{ "Text": "Item1", "Value": "Item1" },
+		{ "Text": "Item2", "Value": "Item2" },
+		{ "Text": "&#x3C;script&#x3E;debugger;window.testVar++;&#x3C;/script&#x3E;", "Value": "Item3"},
+		{ "Text": "Item4", "Value": "Item4"}, 
+		{ "Text": "Item5", "Value": "Item5"}
+	],
+		$container = this.util.appendToFixture(this.divTag)
+			.igTree({
+				dragAndDrop : true,
+                bindings: {
+                    textKey: 'Text',
+                    valueKey: 'Value'
+                },
+                dataSource: data
+			}),
+		node = $container.igTree("nodeByPath", "2");
+	this.simulateDragStart(node);
+	this.simulateDrag(node, $container.igTree("nodeByPath", "1"));
+	this.simulateDragStop(node);
+	assert.equal(window.testVarDragAndDrop, 0, "The script in the node was executed");
+	delete window.testVarDragAndDrop;
+});
 QUnit.test("[Add/Remove nodes 09] igTree setOption methods", function (assert) {
 	assert.expect(39);
 

--- a/tests/unit/tree/tree-test.js
+++ b/tests/unit/tree/tree-test.js
@@ -4695,7 +4695,7 @@ QUnit.test("[Add/Remove nodes 14] Drag and Drop node header with script tag", fu
 		data = [
 		{ "Text": "Item1", "Value": "Item1" },
 		{ "Text": "Item2", "Value": "Item2" },
-		{ "Text": "&#x3C;script&#x3E;debugger;window.testVar++;&#x3C;/script&#x3E;", "Value": "Item3"},
+		{ "Text": "&#x3C;script&#x3E;window.testVarDragAndDrop++;&#x3C;/script&#x3E;", "Value": "Item3"},
 		{ "Text": "Item4", "Value": "Item4"}, 
 		{ "Text": "Item5", "Value": "Item5"}
 	],


### PR DESCRIPTION
Closes #1724

If an html-encoded script tag is passed as node name, the script was executed on drag/hover because hover helper markup was set with `$.text()` instead of `$.html()`. All markup assignments are now done with `$.html()` so jQuery handles escaping; 

