### PR TITLE
Fix code scanning alert no. 28: Inefficient regular expression

### DIFF
--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -127,7 +127,7 @@
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
 			nonEncodeSub: /\{\{html\s+([\w\$\-]+(\.|\s)?[\w\$\-]*)+\}\}/,
-			forSub: /\$\{(([\w\$]+\.[\w\$]*)+)\}/,
+			forSub: /\$\{(([\w\$]+\.[\w\$]+)+)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template
 				Use $.ig.regExp.block.exec(tmpl) in order to get the block directive in the tmpl string


### PR DESCRIPTION
Fixes [https://github.com/IgniteUI/ignite-ui/security/code-scanning/28](https://github.com/IgniteUI/ignite-ui/security/code-scanning/28)

To fix the problem, we need to modify the regular expression to remove the ambiguity that leads to exponential backtracking. Specifically, we should avoid using nested quantifiers that can match empty strings. In this case, we can refactor the regular expression to ensure that each part of the pattern is unambiguous and does not lead to excessive backtracking.

The best way to fix this issue is to replace the problematic part of the regular expression `[\w\$]*` with a more specific pattern that does not allow for empty matches. We can use a non-empty character class that matches one or more word characters or dollar signs, ensuring that the pattern is unambiguous.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
