### PR TITLE
#1695 Prevent parsing invalid date produced with IME input

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -8397,8 +8397,8 @@
 				dateObj = this._getDateOffset(dateObj);
 			}
 
-			// TODO update all the fields
-			if (dateObj) {
+			// D.P. 26th Sep 2018 #1695 Uncaught TypeError w/ IME numbers, don't parse invalid date:
+			if (dateObj && dateObj.getTime() === dateObj.getTime()) {
 				if (this._dateIndices.yy !== undefined) {
 					year = this._getDateField("FullYear", dateObj).toString();
 					if (this._dateIndices.fourDigitYear) {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -5032,7 +5032,7 @@
 
 				// In case of IME input digits we need to convert
 				// value = $.ig.util.replaceJpToEnNumbers(value);
-				value = $.ig.util.IMEtoNumberString(value, $.ig.util.IMEtoENNumbersMapping);
+				value = $.ig.util.IMEtoNumberString(value, $.ig.util.IMEtoENNumbersMapping());
 
 				// D.P. 27th Oct 2015 Bug 208296: Don't replace group separator on actual numbers as it can be '.'
 				value = value.toString().replace(new RegExp($.ig.util.escapeRegExp(groupSeparator), "g"), ""); // TODO VERIFY Remove group separator cause parseInt("1,000") returns 1?

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1626,6 +1626,41 @@
 				
 				$editor.remove()
 			});
+
+			QUnit.test('Bug 1695 Uncaught TypeError is thrown when IME is enabled and a number is typed', function (assert) {
+				assert.expect(4);
+				var done = assert.async(),
+					$editor = $('<input id="dateTimeTest"/>').appendTo("#testBedContainer").igDatePicker({
+						regional: "ja",
+						dataMode:"editModeText"
+					}),
+					textChangedArgs = [];
+
+
+				$editor.trigger("focus");
+				$editor.on("igdatepickertextchanged", function (evt, args) {
+					textChangedArgs.push(args);
+				});
+				$editor[0].setSelectionRange(0, 0);
+				$.ig.TestUtil.keyDownChar(50, $editor);
+				$editor.trigger(jQuery.Event("compositionstart"));
+				$editor.trigger(jQuery.Event("compositionupdate"));
+				$editor.val("２" + $editor.val());
+				$.ig.TestUtil.keyUpChar(50, $editor);
+				assert.ok(true, "Text change processing did not throw.");
+
+				assert.equal(textChangedArgs.length, 1, "textChanged should be triggered");
+				assert.equal(textChangedArgs.pop().text, "２____/__/__", "textChanged arg should be correct");
+				$editor[0].setSelectionRange(1, 1);
+				$editor.trigger(jQuery.Event("compositionend"));
+				$.ig.TestUtil.wait(0) //composition handlers
+				.then(function () {
+					assert.equal($editor.val(), "2___/__/__", "IME value not converted and applied to mask.");
+					$editor.off("igdatepickertextchanged");
+					$editor.remove();
+					done();
+				});
+			}); // Bug 1695
 		});
 
 		function emulateKeyBoard(key, ctrl, shift, alt, element) {

--- a/tests/unit/editors/numericEditor/tests.html
+++ b/tests/unit/editors/numericEditor/tests.html
@@ -2587,6 +2587,31 @@
 			done();
 		});
 	});
+
+	QUnit.test('IME input numbers', function (assert) {
+		assert.expect(2);
+		var done = assert.async(),
+			$editor = $('<input id="dateTimeTest"/>').appendTo("#testBedContainer").igNumericEditor();
+
+		$editor.trigger("focus");
+		$editor[0].setSelectionRange(0, 0);
+		$.ig.TestUtil.keyDownChar(50, $editor);
+		$editor.trigger(jQuery.Event("compositionstart"));
+		$editor.trigger(jQuery.Event("compositionupdate"));
+		$editor.val("２");
+		$.ig.TestUtil.keyUpChar(50, $editor);
+		$editor[0].setSelectionRange(1, 1);
+		$editor.trigger(jQuery.Event("compositionend"));
+
+		$.ig.TestUtil.wait(0) //composition handlers
+		.then(function () {
+			$editor.trigger("blur");
+			assert.equal($editor.val(), "2", "IME text not converted and applied to mask.");
+			assert.strictEqual($editor.igNumericEditor("value"), 2, "Value after IME not correct");
+			$editor.remove();
+			done();
+		});
+	}); // Bug 1695
 });
 	function testSelection(input, start, end) {
 		equal(input[0].selectionStart, start, "The selection doesn't start from index " + start);


### PR DESCRIPTION
Closes #1695 

### Additional information related to this pull request:
Also noticed a missing call to the IME number mapping on the numeric editor, updated that as well.