### PR TITLE
Validator should correctly set its language and locale

### DIFF
--- a/tests/unit/editors/baseEditor/base-test.js
+++ b/tests/unit/editors/baseEditor/base-test.js
@@ -503,3 +503,45 @@ QUnit.test('Destroy method reverts input state.', function (assert) {
 	//check the value attribute and see if it is restored
 	assert.equal(document.getElementById(textEditorId).getAttribute("value"), "myInputValue", 'Input value attr is not the same as before Editor init');
 });
+
+QUnit.only('Set editor`s validator language', function (assert) {
+	assert.expect(6);
+	var $textEditorNoLocale = this.util.appendToFixture(this.inputTag);
+	$textEditorNoLocale.igTextEditor(
+		{
+			validatorOptions : {
+				required: true
+			}
+		});
+
+	assert.equal($textEditorNoLocale.igValidator("option", "locale"), undefined, "Validator's locale should be undefined when editor has no locale");
+	assert.equal($textEditorNoLocale.igValidator("option", "language").language, undefined, "Validator's language should be undefined when editor has no language");
+
+	var $textEditorWithLocale = this.util.appendToFixture(this.inputTag);
+	$textEditorWithLocale.igTextEditor(
+		{
+			language: "fr",
+			locale: "bg",
+			validatorOptions : {
+				required: true
+			}
+		});
+
+	assert.equal($textEditorWithLocale.igValidator("option", "locale"), "bg", "Validator's locale should be 'bg' when editor has locale");
+	assert.equal($textEditorWithLocale.igValidator("option", "language"), "fr", "Validator's language should be 'fr when editor has language");
+
+	var $textEditorValidatorWithLocale = this.util.appendToFixture(this.inputTag);
+	$textEditorValidatorWithLocale.igTextEditor(
+		{
+			language: "fr",
+			locale: "bg",
+			validatorOptions : {
+				language: "es",
+				locale: "jp",
+				required: true
+			}
+		});
+
+		assert.equal($textEditorValidatorWithLocale.igValidator("option", "locale"), "jp", "Validator's language should be 'fr when validator has language");
+	assert.equal($textEditorValidatorWithLocale.igValidator("option", "language"), "es", "Validator's locale should be 'es' when validator has locale");
+});

--- a/tests/unit/editors/baseEditor/tests.html
+++ b/tests/unit/editors/baseEditor/tests.html
@@ -7,6 +7,7 @@
 	<link type="text/css" href="../../../../src/css/themes/infragistics/infragistics.theme.css" rel="stylesheet" />
 	<link type="text/css" href="../../../../src/css/structure/modules/infragistics.ui.popover.css" rel="stylesheet" />
 	<link type="text/css" href="../../../../src/css/structure/modules/infragistics.ui.notifier.css" rel="stylesheet" />
+    <link type="text/css" href="../../../../src/css/structure/modules/infragistics.ui.validator.css" rel="stylesheet" />
 	<link type="text/css" href="../../../../src/css/structure/modules/infragistics.ui.editors.css" rel="stylesheet" />
 
 
@@ -18,6 +19,7 @@
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.popover-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.notifier-en.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.editors-en.js"></script>
+    <script type="text/javascript" src="../../../../src/js/modules/i18n/infragistics.ui.validator-en.js"></script>
 
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.util.jquery.js"></script>
@@ -25,6 +27,7 @@
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.popover.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.notifier.js"></script>
 	<script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.editors.js"></script>
+    <script type="text/javascript" src="../../../../src/js/modules/infragistics.ui.validator.js"></script>
 
 	<script type="text/javascript" src="../../common/test-util.js"></script>
 


### PR DESCRIPTION
If one sets language/locale to igEditor is should set same language/locale to its validator if any. If language/locale are set to validator through `validatorOptions`, even if one sets different language/locale to the editor validator should use ones set through its options.

Closes #1901 

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them

