### PR TITLE
Fix code scanning alert no. 328: Inefficient regular expression

### DIFF
--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -126,7 +126,7 @@
 			/* type="RegExp" Matches any substitution element in the template that is to be rendered as it is
 				Use $.ig.regExp.sub.exec(tmpl) in order to get the substitution element in the tmpl string
 			*/
-			nonEncodeSub: /\{\{html\s+([\w\$\-]+(\.|\s)?[\w\$\-]*)+\}\}/,
+			nonEncodeSub: /\{\{html\s+((?:[\w\$-]+)(?:\.(?:[\w\$-]+)|\s(?:[\w\$-]+))*)\}\}/,
 			forSub: /\$\{([\w\$]+\.[\w\$]+(?:\.[\w\$]+)*)\}/,
 			arg: /args\[\d+\](?!.*\+)/,
 			/* type="RegExp" Matches any block directive in the template


### PR DESCRIPTION
Fixes [https://github.com/IgniteUI/ignite-ui/security/code-scanning/328](https://github.com/IgniteUI/ignite-ui/security/code-scanning/328)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should replace the ambiguous character class `[\w\$\-]+` with a more precise pattern that avoids ambiguity.

The best way to fix this without changing existing functionality is to use a non-ambiguous character class. We can replace `[\w\$\-]+` with `(?:[\w\$-]+)` to ensure that the repetition is non-ambiguous.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
