### PR TITLE
Fix code scanning alert no. 26: Inefficient regular expression

### DIFF
--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -122,7 +122,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be encoded before rendering
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			sub: /\$\{(([\w\$\-]+(\.|\s)?[\w\$\-]*)+)\}/,
+			sub: /\$\{([\w\$\-]+(?:\.[\w\$\-]+|\s[\w\$\-]+)*)\}/,
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/


### PR DESCRIPTION
Fixes [https://github.com/IgniteUI/ignite-ui/security/code-scanning/26](https://github.com/IgniteUI/ignite-ui/security/code-scanning/26)

To fix the problem, we need to modify the regular expression to remove the ambiguity that leads to exponential backtracking. Specifically, we should avoid nested quantifiers and ensure that each part of the regular expression can only match in one way. 

The problematic part `[\w\$\-]+(\.|\s)?[\w\$\-]*` can be restructured to avoid nested quantifiers. We can achieve this by breaking down the pattern into more specific parts that do not overlap in their matching capabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
