### PR TITLE
#1804 Remove redundant edit value cache on keydown

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2749,7 +2749,6 @@
 						self._editorInput.val() !== self._currentInputTextValue) {
 						self._processTextChanged();
 					}
-					self._currentInputTextValue = self._editorInput.val();
 					self._triggerKeyDown(event);
 				},
 				"keyup.editor": function (event) {

--- a/tests/unit/editors/baseEditor/base-test.js
+++ b/tests/unit/editors/baseEditor/base-test.js
@@ -116,10 +116,12 @@ QUnit.test('Events', function (assert) {
 	testEvent("mousemove", $editor, $editor);
 	testEvent("mouseover", $editor, $container);
 	this.mouseout($container[0]);
+
+	// focus first
+	testEvent("focus", $editor, $field);
 	testEvent("keydown", $editor, $editor);
 	testEvent("keyup", $editor, $editor);
 	testEvent("keypress", $editor, $editor);
-	testEvent("focus", $editor, $field);
 
 	flag = false;
 	$editor.off("igtexteditorkeydown igtexteditorkeyup igtexteditorkeypress");


### PR DESCRIPTION
Closes #1804 

### Additional information related to this pull request:

