### PR TITLE
#1842 - set regional defaults to "defaults" instead of "en-US"

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11129,7 +11129,7 @@
 
 			//V.S. March 7th 2018 - #1358 if no regional option is provided and a global regional is set, uses the global one
 			if ($.datepicker && typeof reg === "string") {
-				if (reg === "defaults" || reg === "en-US") {
+				if (reg === "defaults") {
 					if (typeof $.ig.util.regional === "string" && $.ig.util.regional) {
 						abbreviation = $.ig.util.regional;
 					}

--- a/src/js/modules/infragistics.ui.widget.js
+++ b/src/js/modules/infragistics.ui.widget.js
@@ -82,7 +82,7 @@
 				$(".selector").%%WidgetName%%("option", "regional", "ja");
 			```
 			*/
-			regional: "en-US"
+			regional: "defaults"
 		},
 		_createWidget: function (options) {
 			this._userPreset = options;


### PR DESCRIPTION
Closes #1842 

### Additional information related to this pull request:
The default regionals in the `widget` class was set to `en-US` instead of `defaults` - `defaults` is always provided (`en-US` of no regionals are loaded OR the last loaded regional). Change simplifies checks for `default` regional so they no logner require checks for `en-US` explicitly. 
