### PR TITLE
#1804 Remove redundant edit value cache on keydown

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2744,7 +2744,6 @@
 						self._editorInput.val() !== self._currentInputTextValue) {
 						self._processTextChanged();
 					}
-					self._currentInputTextValue = self._editorInput.val();
 					self._triggerKeyDown(event);
 				},
 				"keyup.editor": function (event) {

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1575,6 +1575,43 @@
 				equal($editor.val(), "123_______", "(numeric nullValue) Typing did not update Edit text."); */
 				$editor.remove();
 			});
+
+			testId = 'Bug 256852: textChanged not fired on Safari on MacOS (Grid filtering)';
+			test(testId, function (assert) {
+				assert.expect(2);
+				var done = assert.async(),
+					$editor =  $("<input/>").appendTo("#testBedContainer").igTextEditor(),
+					$field = $editor.igTextEditor("field"),
+					textChangedArgs = [];
+
+				$editor.on("igtexteditortextchanged", function (evt, args) {
+					textChangedArgs.push(args);
+				});
+
+				/* Safari fires composition in the following order:
+					1. compositionstart
+					2. compositionupdate
+					3. input (value assigned to input)
+					4. keydown
+					5. keyup */
+				$field.focus();
+				$field.trigger(jQuery.Event("compositionstart"));
+				$field.trigger(jQuery.Event("compositionupdate"));
+				$field.val("d");
+				$field.trigger(jQuery.Event("input"));
+				$field.trigger(jQuery.Event("keydown"));
+				$field.trigger(jQuery.Event("keyup"));
+
+				assert.equal(textChangedArgs.length, 1, "textChanged should be triggered");
+				assert.equal(textChangedArgs.pop().text, "d", "textChanged arg should be correct");
+
+				$.ig.TestUtil.wait(0) //compositionupdate handler
+				.then(function () {
+					$editor.off("igtexteditortextchanged");
+					$editor.remove();
+					done();
+				});
+			});
 		});
 
 		function emulateKeyBoard(key, ctrl, shift, alt, element) {

--- a/tests/unit/editors/baseEditor/tests.html
+++ b/tests/unit/editors/baseEditor/tests.html
@@ -182,7 +182,10 @@
 			flag = false;
 
 
-
+			// focus first
+			editor.trigger('focus');
+			ok(flag, "focus not fired");
+			flag = false;
 			$('#eventEditor').trigger('keydown');
 			ok(flag, "keydown not fired");
 			flag = false;
@@ -191,9 +194,6 @@
 			flag = false;
 			$('#eventEditor').trigger('keypress');
 			ok(flag, "keypres not fired");
-			flag = false;
-			editor.trigger('focus');
-			ok(flag, "focus not fired");
 			flag = false;
 
 			$('#eventEditor').off("igtexteditorkeydown igtexteditorkeyup igtexteditorkeypress"); 


### PR DESCRIPTION
Closes #1804

### Additional information related to this pull request:
