### PR TITLE
#1804 Remove redundant edit value cache on keydown

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2749,7 +2749,6 @@
 						self._editorInput.val() !== self._currentInputTextValue) {
 						self._processTextChanged();
 					}
-					self._currentInputTextValue = self._editorInput.val();
 					self._triggerKeyDown(event);
 				},
 				"keyup.editor": function (event) {

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1624,7 +1624,43 @@
 				assert.strictEqual($editor.igNumericEditor("value"), null, "igNumericEditor value did not clear");
 				assert.strictEqual($editor.igNumericEditor("field").val(), "", "igNumericEditor text did not clear");
 				
-				$editor.remove()
+				$editor.remove();
+			});
+
+			QUnit.test('Bug 256852: textChanged not fired on Safari on MacOS (Grid filtering)', function (assert) {
+				assert.expect(2);
+				var done = assert.async(),
+					$editor =  $("<input/>").appendTo("#testBedContainer").igTextEditor(),
+					$field = $editor.igTextEditor("field"),
+					textChangedArgs = [];
+
+				$editor.on("igtexteditortextchanged", function (evt, args) {
+					textChangedArgs.push(args);
+				});
+
+				/* Safari fires composition in the following order:
+					1. compositionstart
+					2. compositionupdate
+					3. input (value assigned to input)
+					4. keydown
+					5. keyup */
+				$field.focus();
+				$field.trigger(jQuery.Event("compositionstart"));
+				$field.trigger(jQuery.Event("compositionupdate"));
+				$field.val("d");
+				$field.trigger(jQuery.Event("input"));
+				$field.trigger(jQuery.Event("keydown"));
+				$field.trigger(jQuery.Event("keyup"));
+
+				assert.equal(textChangedArgs.length, 1, "textChanged should be triggered");
+				assert.equal(textChangedArgs.pop().text, "d", "textChanged arg should be correct");
+
+				$.ig.TestUtil.wait(0) //compositionupdate handler
+				.then(function () {
+					$editor.off("igtexteditortextchanged");
+					$editor.remove();
+					done();
+				});
 			});
 		});
 

--- a/tests/unit/editors/baseEditor/tests.html
+++ b/tests/unit/editors/baseEditor/tests.html
@@ -181,7 +181,10 @@
 			flag = false;
 
 
-
+			// focus first
+			editor.trigger('focus');
+			ok(flag, "focus not fired");
+			flag = false;
 			$('#eventEditor').trigger('keydown');
 			ok(flag, "keydown not fired");
 			flag = false;
@@ -190,9 +193,6 @@
 			flag = false;
 			$('#eventEditor').trigger('keypress');
 			ok(flag, "keypres not fired");
-			flag = false;
-			editor.trigger('focus');
-			ok(flag, "focus not fired");
 			flag = false;
 
 			$('#eventEditor').off("igtexteditorkeydown igtexteditorkeyup igtexteditorkeypress"); 


### PR DESCRIPTION
Closes #1804 

### Additional information related to this pull request:

