### PR TITLE
igVideoPlayer does not throw errors upon initialization on a video element

### DIFF
--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -2508,6 +2508,8 @@
 			this._removeVideoProperty(video, "autoplay");
 			this._removeVideoProperty(video, "preload");
 			this._removeVideoProperty(video, "loop");
+
+			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
 			if (this._oldPoster !== "") {
 				this._removeVideoProperty(video, "poster");
 			}

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -2412,7 +2412,8 @@
 			var o = this.options,
 				video,
 				css = this.css;
-
+			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
+			this._isRendering = true;
 			this._prevReadyState = 0;
 			this._bookmarksRendered = false;
 
@@ -2481,6 +2482,10 @@
 			});
 
 			this.container.addClass(css.baseClasses);
+			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
+			setTimeout(() => {
+				delete this._isRendering;
+			});
 		},
 
 		_createVideoElement: function (id) {
@@ -2501,7 +2506,7 @@
 			this._removeVideoProperty(video, "autoplay");
 			this._removeVideoProperty(video, "preload");
 			this._removeVideoProperty(video, "loop");
-			this._removeVideoProperty(video, "poster");
+			this._oldPoster === "" ? $.noop() : this._removeVideoProperty(video, "poster");
 			this._removeVideoProperty(video, "controls");
 			this._removeVideoProperty(video, "src");
 		},
@@ -3860,7 +3865,10 @@
 					control._hideWaitingIndicator();
 				},
 				timeupdate: function (event) {
-					control._changeCurrentTime(event);
+					// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
+					if (control._isRendering === undefined) {
+						control._changeCurrentTime(event);
+					}
 				},
 				ended: function (event) {
 					/* Display big play button in the center when ended. */
@@ -3925,6 +3933,12 @@
 					control._refreshDuration();
 				}
 			};
+
+			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
+			if (control._isRendering === undefined) {
+				control._changeCurrentTime(event);
+			}
+
 			video.bind(this._videoEvents);
 		},
 

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -2412,6 +2412,7 @@
 			var o = this.options,
 				video,
 				css = this.css;
+
 			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
 			this._isRendering = true;
 			this._prevReadyState = 0;
@@ -2482,6 +2483,7 @@
 			});
 
 			this.container.addClass(css.baseClasses);
+
 			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
 			setTimeout(() => {
 				delete this._isRendering;
@@ -2506,7 +2508,9 @@
 			this._removeVideoProperty(video, "autoplay");
 			this._removeVideoProperty(video, "preload");
 			this._removeVideoProperty(video, "loop");
-			this._oldPoster === "" ? $.noop() : this._removeVideoProperty(video, "poster");
+			if (this._oldPoster !== "") {
+				this._removeVideoProperty(video, "poster");
+			}
 			this._removeVideoProperty(video, "controls");
 			this._removeVideoProperty(video, "src");
 		},

--- a/src/js/modules/infragistics.ui.videoplayer.js
+++ b/src/js/modules/infragistics.ui.videoplayer.js
@@ -2412,9 +2412,6 @@
 			var o = this.options,
 				video,
 				css = this.css;
-
-			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
-			this._isRendering = true;
 			this._prevReadyState = 0;
 			this._bookmarksRendered = false;
 
@@ -2483,11 +2480,6 @@
 			});
 
 			this.container.addClass(css.baseClasses);
-
-			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
-			setTimeout(() => {
-				delete this._isRendering;
-			});
 		},
 
 		_createVideoElement: function (id) {
@@ -3871,10 +3863,7 @@
 					control._hideWaitingIndicator();
 				},
 				timeupdate: function (event) {
-					// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
-					if (control._isRendering === undefined) {
-						control._changeCurrentTime(event);
-					}
+					control._changeCurrentTime(event);
 				},
 				ended: function (event) {
 					/* Display big play button in the center when ended. */
@@ -3939,11 +3928,6 @@
 					control._refreshDuration();
 				}
 			};
-
-			// B.P. Dec 11th, 2018 Bug #1827 An error is thrown when igVideoPlayer is initialized on a video element
-			if (control._isRendering === undefined) {
-				control._changeCurrentTime(event);
-			}
 
 			video.bind(this._videoEvents);
 		},

--- a/tests/unit/videoplayer/videoplayer-test.js
+++ b/tests/unit/videoplayer/videoplayer-test.js
@@ -14,6 +14,11 @@
 function createFixtureDiv(divId){
 	$.ig.TestUtil.appendToFixture('<div id=' + divId + '/>');
 }
+
+function createFixtureVideo(videoId) {
+	$.ig.TestUtil.appendToFixture(`<video id=${videoId}/>`);
+}
+
 // #player1 and #player2 with isAutoPlay and isMuted set to true
 function createBasicPlayer(divId, isAutoPlay = false, isMuted = false){
 
@@ -1850,3 +1855,36 @@ QUnit.test('Test fullscreen option class when set to false test 56', function (a
 	assert.notOk(hasFullScreenClass, "The full-screen-mode class should be removed from body when the video player fullscreen option is set to false.");
 });
 
+
+QUnit.test('Test igVidioPlayer throws no errors when initialized on a video element test 57', function (assert) {
+	createFixtureVideo('player17');
+	try {
+		assert.ok($("#player17").igVideoPlayer());
+	} catch {
+		assert.ok(false, "igVideoPlayer threw an error upon initialization on a video element.");
+	}
+});
+
+QUnit.test('Test igVidioPlayer renders correctly on a video element test 58', function (assert) {
+	var playerId = 'player18';
+	createFixtureVideo(playerId);
+	$(`#${playerId}`).igVideoPlayer();
+
+	var container = $(`#${playerId}_container`), 
+		video = $(`#${playerId}`),
+		playButton = $(`#${playerId}_play`),
+		playerWaiting = $(`#${playerId}_waiting`),
+		seekToolTip = $(`#${playerId}_seek_tooltip`);
+
+	assert.ok(container !== null, 'igVideoPlayer container is rendered.');
+	assert.ok(video !== null, 'igVideoPlayer video is rendered.');
+	assert.ok(playButton !== null, 'igVideoPlayer play button is rendered.');
+	assert.ok(playerWaiting !== null, 'igVideoPlayer waiting state is rendered.');
+	assert.ok(seekToolTip !== null, 'igVideoPlayer seek tooltip is rendered.');
+
+	this.checkElementNotClass(container, 'ui-widget ui-igplayer', assert);
+	this.checkElementNotClass(video, 'ui-igplayer-video', assert);
+	this.checkElementNotClass(playButton, 'ui-state-default ui-igplayer-centerplaybutton-play', assert);
+	this.checkElementNotClass(playerWaiting, 'ui-state-default ui-igplayer-waiting', assert);
+	this.checkElementNotClass(seekToolTip, 'ui-widget ui-igpopover ui-igplayer-tooltip ui-igplayer-seektooltip', assert);
+});

--- a/tests/unit/videoplayer/videoplayer-test.js
+++ b/tests/unit/videoplayer/videoplayer-test.js
@@ -1869,7 +1869,6 @@ QUnit.test('Test igVidioPlayer renders correctly on a video element test 58', fu
 	var playerId = 'player18';
 	createFixtureVideo(playerId);
 	$(`#${playerId}`).igVideoPlayer();
-
 	var container = $(`#${playerId}_container`), 
 		video = $(`#${playerId}`),
 		playButton = $(`#${playerId}_play`),
@@ -1882,9 +1881,9 @@ QUnit.test('Test igVidioPlayer renders correctly on a video element test 58', fu
 	assert.ok(playerWaiting !== null, 'igVideoPlayer waiting state is rendered.');
 	assert.ok(seekToolTip !== null, 'igVideoPlayer seek tooltip is rendered.');
 
-	this.checkElementNotClass(container, 'ui-widget ui-igplayer', assert);
-	this.checkElementNotClass(video, 'ui-igplayer-video', assert);
-	this.checkElementNotClass(playButton, 'ui-state-default ui-igplayer-centerplaybutton-play', assert);
-	this.checkElementNotClass(playerWaiting, 'ui-state-default ui-igplayer-waiting', assert);
-	this.checkElementNotClass(seekToolTip, 'ui-widget ui-igpopover ui-igplayer-tooltip ui-igplayer-seektooltip', assert);
+	this.checkElementClass(container, 'ui-widget ui-igplayer', assert);
+	this.checkElementClass(video, 'ui-igplayer-video', assert);
+	this.checkElementClass(playButton, 'ui-state-default ui-igplayer-centerplaybutton-play', assert);
+	this.checkElementClass(playerWaiting, 'ui-state-default ui-igplayer-waiting', assert);
+	this.checkElementClass(seekToolTip, 'ui-widget ui-igpopover ui-igplayer-tooltip ui-igplayer-seektooltip', assert);
 });


### PR DESCRIPTION
Closes #1827 

~The error occurs because of the untimely use of the `timeupdate` video event. It is bound to the element upon creation and attempts to use the video's duration property. For `WebKit` browsers, such as `Chrome`, the duration property is `NaN` until the `durationchange` event is thrown. So now we wait in an interval for the video to finish loading and then we call the `timeupdate` handler. Albeit possibly inconsistent and error inducing, a workaround would be to bind the control's events when `durationchange` is triggered.~

__Edit:__ The `poster` attribute not being set is what originally triggers the issue, as it becomes `undefined` and chains the two errors together. That is why we don't need to set any intervals or bind events differently. We only need to specify that no action should be taken when the `poster` attribute is not set upon initialization.
