### PR TITLE
#1776 [igEditors] add input handler for auto-fill

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2712,6 +2712,13 @@
 				"focus.editor": function (event) {
 					self._setFocus(event);
 				},
+				"input.editor": function () {
+					if (!self._editMode) {
+						// D.P. 26th Sep 2018 #1776 Auto-fill on page load does not update the editor
+						self._processTextChanged();
+						self._processValueChanging(self._editorInput.val());
+					}
+				},
 				"dragenter.editor": function () {
 					if (!self._focused && !self._editMode) {
 						//Controlled edit mode without selection to allow default drop handling
@@ -2834,7 +2841,7 @@
 			this._super();
 
 			if (this._editorInput) {
-				this._editorInput.off("focus.editor blur.editor paste.editor");
+				this._editorInput.off("focus.editor input.editor blur.editor paste.editor");
 				this._editorInput.off("dragenter.editor dragleave.editor drop.editor");
 				this._editorInput.off("keydown.editor keyup.editor keypress.editor");
 				this._editorInput.off("compositionstart.editor compositionend.editor compositionupdate.editor");

--- a/tests/unit/editors/Bugs/tests.html
+++ b/tests/unit/editors/Bugs/tests.html
@@ -1697,6 +1697,30 @@
 					done();
 				});
 			}); // Bug 1695
+			QUnit.test('Bug 1776 Auto-fill does not update igTextEditor', function (assert) {
+				assert.expect(5);
+				var $editor = $('<input id="dateTimeTest"/>').appendTo("#testBedContainer").igTextEditor(),
+					textChangedArgs = [], valueChangedArgs = [];
+
+				$editor.on("igtexteditortextchanged", function (evt, args) {
+					textChangedArgs.push(args);
+				});
+				$editor.on("igtexteditorvaluechanged", function (evt, args) {
+					valueChangedArgs.push(args);
+				});
+
+				// no focus, immediate change like auto-fill:
+				$editor.val("username");
+				$editor.trigger(jQuery.Event("input"));
+
+ 				assert.equal(textChangedArgs.length, 1, "textChanged should be triggered");
+				assert.equal(textChangedArgs.pop().text, "username", "textChanged arg should be correct");
+				assert.equal(valueChangedArgs.length, 1, "valueChanged should be triggered");
+				assert.equal(valueChangedArgs.pop().newValue, "username", "valueChanged arg should be correct");
+				assert.equal($editor.igTextEditor("value"), "username", "Value not updated");
+				$editor.off("igtexteditortextchanged igtexteditorvaluechanged");
+				$editor.remove();
+			}); // Bug 1776
 		});
 
 		function emulateKeyBoard(key, ctrl, shift, alt, element) {


### PR DESCRIPTION
Closes #1776 

### Additional information related to this pull request:
Auto-fill seems to trigger `input` fairly consistently on moder browsers and seems to be the only way to get that event without the actual field being focus (in edit).
