### PR TITLE
Move thin scrollbars to show only after scrolling has started and not on touchstart.

### DIFF
--- a/src/js/modules/infragistics.ui.scroll.js
+++ b/src/js/modules/infragistics.ui.scroll.js
@@ -2421,8 +2421,6 @@
 			this._offsetDirection = 0;
 
 			this._igScollTouchPrevented = false;
-
-			this._showScrollbars(true);
 		},
 
 		_onTouchMoveContainer: function (event) {
@@ -2510,11 +2508,12 @@
 			}
 
 			if (scrolledXY.x === 0 && scrolledXY.y === 0) {
-			    this._igScollTouchPrevented = true;
+				this._igScollTouchPrevented = true;
 			}
 
 			//On Safari preventing the touchmove would prevent default page scroll behaviour even if there is the element doesn't have overflow
 			if (!this._igScollTouchPrevented && event.cancelable) {
+				this._showScrollbars(true);
 				event.preventDefault();
 			}
 		},


### PR DESCRIPTION
In the new iOS 13 when clicking some element inside igScroll's content it cancels transitions too fast for the scrollbar animations and causes native events instability.

Closes issue with ID 267598

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR contains breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them

