### PR TITLE
Override igTextEditor._deleteList to prevent the removal of jQuery datepicker - 19.2

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11441,11 +11441,13 @@
 			this._editorInput.datepicker("hide");
 			this._editorInput.attr("aria-expanded", false);
 		},
-		// B.P. 12/06/2019 #1921 Mouse over highlighting of dates does not work after the control is recreated. 
+
+		// B.P. 12/06/2019 #1921 Mouse over highlighting of dates does not work after the control is recreated.
 		_deleteList: function () {
 			this._detachListEvents();
 			delete this._dropDownList;
 		},
+
 		// igDatePicker public methods
 		changeRegional: function() { //igDatePicker
 			/* changes the the regional settings of widget element to the language specified in [options.regional](ui.igdatepicker#options:regional)

--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -11441,7 +11441,11 @@
 			this._editorInput.datepicker("hide");
 			this._editorInput.attr("aria-expanded", false);
 		},
-
+		// B.P. 12/06/2019 #1921 Mouse over highlighting of dates does not work after the control is recreated. 
+		_deleteList: function () {
+			this._detachListEvents();
+			delete this._dropDownList;
+		},
 		// igDatePicker public methods
 		changeRegional: function() { //igDatePicker
 			/* changes the the regional settings of widget element to the language specified in [options.regional](ui.igdatepicker#options:regional)

--- a/tests/unit/editors/DatePickerBugs/datePickerBugs-test.js
+++ b/tests/unit/editors/DatePickerBugs/datePickerBugs-test.js
@@ -545,3 +545,36 @@ QUnit.test("Issue 1733 - igDatePicker throws error, when selecting with displayM
 		throw er;
 	});
 });
+
+QUnit.test("Issue 1921 - Mouse over highlighting of dates does not work after the control is recreated", function (assert) {
+	const hover = "ui-state-hover",
+	selector = ".ui-datepicker-calendar",
+	self = this,
+	done = assert.async(),
+	tableRow = `${selector}>tbody>tr`;
+
+	// create and open the datepicker
+	this.editor = this.appendToFixture(this.divTag).igDatePicker();
+	this.editor.igDatePicker("showDropDown");
+	$.ig.TestUtil.wait(400).then(function () {
+		// destroy the datepicker
+		self.editor.igDatePicker("destroy");
+		// the jquery datepicker should not be destroyed
+		const datePickerDiv = $(selector);
+		assert.ok(datePickerDiv !== undefined && datePickerDiv !== null);
+		return $.ig.TestUtil.wait(400);
+	}).then(function() {
+		// recreate and reopen the datepicker
+		self.editor = self.appendToFixture(self.divTag).igDatePicker();
+		self.editor.igDatePicker("showDropDown");
+		return $.ig.TestUtil.wait(400);
+	}).then(function() {
+		// trigger "mouseover" on the second element of the second row
+		$($(tableRow)[1].childNodes[1].childNodes[0]).trigger("mouseover");
+		return $.ig.TestUtil.wait(400);
+	}).then(function() {
+		// the second element of the second row should have the ui-state-hover class
+		assert.ok($(tableRow)[1].childNodes[1].childNodes[0].classList.toString().includes(hover));
+		done();
+	});
+});

--- a/tests/unit/editors/DatePickerBugs/datePickerBugs-test.js
+++ b/tests/unit/editors/DatePickerBugs/datePickerBugs-test.js
@@ -575,6 +575,7 @@ QUnit.test("Issue 1921 - Mouse over highlighting of dates does not work after th
 	}).then(function() {
 		// the second element of the second row should have the ui-state-hover class
 		assert.ok($(tableRow)[1].childNodes[1].childNodes[0].classList.toString().includes(hover));
+		self.editor.igDatePicker("destroy");
 		done();
 	});
 });


### PR DESCRIPTION
Closes #1921 

The `igDatePicker` extends the `igDateEditor`, which in turn extends the `igTextEditor`. The `igTextEditor` has a function called `_deleteList` which is called when the control is to be destroyed. It clears the `DOM` but also removes the `jQuery` datepicker element. This removal causes the inability of the `igDatePicker` to apply the `ui-state-hover` class on the element which has triggered the mouseover event.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them

