### PR TITLE
Updating spreadsheet loader dependencies for 18.2

### DIFF
--- a/src/js/infragistics.loader.js
+++ b/src/js/infragistics.loader.js
@@ -2112,7 +2112,9 @@ $.ig.dependencies = [
 			{ name: "igCombo" },
 			{ name: "igDialog" },
 			{ name: "_ig_undo" },
-			{ name: "igEditors" }
+			{ name: "igEditors" },
+			{ name: "igPopover" },
+			{ name: "igColorPicker" }
 		],
 		group: $.ig.loaderClass.locale.gridGroup,
 		scripts: [


### PR DESCRIPTION
The format cells dialog uses popover and colorpicker.