### PR TITLE
Fix mask editor showing literals for empty value on blur - 18.2

### DIFF
--- a/src/js/modules/infragistics.ui.editors.js
+++ b/src/js/modules/infragistics.ui.editors.js
@@ -7219,7 +7219,7 @@
 				!this.options.revertIfNotValid)) {
 
 				// 12 December 2018 Bug #1853 When value is not formatted as a mask (Android devices).
-				if (value.length !== this._maskWithPrompts.length) {
+				if (value.length && value.length !== this._maskWithPrompts.length) {
 					value = this._parseValueByMask(value);
 				}
 				this._updateValue(value);

--- a/tests/unit/editors/Bugs/bugs-test.js
+++ b/tests/unit/editors/Bugs/bugs-test.js
@@ -1827,3 +1827,31 @@ QUnit.test('Bug 264559: Text from Excel cannot be pasted --> Remove new line cha
 		done();
 	});
 });
+
+QUnit.test('Bug 1974: inputMask literals are visible for empty value after blur', function (assert) {
+	assert.expect(6);
+
+	var $editor1 = $.ig.TestUtil.appendToFixture(this.inputTag, { type: "text" });
+	$editor1.igMaskEditor({
+		inputMask: 'AaaL/aa'
+	});
+
+	var $editor2 = $.ig.TestUtil.appendToFixture(this.inputTag, { type: "text" });
+	$editor2.igMaskEditor({
+		inputMask: '(000) 000-000'
+	});
+
+	var field = $editor1.igMaskEditor("field");
+	field.focus();
+	assert.equal(field.val(), "____/__", "Mask should be visible");
+	field.blur();
+	assert.equal(field.val(), "", "Editor text field should remain empty");
+	assert.equal($editor1.igMaskEditor("value"), "", "Value should be empty");
+
+	field = $editor2.igMaskEditor("field");
+	field.focus();
+	assert.equal(field.val(), "(___) ___-___", "Mask should be visible");
+	field.blur();
+	assert.equal(field.val(), "", "Editor text field should remain empty");
+	assert.equal($editor1.igMaskEditor("value"), "", "Value should be empty");
+});


### PR DESCRIPTION
Closes #1974

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them

