### PR TITLE
1724 - igTree - Node no longer executes html-encoded scripts on drag - 18.1

### DIFF
--- a/src/js/modules/infragistics.ui.tree.js
+++ b/src/js/modules/infragistics.ui.tree.js
@@ -2091,7 +2091,7 @@
 				helper = dragAndDropSettings.helper === "default" ? function (event) {
 					var target = $(event.target).closest("li[data-role=node]"),
 						markup = $(self.options.dragAndDropSettings.invalidMoveToMarkup
-						.replace("{0}", target.children("a").text()));
+						.replace("{0}", target.children("a").html()));
 					markup.addClass(self.css.invalidDropIndicator)
 						.find("span")
 						.addClass(self.css.invalidMoveMarkupIcon);
@@ -2183,10 +2183,10 @@
 			if ((target.is("a") || target.closest("a").parent().is("li[data-role=node]")) &&
 				this._validationObject.valid) {
 				if (copy) {
-					markup = $(this.options.dragAndDropSettings.copyToMarkup.replace("{0}", target.text()));
+					markup = $(this.options.dragAndDropSettings.copyToMarkup.replace("{0}", target.html()));
 					markup.find("span").addClass(this.css.copyMarkupIcon);
 				} else {
-					markup = $(this.options.dragAndDropSettings.moveToMarkup.replace("{0}", target.text()));
+					markup = $(this.options.dragAndDropSettings.moveToMarkup.replace("{0}", target.html()));
 					markup.find("span").addClass(this.css.moveMarkupIcon);
 				}
 				this._helper = markup.html();
@@ -2201,24 +2201,24 @@
 					if (copy) {
 						if (target.next("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.copyBetweenMarkup.replace("{0}", target
-								.children("a").text()).replace("{1}",
-								target.next("li[data-role=node]").children("a").text()));
+								.children("a").html()).replace("{1}",
+								target.next("li[data-role=node]").children("a").html()));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.copyAfterMarkup.replace(
-										"{0}", target.children("a").text()
+										"{0}", target.children("a").html()
 									));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						}
 					} else {
 						if (target.next("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.moveBetweenMarkup.replace("{0}", target
-								.children("a").text()).replace("{1}", target
-								.next("li[data-role=node]").children("a").text()));
+								.children("a").html()).replace("{1}", target
+								.next("li[data-role=node]").children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.moveAfterMarkup
-								.replace("{0}", target.children("a").text()));
+								.replace("{0}", target.children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						}
 					}
@@ -2232,25 +2232,25 @@
 					if (copy) {
 						if (target.prev("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.copyBetweenMarkup
-								.replace("{0}", target.children("a").text())
+								.replace("{0}", target.children("a").html())
 								.replace("{1}", target.prev("li[data-role=node]")
-								.children("a").text()));
+								.children("a").html()));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.copyBeforeMarkup
-								.replace("{0}", target.children("a").text()));
+								.replace("{0}", target.children("a").html()));
 							markup.find("span").addClass(this.css.copyMarkupIcon);
 						}
 					} else {
 						if (target.prev("li[data-role=node]").length > 0) {
 							markup = $(this.options.dragAndDropSettings.moveBetweenMarkup
 								.replace("{0}", target.prev("li[data-role=node]")
-								.children("a").text())
-								.replace("{1}", target.children("a").text()));
+								.children("a").html())
+								.replace("{1}", target.children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						} else {
 							markup = $(this.options.dragAndDropSettings.moveBeforeMarkup
-								.replace("{0}", target.children("a").text()));
+								.replace("{0}", target.children("a").html()));
 							markup.find("span").addClass(this.css.moveMarkupIcon);
 						}
 					}

--- a/tests/unit/tree/tests.htm
+++ b/tests/unit/tree/tests.htm
@@ -2131,6 +2131,7 @@
 			testId_10 = "igTree transaction log";
 			testId_11 = "igTree add/remove with render on demand";
 			testId_12 = "igTree remove nodes by value";
+			testId_13 = "igTree Drag and Drop node header with script tag"
 			
 			QUnit.test(testId_1, function (assert) {
 				assert.expect(13);
@@ -2798,6 +2799,35 @@
 				node = tree.igTree('nodeByPath', '0_0');
 				assert.ok(tree.igTree("isChecked", node), "The node is not checked after all remaining children are checked");
 			});
+			QUnit.test(testId_13, function (assert) {
+				assert.expect(1);
+				delete window.testVarDragAndDrop;
+				window.testVarDragAndDrop = 0;
+				var path = "0",
+					data = [
+					{ "Text": "Item1", "Value": "Item1" },
+					{ "Text": "Item2", "Value": "Item2" },
+					{ "Text": "&#x3C;script&#x3E;window.testVarDragAndDrop++;&#x3C;/script&#x3E;", "Value": "Item3"},
+					{ "Text": "Item4", "Value": "Item4"}, 
+					{ "Text": "Item5", "Value": "Item5"}
+				],
+					$container = $('<div></div>').appendTo(document.body)
+						.igTree({
+							dragAndDrop : true,
+							bindings: {
+								textKey: 'Text',
+								valueKey: 'Value'
+							},
+							dataSource: data
+						}),
+					node = $container.igTree("nodeByPath", "2");
+				$.ig.TestUtil.simulateDragStart(node);
+				$.ig.TestUtil.simulateDrag(node, $container.igTree("nodeByPath", "1"));
+				$.ig.TestUtil.simulateDragStop(node);
+				assert.equal(window.testVarDragAndDrop, 0, "The script in the node was executed");
+				delete window.testVarDragAndDrop;
+				$container.igTree('destroy');
+			})
 			/* ***************** END igTree add/remove nodes ***************** */
 		});
 	


### PR DESCRIPTION
If an html-encoded script tag is passed as node name, the script was executed on drag/hover because hover helper markup was set with $.text() instead of $.html(). All markup assignments are now done with $.html() so jQuery handles escaping;

