### PR TITLE
Custom sort dialog is broken in IE

### DIFF
--- a/src/css/structure/modules/infragistics.ui.spreadsheet.css
+++ b/src/css/structure/modules/infragistics.ui.spreadsheet.css
@@ -912,28 +912,28 @@
     margin-bottom: 10px;
 }
 #grdHeaders {
+	display: grid;
 	display: -ms-grid;
 	-ms-grid-rows: auto 3px;
 	-ms-grid-columns: 1fr 2px 1fr 12px 1fr 12px;
-	display: grid;
 	grid-template-rows: auto;
 	grid-template-columns: 1fr 1fr 2fr;
 	grid-gap: 12px;
 }
 #grdSortConditions {
+	display: grid;
 	display: -ms-grid;
 	-ms-grid-rows: auto 3px;
 	-ms-grid-columns: 1fr 2px 1fr 12px 1fr 12px;
-	display: grid;
 	grid-template-rows: auto;
 	grid-template-columns: 1fr 1fr 2fr;
 	grid-gap: 12px;
 }
 #pnlColumnContentsGrid {
+	display: grid;
 	display: -ms-grid;
 	-ms-grid-rows: auto 3px;
 	-ms-grid-columns: auto 10px 1fr 10px;
-	display: grid;
 	grid-template-rows: auto;
 	grid-template-columns: auto 1fr;
 	grid-gap: 10px;


### PR DESCRIPTION
TFS 258730   

The "cssmin" grunt task removed the "display: -ms-grid" rule because it was duplicate. The strange thing is that it won't remove it if it's right after the "display: grid". They probably have a bug or something in their minification code.

