### PR TITLE
currentTime moves as expected - 18.1

### DIFF
--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -3980,11 +3980,13 @@
 			$(document).bind(this._documentEvts);
 
 			if (!this.options.browserControls) {
+				// B.P. August 21st, 2018 #1722 currentTime moves as expected
+				// The control used to use mouseover and mouseout, which resulted in flickering.
 				this._controlsEvts = {
-					mouseover: function (event) {
+					mouseenter: function (event) {
 						control._onControlMouseOver(event);
 					},
-					mouseout: function (event) {
+					mouseleave: function (event) {
 						control._onControlMouseOut(event);
 					}
 				};


### PR DESCRIPTION
Closes #1722 

~```this.element.offset()``` returned zeroes for ```top``` and ```left``` due to a parent element becoming ```:hidden``` after a mouse click was performed. This happened only on some occasions. Now ```_mouseCapture``` gets all ```:hidden``` parent elements and calls ```.show()``` on each of them, only if the error occurred.~

Edit: The controls flickered due to event propagation from `mouseover` and `mouseout`. Changed them with `mouseenter` and `mouseleave`.