### PR TITLE
Fix code scanning alert no. 27: Inefficient regular expression

### DIFF
--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+([\w\$\-]+(\.|\s)?[\w\$\-]*)+\}\}/,
+			nonEncodeSub: /\{\{html\s+((?:[^\s{}])+(\.|\s)?(?:[^\s{}])*)+\}\}/,
 			forSub: /\$\{(([\w\$]+\.[\w\$]*)+)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+([^\s{}]+(?:\.[^\s{}]+)*)\}\}/,
+			nonEncodeSub: /\{\{html\s+([^\s{}]+(?:\.[^\s{}]+?)*)\}\}/,
 			forSub: /\$\{([\w\$]+\.[\w\$]+(?:\.[\w\$]+)*)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+([^\s{}]+(?:\.[^\s{}]+)*)\}\}/,
+			nonEncodeSub: /\{\{html\s+([^\s{}\.]+(?:\.[^\s{}\.]+)*)\}\}/,
 			forSub: /\$\{([\w\$]+\.[\w\$]+(?:\.[\w\$]+)*)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+([^\s{}]+(\.|\s)?[^\s{}]*)+\}\}/,
+			nonEncodeSub: /\{\{html\s+([^\s{}]+(?:\.[^\s{}]+)*)\}\}/,
 			forSub: /\$\{([\w\$]+\.[\w\$]+(?:\.[\w\$]+)*)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+([^\s{}]+(?:\.[^\s{}]+?)*)\}\}/,
+			nonEncodeSub: /\{\{html\s+([^\s{}]+(?:\.[^\s{}]+)*)\}\}/,
 			forSub: /\$\{([\w\$]+\.[\w\$]+(?:\.[\w\$]+)*)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template

--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+((?:[^\s{}])+(\.|\s)?(?:[^\s{}])*)+\}\}/,
+			nonEncodeSub: /\{\{html\s+([^\s{}]+(\.|\s)?[^\s{}]*)+\}\}/,
 			forSub: /\$\{(([\w\$]+\.[\w\$]*)+)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template


### PR DESCRIPTION
Fixes [https://github.com/IgniteUI/ignite-ui/security/code-scanning/27](https://github.com/IgniteUI/ignite-ui/security/code-scanning/27)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we can replace the ambiguous character class `[\w\$\-]+` with a more precise pattern that avoids backtracking issues. One approach is to use a non-capturing group with a negated character class to ensure that the pattern matches in a linear time complexity.

- **General Fix:** Modify the regular expression to use a non-capturing group with a negated character class to avoid backtracking.
- **Detailed Fix:** Replace the pattern `[\w\$\-]+` with `(?:[^\s{}])+` to match one or more characters that are not whitespace, curly braces, or other problematic characters.
- **File/Region/Lines to Change:** The change should be made in the file `src/js/modules/infragistics.templating.js` on line 129.
- **Required Changes:** No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
