### PR TITLE
Removed "pattern" from the exception message.

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -5985,7 +5985,7 @@
 						if (next === "<" || next === "\"") {
 
 							if (netPattern[ i + 2 ] === "=" || netPattern[ i + 2 ] === "!") {
-								throw new Error("Lookbehind assertions are not supported in JavaScript: " + pattern);
+								throw new Error("Lookbehind assertions are not supported in JavaScript.");
 							}
 
 							i++;


### PR DESCRIPTION
We believe this is leftover from here:
https://github.com/IgniteUI/ignite-ui/blob/4c00110cba88b3ee71086f0e6c9a521716bbe509/src/js/modules/infragistics.util.js#L5944
It causes the following error:
![imgpsh_mobile_save](https://user-images.githubusercontent.com/16020256/46212438-a517f700-c33e-11e8-869e-7ad2c3e9a8b3.jpg)
