### PR TITLE
Fix code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/src/js/modules/infragistics.templating.js
+++ b/src/js/modules/infragistics.templating.js
@@ -186,8 +186,9 @@
 				    splitName = tempToken[ 1 ].split(".");
 
 					// K.D. September 25th, 2012 Bug #122463 The property can contain $ in its name.
-					template = template.replace(new RegExp("\\$\\{" + tempToken[ 1 ].replace(/\$/g, "\\$") + "\\}", "g"), "");
-					tempToken[ 3 ] = new RegExp("\\$\\{" + tempToken[ 1 ].replace(/\$/g, "\\$")  + "\\}", "g");
+					tempToken[ 1 ] = tempToken[ 1 ].replace(/\\/g, "\\\\").replace(/\$/g, "\\$");
+					template = template.replace(new RegExp("\\$\\{" + tempToken[ 1 ] + "\\}", "g"), "");
+					tempToken[ 3 ] = new RegExp("\\$\\{" + tempToken[ 1 ] + "\\}", "g");
 					tempToken[ 1 ] = splitName;
 					tempToken[ 2 ] = true;
 					this.tokens.push(tempToken);
@@ -200,8 +201,9 @@
 				    splitName = tempToken[ 1 ].split(".");
 
 					// K.D. September 25th, 2012 Bug #122463 The property can contain $ in its name.
-					template = template.replace(new RegExp("\\{\\{html\\s+" + tempToken[ 1 ].replace(/\$/g, "\\$") + "\\}\\}", "g"), "");
-					tempToken[ 3 ] = new RegExp("\\{\\{html\\s+" + tempToken[ 1 ].replace(/\$/g, "\\$") + "\\}\\}", "g");
+					tempToken[ 1 ] = tempToken[ 1 ].replace(/\\/g, "\\\\").replace(/\$/g, "\\$");
+					template = template.replace(new RegExp("\\{\\{html\\s+" + tempToken[ 1 ] + "\\}\\}", "g"), "");
+					tempToken[ 3 ] = new RegExp("\\{\\{html\\s+" + tempToken[ 1 ] + "\\}\\}", "g");
 					tempToken[ 1 ] = splitName;
 					tempToken[ 2 ] = false;
 					this.tokens.push(tempToken);


### PR DESCRIPTION
Fixes [https://github.com/IgniteUI/ignite-ui/security/code-scanning/5](https://github.com/IgniteUI/ignite-ui/security/code-scanning/5)

To fix the problem, we need to ensure that backslashes in `tempToken[1]` are properly escaped before using it in a regular expression. This can be achieved by adding an additional `replace` call to escape backslashes. Specifically, we should replace each backslash (`\`) with a double backslash (`\\`) before proceeding with the existing replacements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
