### PR TITLE
Fix for bug #261942 - Dont reposition dropdown when setting combo sizes

### DIFF
--- a/src/js/modules/infragistics.ui.combo.js
+++ b/src/js/modules/infragistics.ui.combo.js
@@ -5039,11 +5039,9 @@
 					break;
 				case "width":
 					_options.$comboWrapper.outerWidth(value);
-					this.positionDropDown();
 					break;
 				case "height":
 					_options.$comboWrapper.outerHeight(value);
-					this.positionDropDown();
 					break;
 				case "headerTemplate":
 					this._renderHeaderTemplate(this.css, this.options, _options.$dropDownCont);


### PR DESCRIPTION
Closes 261942 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them

