### PR TITLE
Fix issues with to/from oa date

### DIFF
--- a/src/js/modules/infragistics.util.js
+++ b/src/js/modules/infragistics.util.js
@@ -1260,10 +1260,11 @@
 			return new Date();
 		},
 		fromOADate: function (value) {
-			var result = new Date(+(new Date(1899, 11, 30)) + Math.round(value * 86400000));
+			var days = Math.floor(value);
+			var result = new Date(1899, 11, 30 + days);
 
-			if (result.dst && result.dst()) {
-				return $.ig.Date.prototype.addHours(result, -1);
+			if (value !== days) {
+				result = new Date(+result + Math.round((value - days) * 86400000));
 			}
 
 			return result;
@@ -1477,13 +1478,10 @@
 	}, true);
 
 	$.ig.extendNativePrototype(Date.prototype, "toOADate", function () {
-		var result = (this - new Date(1899, 11, 30)) / 86400000;
-
-		if (this.dst && this.dst()) {
-			return result + (1 / 24);
-		}
-
-		return result;
+		var u1 = Date.UTC(this.getFullYear(), this.getMonth(), this.getDate(),
+			this.getHours(), this.getMinutes(), this.getSeconds(), this.getMilliseconds());
+		var u2 = Date.UTC(1899, 11, 30);
+		return (u1 - u2) / 86400000;
 	});
 
 	$.ig.extendNativePrototype(Date.prototype, "kind", function () {

--- a/tests/unit/util/util-test.js
+++ b/tests/unit/util/util-test.js
@@ -408,8 +408,15 @@ QUnit.test('[ID19] Test arrayCopy1', function (assert) {
 });
 
 QUnit.test('[ID20] Test OADate', function (assert) {
-	assert.expect(1);
+	assert.expect(7);
 
-	var dt = new Date(2000, 1, 1);
-	assert.equal($.ig.Date.prototype.fromOADate(dt.toOADate()).getTime(), +dt,  "The date should roundtrip");
+	var dates = [new Date(2000, 1, 1), new Date(2004, 6, 30), new Date(2004, 0, 1, 11), new Date(2007, 12, 31, 11, 30), new Date("2011-10-10T14:48:00.000+09:00")];
+	for (var i = 0; i < dates.length; i++) {
+		var dt = dates[i];
+		assert.equal($.ig.Date.prototype.fromOADate(dt.toOADate()).getTime(), +dt,  "The date should roundtrip:" + dt);
+	}
+	
+	var d1 = new Date(1999, 6, 4, 12, 0, 0);
+	assert.equal(d1.toOADate(), 36345.5,  "toOADate for " + d1);
+	assert.equal($.ig.Date.prototype.fromOADate(36345.5).getTime(), +d1,  "fromOADate to " + d1);
 });

--- a/tests/unit/util/util-test.js
+++ b/tests/unit/util/util-test.js
@@ -406,3 +406,10 @@ QUnit.test('[ID19] Test arrayCopy1', function (assert) {
 	$.ig.util.arrayCopy1(arr, 0, target, 1, 4);
 	assert.deepEqual(target, [6,1,2,3,4], "Copy content to the end of another array");
 });
+
+QUnit.test('[ID20] Test OADate', function (assert) {
+	assert.expect(1);
+
+	var dt = new Date(2000, 1, 1);
+	assert.equal($.ig.Date.prototype.fromOADate(dt.toOADate()).getTime(), +dt,  "The date should roundtrip");
+});


### PR DESCRIPTION
### Additional information related to this pull request:
There were issues with how we were converting to/from OA date when the timezone offset for Dec 30, 1899 differed from the current timezone offset which happens for certain timezones.
