### PR TITLE
Use encodeUriComponent instaead of escape to encode filtering params in URL

### DIFF
--- a/src/js/modules/infragistics.datasource.js
+++ b/src/js/modules/infragistics.datasource.js
@@ -26,7 +26,7 @@
  *
  */
 
-/*global Class, ActiveXObject, DOMParser, XPathResult, XMLSerializer, escape */
+/*global Class, ActiveXObject, DOMParser, XPathResult, XMLSerializer */
 (function (factory) {
 	if (typeof define === "function" && define.amd) {
 
@@ -5025,7 +5025,7 @@
 							);
 							/* d = ffields[i].expr.getTime(); */
 						} else {
-							d = escape(ffields[ i ].expr);
+							d = encodeURIComponent(ffields[ i ].expr);
 						}
 						if (params.filteringParams[ key ] === undefined) {
 							params.filteringParams[ key ] = ffields[ i ].cond +

--- a/tests/unit/dataSource/properties/properties-test.js
+++ b/tests/unit/dataSource/properties/properties-test.js
@@ -1035,7 +1035,7 @@ QUnit.module("igDataSource Properties", {
 			var nYear = nextMonthDate.getFullYear();
 			var prevMonthYear = prevMonthDate.getFullYear();
 
-			var params = unescape($.param(dsFilter._encodeUrl()));
+			var params = decodeURIComponent($.param(dsFilter._encodeUrl()));
 			assert.equal(params,
 				"$filter=day(Date) eq " + date.getDate().toString() + " and month(Date) eq " + currMonth.toString() + " and year(Date) eq " + date.getFullYear().toString() +
 				" and month(Date2) eq " + prevMonth.toString() + " and year(Date2) eq " + prevMonthYear.toString() + " and month(Date3) eq " +

--- a/tests/unit/dataSource/remote/remote-test.js
+++ b/tests/unit/dataSource/remote/remote-test.js
@@ -444,7 +444,7 @@
 			" or ReleaseDate gt DateTime'" + $.ig.formatter(date, "date", "yyyy-MM-ddT23:59:59") + "' or ReleaseDate lt DateTime'" + $.ig.formatter(date, "date", "yyyy-MM-dd") +
 			"' or day(ReleaseDate) eq " + day + " and month(ReleaseDate) eq " + month + " and year(ReleaseDate) eq " + year + " or day(ReleaseDate) eq "+ day +
 			" and month(ReleaseDate) eq " + month + " and year(ReleaseDate) eq " + year + "&filterLogic=or";
-		assert.equal(unescape(params), result);
+		assert.equal(decodeURIComponent(params), result);
 
 		ds.settings.filtering.expressions = [
 			{fieldName: "ThisMonth", cond: "thisMonth", logic: "or"},

--- a/tests/unit/dataSource/remote/remote-test.js
+++ b/tests/unit/dataSource/remote/remote-test.js
@@ -730,6 +730,7 @@
 		assert.equal(params, "%24filter=startswith(tolower(ProductID)%2C'cr')%20eq%20true");
 	});
 
+	// After fix for https://github.com/IgniteUI/ignite-ui/issues/2048, encodeURIComponent is used for encoding, which encodes only CERTAIn characters, not all characters
 	QUnit.test("Ensure special characters in filtering expression are escaped when encoded to url. ", function (assert) {
 		assert.expect(1);
 		var ds =new $.ig.RemoteDataSource({ responseDataType: "json",
@@ -737,12 +738,14 @@
 		paging: {enabled: true, remote: true},
 		dataSource: "products123", schema: {searchField : "data.results", fields:[{name: "ProductID"}]}} ).dataBind();
 
+		var specialCharacter = "%EF%BC%93"; // FULLWIDTH DIGIT THREE, https://www.fileformat.info/info/unicode/char/ff13/index.htm
+		var expr = decodeURIComponent(specialCharacter);
 		ds.settings.filtering.expressions = [
-			{ fieldName: "ProductID", expr: "()", cond: "Contains" }
+			{ fieldName: "ProductID", expr: expr, cond: "Contains" }
 		];
 		ds.settings.paging = {};
 
 		ds.settings.filtering.filterExprUrlKey = "filter";
 		params = $.param(ds._encodeUrl());
-		assert.equal(params, "filter(ProductID)=Contains(%2528%2529)", "Filtering Expression Value should be escaped.");
+		assert.equal(params, "filter(ProductID)=Contains(%25EF%25BC%2593)", "Filtering Expression Value should be escaped.");
 	});

--- a/tests/unit/dataSource/remote/remote-test.js
+++ b/tests/unit/dataSource/remote/remote-test.js
@@ -741,7 +741,7 @@
 		var specialCharacter = "%EF%BC%93"; // FULLWIDTH DIGIT THREE, https://www.fileformat.info/info/unicode/char/ff13/index.htm
 		var expr = decodeURIComponent(specialCharacter);
 		ds.settings.filtering.expressions = [
-			{ fieldNgit puame: "ProductID", expr: expr, cond: "Contains" }
+			{ fieldName: "ProductID", expr: expr, cond: "Contains" }
 		];
 		ds.settings.paging = {};
 

--- a/tests/unit/dataSource/remote/remote-test.js
+++ b/tests/unit/dataSource/remote/remote-test.js
@@ -741,7 +741,7 @@
 		var specialCharacter = "%EF%BC%93"; // FULLWIDTH DIGIT THREE, https://www.fileformat.info/info/unicode/char/ff13/index.htm
 		var expr = decodeURIComponent(specialCharacter);
 		ds.settings.filtering.expressions = [
-			{ fieldName: "ProductID", expr: expr, cond: "Contains" }
+			{ fieldNgit puame: "ProductID", expr: expr, cond: "Contains" }
 		];
 		ds.settings.paging = {};
 


### PR DESCRIPTION
Closes #2048 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them

