### PR TITLE
igDateEditor continues to spin down, #1846

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2649,7 +2649,7 @@
 				return;
 			}
 
-			//	MV 23.11.18 #258989
+			//	MV 23.11.18 #1846
 			//	ensure events are attached just once
 			this._detachButtonsEvents(target);
 
@@ -3781,7 +3781,8 @@
 			var self = this;
 			if (type === "spinUp") {
 				this._handleSpinUpEvent();
-				//	MV 23.11.18 #258989
+
+				//	MV 23.11.18 #1846
 				//	we should call setTimeout just once
 				if (!target.attr("disabled") && !target._spinTimeOut) {
 					target._spinTimeOut = setTimeout(function () {
@@ -3792,7 +3793,8 @@
 				}
 			} else if (type === "spinDown") {
 				this._handleSpinDownEvent();
-				//	MV 23.11.18 #258989
+
+				//	MV 23.11.18 #1846
 				//	we should call setTimeout just once
 				if (!target.attr("disabled") && !target._spinTimeOut) {
 					target._spinTimeOut = setTimeout(function () {

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -3776,7 +3776,9 @@
 			var self = this;
 			if (type === "spinUp") {
 				this._handleSpinUpEvent();
-				if (!target.attr("disabled")) {
+				//	MV 23.11.18 #258989
+				//	we should call setTimeout just once
+				if (!target.attr("disabled") && !target._spinTimeOut) {
 					target._spinTimeOut = setTimeout(function () {
 						target._spinInterval = setInterval(function () {
 							self._handleSpinUpEvent();
@@ -3785,7 +3787,9 @@
 				}
 			} else if (type === "spinDown") {
 				this._handleSpinDownEvent();
-				if (!target.attr("disabled")) {
+				//	MV 23.11.18 #258989
+				//	we should call setTimeout just once
+				if (!target.attr("disabled") && !target._spinTimeOut) {
 					target._spinTimeOut = setTimeout(function () {
 						target._spinInterval = setInterval(function () {
 							self._handleSpinDownEvent();

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -2648,6 +2648,11 @@
 			if (!target) {
 				return;
 			}
+
+			//	MV 23.11.18 #258989
+			//	ensure events are attached just once
+			this._detachButtonsEvents(target);
+
 			/* jshint -W083*/
 			target.on({
 				"mouseenter.button": function () {


### PR DESCRIPTION
Closes #1846

In _handleSpinEvent we are starting a timer. This allow us to spin editor's value if mouse button is hold down. We are now checking if we already started the timer - if so we do not start it again. This solves the issue.
Note that the root of this issue is using igDateEditor to show time. When using it this way, and put it in edit mode, there is no way to determine the date from the input, as it only shows hours and minutes. This disallows us to correctly setup control, e.g. enable and disable spin buttons, validate edit date and so on.
If one need to show time we have igTimePicker control which could do this.